### PR TITLE
Make type optional in BATCH-3.2

### DIFF
--- a/extensions/batch-3.2
+++ b/extensions/batch-3.2
@@ -25,7 +25,7 @@ is concluded.
 
 The following syntax MUST be used when starting a batch:
 
-	BATCH +reference-tag type [<parameter 1> [<parameter 2> ... [<parameter n>]]]
+	BATCH +reference-tag [type [<parameter 1> [<parameter 2> ... [<parameter n>]]]]
 
 The following syntax MUST be used when ending a batch:
 


### PR DESCRIPTION
The non-optional type parameter in BATCH has only somewhat-recently been added, and previously did not exist, I believe this should be made optional and an absent type should be treated as a generic "these are all related to each other" group of lines - which I believe is in the spirit of the initial implementation of the spec. This also serves to maintain backwards-compatibility with older versions of the spec (excluding the short-lived num-of-lines param)

BATCH types have formal specifications (of which currently "NETSPLIT" and "NETJOIN" are the only ones), but as there is no way to show what types a client/server understands/uses and what it doesn't and it's possible that as time goes on new types may be added (eg, in v3.3 or v3.4 etc) that the client isn't aware of (as it was created before they were added to the spec) then these types are essentially informational rather than anything else (an unknown type will need to be treated as a generic group of related messages), there seems to be no reason to making them a required parameter (other than breaking old implementations).

Further to the above, I don't believe that there is always a specific need to have a "type" - for example, a group of PRIVMSG lines (eg a channel back-buffer), the MOTD, names responses, WHO replies, WHOIS replies, list mode replies etc could all in theory be BATCHed as they are all related - but do we need to have a separate batch type for all of them? 
