### PR TITLE
index: Added Nefarious IRCu as an IRCv3.1 compatible server

### DIFF
--- a/index
+++ b/index
@@ -103,6 +103,7 @@ This software is compliant natively; other software may be compliant with extens
  * [Charybdis](http://www.stack.nl/~jilles/irc/#charybdis) 3.0 or later
  * [Elemental IRCd](https://github.com/lyska/elemental-ircd)
  * [InspIRCd](http://www.inspircd.org/) 1.2 or later
+ * [Nefarious IRCu](https://github.com/evilnet/nefarious2) 2.0 or later
  * ShadowIRCd 6.0 or later _(dead)_
  * [UnrealIRCd](http://www.unrealircd.org/) 3.2.10 or later
 


### PR DESCRIPTION
About time Nefarious IRCu was added to the list of servers supporting IRCv3.1 specifications.
