### PR TITLE
index: Updated Nefarious IRCu link

### DIFF
--- a/index
+++ b/index
@@ -24,7 +24,7 @@ The IRCv3 working group contains participants from the following organizations (
  * [IRCCloud](http://www.irccloud.com)
  * [Mibbit](http://www.mibbit.com)
  * [mIRC](http://www.mirc.co.uk)
- * [Nefarious IRCu](http://evilnet.sourceforge.net)
+ * [Nefarious IRCu](https://github.com/evilnet/nefarious/wiki)
  * [ngIRCd](http://www.ngircd.barton.de)
  * [QuakeNet](http://www.quakenet.org)
  * [Undernet](http://www.undernet.org)


### PR DESCRIPTION
Having moved evilnet developments projects to github the URL for Nefarious IRCu needs updating.
