### PR TITLE
specification/metadata-3.2: Remove channels.

### DIFF
--- a/specification/metadata-3.2.md
+++ b/specification/metadata-3.2.md
@@ -23,9 +23,6 @@ that services-driven metadata will be encapsulated via `PRIVMSG`.
 ## METADATA
 
 All metadata subcommands will flow through the outgoing `METADATA` verb.
-Metadata may apply to channels, as well; in that case, an optional
-argument is provided prior to the subcommand, as outlined in the format for
-each, if supported.
 
 This specification adds the `metadata-notify` capability for notifications.
 Please see the 'Metadata Notifications' section for more information.
@@ -45,7 +42,7 @@ of `METADATA LIST` MUST be as follows:
 
 `METADATA <Target> LIST [:String]`
 
-*Errors*: ERR_NOMATCHINGKEYS
+*Errors*: `ERR_NOMATCHINGKEYS`
 
 ### METADATA SET
 
@@ -57,16 +54,15 @@ format of `METADATA SET` MUST be as follows:
 `METADATA <Target> SET <Key> [:Value]`
 
 It is an error for users to set keys for other users, for services accounts
-other than their own (without an appropriate operator privilege), for channels
-for which they lack implementation-defined permission, or for
+other than their own (without an appropriate operator privilege), or for
 implementation-defined keys which would require special access which the user
 does not possess.
 
-*Errors*: ERR_KEYINVALID, ERR_KEYNOTSET, ERR_KEYNOPERMISSION
+*Errors*: `ERR_KEYINVALID`, `ERR_KEYNOTSET`, `ERR_KEYNOPERMISSION`
 
 ### METADATA CLEAR
 
-This subcommand MUST remove all metadata, equivalently to using METADATA SET
+This subcommand MUST remove all metadata, equivalently to using `METADATA SET`
 on all keys with an empty value. The format of `METADATA CLEAR` MUST be as
 follows:
 
@@ -78,7 +74,7 @@ subcommand.
 ## Metadata Notifications
 
 Notifications, e.g. from metadata subscriptions, MUST be passed to the client
-using the incoming METADATA verb, the format of which is as follows:
+using the incoming `METADATA` verb, the format of which is as follows:
 
 `METADATA <Source> <Target> <Key> :<Value>`
 
@@ -92,8 +88,8 @@ regardless of subscription status.
 
 ## Metadata Restrictions
 
-Keys MUST be restricted to the ranges A-Z, a-z, and 0-9, and are
-case-insensitive; they MUST, moreover, be namespaced using the period (.) as a
+Keys MUST be restricted to the ranges `A-Z`, `a-z`, and `0-9`, and are
+case-insensitive; they MUST, moreover, be namespaced using the period (`.`) as a
 separator. Values are unrestricted, except that they MUST be UTF-8; binary data
 MUST use the 'data:' URI scheme as standardized by browsers and SHOULD be
 discouraged.
@@ -159,7 +155,7 @@ for persistence MUST be as follows:
 
 where `<Service>` is the relevant service and `<Metadata command>` is any 
 `METADATA` subcommand as outlined previously. Responses MUST be presented
-appropriately to the service rather than through RPL_* or ERR_* events.
+appropriately to the service rather than through `RPL_*` or `ERR_*` events.
 
 In addition, services MAY display metadata via the `INFO` command with the
 relevant service and account name.
@@ -171,7 +167,7 @@ keys against either or neither of them. Implementations may block keys which
 might result in impersonation. It is an error for user-set metadata to have
 any effect on server operations.
 
-If `METADATA` is supported, it MUST be specified in RPL_ISUPPORT using the
+If `METADATA` is supported, it MUST be specified in `RPL_ISUPPORT` using the
 `METADATA` key.
 
 ## Numerics
@@ -179,16 +175,16 @@ If `METADATA` is supported, it MUST be specified in RPL_ISUPPORT using the
 The numerics 760 through 769 MUST be reserved for metadata, carrying the
 following labels and formats:
 
-| No. | Label               | Format                              |
-| --- | ------------------- | ----------------------------------- |
-| 760 | RPL_WHOISKEYVALUE   | `<Target> <Key> :<Value`            |
-| 761 | RPL_KEYVALUE        | `<Target> <Key>[ :<Value>]`         |
-| 762 | RPL_METADATAEND     | `:end of metadata`                  |
-| 765 | ERR_TARGETINVALID   | `<Target> :invalid metadata target` |
-| 766 | ERR_NOMATCHINGKEYS  | `<String> :no matching keys`        |
-| 767 | ERR_KEYINVALID      | `<Key> :invalid metadata key`       |
-| 768 | ERR_KEYNOTSET       | `<Target> <Key> :key not set`       |
-| 769 | ERR_KEYNOPERMISSION | `<Target> <Key> :permission denied` |
+| No. | Label                 | Format                              |
+| --- | --------------------- | ----------------------------------- |
+| 760 | `RPL_WHOISKEYVALUE`   | `<Target> <Key> :<Value`            |
+| 761 | `RPL_KEYVALUE`        | `<Target> <Key>[ :<Value>]`         |
+| 762 | `RPL_METADATAEND`     | `:end of metadata`                  |
+| 765 | `ERR_TARGETINVALID`   | `<Target> :invalid metadata target` |
+| 766 | `ERR_NOMATCHINGKEYS`  | `<String> :no matching keys`        |
+| 767 | `ERR_KEYINVALID`      | `<Key> :invalid metadata key`       |
+| 768 | `ERR_KEYNOTSET`       | `<Target> <Key> :key not set`       |
+| 769 | `ERR_KEYNOPERMISSION` | `<Target> <Key> :permission denied` |
 
 For `RPL_WHOISKEYVALUE`, the `<Target>` is the usual WHOIS target. For
 all other numerics, the `<Target>` is the nick or valid server-defined

--- a/specification/metadata-3.2.md
+++ b/specification/metadata-3.2.md
@@ -23,6 +23,9 @@ that services-driven metadata will be encapsulated via `PRIVMSG`.
 ## METADATA
 
 All metadata subcommands will flow through the outgoing `METADATA` verb.
+Metadata may apply to channels, as well; in that case, an optional
+argument is provided prior to the subcommand, as outlined in the format for
+each, if supported.
 
 This specification adds the `metadata-notify` capability for notifications.
 Please see the 'Metadata Notifications' section for more information.
@@ -42,7 +45,7 @@ of `METADATA LIST` MUST be as follows:
 
 `METADATA <Target> LIST [:String]`
 
-*Errors*: `ERR_NOMATCHINGKEYS`
+*Errors*: ERR_NOMATCHINGKEYS
 
 ### METADATA SET
 
@@ -54,15 +57,16 @@ format of `METADATA SET` MUST be as follows:
 `METADATA <Target> SET <Key> [:Value]`
 
 It is an error for users to set keys for other users, for services accounts
-other than their own (without an appropriate operator privilege), or for
+other than their own (without an appropriate operator privilege), for channels
+for which they lack implementation-defined permission, or for
 implementation-defined keys which would require special access which the user
 does not possess.
 
-*Errors*: `ERR_KEYINVALID`, `ERR_KEYNOTSET`, `ERR_KEYNOPERMISSION`
+*Errors*: ERR_KEYINVALID, ERR_KEYNOTSET, ERR_KEYNOPERMISSION
 
 ### METADATA CLEAR
 
-This subcommand MUST remove all metadata, equivalently to using `METADATA SET`
+This subcommand MUST remove all metadata, equivalently to using METADATA SET
 on all keys with an empty value. The format of `METADATA CLEAR` MUST be as
 follows:
 
@@ -74,7 +78,7 @@ subcommand.
 ## Metadata Notifications
 
 Notifications, e.g. from metadata subscriptions, MUST be passed to the client
-using the incoming `METADATA` verb, the format of which is as follows:
+using the incoming METADATA verb, the format of which is as follows:
 
 `METADATA <Source> <Target> <Key> :<Value>`
 
@@ -88,8 +92,8 @@ regardless of subscription status.
 
 ## Metadata Restrictions
 
-Keys MUST be restricted to the ranges `A-Z`, `a-z`, and `0-9`, and are
-case-insensitive; they MUST, moreover, be namespaced using the period (`.`) as a
+Keys MUST be restricted to the ranges A-Z, a-z, and 0-9, and are
+case-insensitive; they MUST, moreover, be namespaced using the period (.) as a
 separator. Values are unrestricted, except that they MUST be UTF-8; binary data
 MUST use the 'data:' URI scheme as standardized by browsers and SHOULD be
 discouraged.
@@ -155,7 +159,7 @@ for persistence MUST be as follows:
 
 where `<Service>` is the relevant service and `<Metadata command>` is any 
 `METADATA` subcommand as outlined previously. Responses MUST be presented
-appropriately to the service rather than through `RPL_*` or `ERR_*` events.
+appropriately to the service rather than through RPL_* or ERR_* events.
 
 In addition, services MAY display metadata via the `INFO` command with the
 relevant service and account name.
@@ -167,7 +171,7 @@ keys against either or neither of them. Implementations may block keys which
 might result in impersonation. It is an error for user-set metadata to have
 any effect on server operations.
 
-If `METADATA` is supported, it MUST be specified in `RPL_ISUPPORT` using the
+If `METADATA` is supported, it MUST be specified in RPL_ISUPPORT using the
 `METADATA` key.
 
 ## Numerics
@@ -175,16 +179,16 @@ If `METADATA` is supported, it MUST be specified in `RPL_ISUPPORT` using the
 The numerics 760 through 769 MUST be reserved for metadata, carrying the
 following labels and formats:
 
-| No. | Label                 | Format                              |
-| --- | --------------------- | ----------------------------------- |
-| 760 | `RPL_WHOISKEYVALUE`   | `<Target> <Key> :<Value`            |
-| 761 | `RPL_KEYVALUE`        | `<Target> <Key>[ :<Value>]`         |
-| 762 | `RPL_METADATAEND`     | `:end of metadata`                  |
-| 765 | `ERR_TARGETINVALID`   | `<Target> :invalid metadata target` |
-| 766 | `ERR_NOMATCHINGKEYS`  | `<String> :no matching keys`        |
-| 767 | `ERR_KEYINVALID`      | `<Key> :invalid metadata key`       |
-| 768 | `ERR_KEYNOTSET`       | `<Target> <Key> :key not set`       |
-| 769 | `ERR_KEYNOPERMISSION` | `<Target> <Key> :permission denied` |
+| No. | Label               | Format                              |
+| --- | ------------------- | ----------------------------------- |
+| 760 | RPL_WHOISKEYVALUE   | `<Target> <Key> :<Value`            |
+| 761 | RPL_KEYVALUE        | `<Target> <Key>[ :<Value>]`         |
+| 762 | RPL_METADATAEND     | `:end of metadata`                  |
+| 765 | ERR_TARGETINVALID   | `<Target> :invalid metadata target` |
+| 766 | ERR_NOMATCHINGKEYS  | `<String> :no matching keys`        |
+| 767 | ERR_KEYINVALID      | `<Key> :invalid metadata key`       |
+| 768 | ERR_KEYNOTSET       | `<Target> <Key> :key not set`       |
+| 769 | ERR_KEYNOPERMISSION | `<Target> <Key> :permission denied` |
 
 For `RPL_WHOISKEYVALUE`, the `<Target>` is the usual WHOIS target. For
 all other numerics, the `<Target>` is the nick or valid server-defined


### PR DESCRIPTION
This commit also completes the monospaced formatting for commands and
numeric labels.