### PR TITLE
away-notify-3.1, account-notify-3.1: fix formatting of examples

### DIFF
--- a/extensions/account-notify-3.1
+++ b/extensions/account-notify-3.1
@@ -16,13 +16,13 @@ accountname changes for clients on common channels with them.
 
 The ACCOUNT message is one of the following:
 
-   :nick!user@host ACCOUNT accountname
+    :nick!user@host ACCOUNT accountname
 
 This message represents that the user identified by nick!user@host has
 logged into a new account.  The last parameter is the display name of
 that account.
 
-   :nick!user@host ACCOUNT *
+    :nick!user@host ACCOUNT *
 
 This message represents that the user identified by nick!user@host has
 logged out of their account.  As the last parameter is an asterisk, this

--- a/extensions/away-notify-3.1
+++ b/extensions/away-notify-3.1
@@ -27,7 +27,7 @@ message set.)
 
 The format of the AWAY message is as follows:
 
-   :nick!user@host AWAY [:message]
+    :nick!user@host AWAY [:message]
 
 If the message is present, the user (specified by the nick!user@host
 mask) is going away.  If the message is not present, the user is


### PR DESCRIPTION
Markdown requires preformatted text to be indented by at least four spaces or one tab.
