### PR TITLE
Terminate MONITOR S with RPL_ENDOFMONLIST

### DIFF
--- a/specification/monitor-3.2.md
+++ b/specification/monitor-3.2.md
@@ -69,7 +69,7 @@ Outputs the current list of targets being monitored.  All output will use
 Outputs for each target in the list being monitored, whether the client is
 online or offline.  All targets that are online will be sent using 
 `RPL_MONONLINE`, all targets that are offline will be sent using
-`RPL_MONOFFLINE`.
+`RPL_MONOFFLINE`, and the output will be terminated with `RPL_ENDOFMONLIST`.
 
 # Numeric replies
 


### PR DESCRIPTION
`MONITOR L` is terminated with `RPL_ENDOFMONLIST`, providing a similar termination numeric for `MONITOR S` would be beneficial for bouncers to route replies to the client which originated the request.
