### PR TITLE
Use gender neutral pronoun

### DIFF
--- a/extensions/extended-join-3.1
+++ b/extensions/extended-join-3.1
@@ -13,7 +13,7 @@ services. This capability MUST be referred to as 'extended-join' at
 capability negotiation time.
 
 When enabled, the JOIN message will designate the account name of the
-user when he/she joins a channel.
+user when they join a channel.
 
 The JOIN message is one of the following:
 


### PR DESCRIPTION
extensions/extended-join-3.1 used binary gender pronouns which I didn't notice in other files. I am not sure if they are used in other files, but this is the instance I noticed.
