### PR TITLE
Add Kiwi IRC to list of compliant web clients

### DIFF
--- a/index
+++ b/index
@@ -121,6 +121,7 @@ This software is compliant natively; other software may be compliant with extens
 
  * [Iris](http://www.atheme.net/iris.html)
  * [Mibbit](http://www.mibbit.com)
+ * [Kiwi IRC](https://kiwiirc.com)
 
 ## Mobile Clients
 


### PR DESCRIPTION
Kiwi IRC has just been updated to support the IRCv3  specifications, supporting the 3.1 base extensions as well as away-notify and preliminary support for 3.2's message tags.
