### PR TITLE
Add pydle to compliant software list.

### DIFF
--- a/index
+++ b/index
@@ -138,3 +138,4 @@ This software is compliant natively; other software may be compliant with extens
 ## Libraries
 
  * [Net::Async::IRC](https://metacpan.org/pod/Net::Async::IRC)
+ * [pydle](https://pypi.python.org/pypi/pydle)


### PR DESCRIPTION
To my knowledge as the author pydle is fully compliant with IRCv3.1 (base + optional) and partially compliant with IRCv3.2.
