### PR TITLE
Merge cap-notify spec into CAP LS 3.2

### DIFF
--- a/extensions/cap-notify-3.2.md
+++ b/extensions/cap-notify-3.2.md
@@ -19,6 +19,10 @@ When enabled, the server MUST notify clients about all new capabilities
 and about existing capabilities that are no longer available via the messages
 specified in this document.
 
+The `cap-notify` capability MUST be implicitly enabled if client requested `CAP LS 3.2`, as described in spec of `CAP LS 3.2`.
+In that case `cap-notify` MAY be presented in response of `CAP LS`, but server MAY choose not to.
+This is for easier adoptation by old software of new features of capabilities negotiation.
+
 ## Subcommands
 
 This specification introduces two new CAP subcommands: `NEW` and `DEL`.

--- a/specification/capability-negotiation-3.2.md
+++ b/specification/capability-negotiation-3.2.md
@@ -44,6 +44,11 @@ If the reply consists of multiple lines (due to IRC line length limitations)
 all but the last subcommand MUST have a parameter containing only an asterisk
 (`*`) preceding the capability list.
 
+### Subcommands
+
+Two new CAP subcommands are introduced: `NEW` and `DEL`.
+Refer to specification of `cap-notify` for details about them.
+
 ## Examples
 
 Example where the client uses CAP 3.2 and the reply contains a cap with


### PR DESCRIPTION
No need for separate cap, if we are changing CAP spec anyway
