### PR TITLE
Add Willie IRC bot to compliant software

### DIFF
--- a/index
+++ b/index
@@ -152,6 +152,10 @@ This software is compliant natively; other software may be compliant with extens
  * [Palaver](http://palaverapp.com/)
  * [IRCCloud](https://www.irccloud.com)
 
+## Bots
+
+ * [Willie](http://willie.dftba.net) 4.1.0 or later
+
 ## Libraries
 
  * [Net::Async::IRC](https://metacpan.org/pod/Net::Async::IRC)


### PR DESCRIPTION
We have a wiki page detailing what we support and how [here](https://github.com/embolalia/willie/wiki/IRCv3-Compatibility).
