### PR TITLE
IRCv3 no more.

### DIFF
--- a/index
+++ b/index
@@ -29,7 +29,6 @@ The IRCv3 working group contains participants from the following organizations (
  * [QuakeNet](http://www.quakenet.org)
  * [Undernet](http://www.undernet.org)
  * [UnrealIRCd](http://www.unrealircd.org)
- * [ZNC](http://znc.in)
 
 To participate, contribute to our specifications and extensions registry on [GitHub](http://github.com/atheme/ircv3-specifications).
 


### PR DESCRIPTION
I'm tired of childish behavior of nenolod and of his threats.

If someone wishes to continue collaborating without nenolod, welcome to
irc.freenode.net #ircv4
