### PR TITLE
Specify correct parsing for capability lists.

### DIFF
--- a/specification/capability-negotiation-3.1
+++ b/specification/capability-negotiation-3.1
@@ -40,7 +40,9 @@ The subcommands for `CAP` are: `LS`, `LIST`, `REQ`, `ACK`, `NAK`, `CLEAR` and `E
 
 The `LS`, `LIST`, `REQ`, `ACK` and `NAK` subcommands may be followed by a single parameter
 containing a space-seperated list of capabilities.  If more than one capability is named,
-the RFC1459 designated sentinel (`:`) for a multi-parameter argument must be present.
+the RFC1459 designated sentinel (`:`) for a multi-parameter argument must be present. The
+list of capabilties MUST be parsed from left to right and capabilities SHOULD only be sent
+once per command. If a capability is sent multiple times, the last one received takes priority.
 
 If a client sends a subcommand which is not in the list above or otherwise issues an
 invalid command, then numeric 410 (ERR_INVALIDCAPCMD) should be sent.  The first parameter


### PR DESCRIPTION
Currently, the capability negotiation specification is ambiguous as to how lists of capabilities are parsed, particularly where the same capability is transmitted multiple times in one message.

This could lead to a situation where a client and server may disagree as to which capabilities are enabled.

My initial proposal was to suggest that we state that capabilities MUST NOT be given twice in the same message, but after floating this idea on the IRC channel, grawity expressed a preference for amending the spec in line with existing implementations ("caps parsed left-to-right and the last one takes priority, exactly like multiple CAP REQ's").
