### PR TITLE
index: add Limnoria as IRCv3.1 compliant bot

### DIFF
--- a/index
+++ b/index
@@ -154,6 +154,7 @@ This software is compliant natively; other software may be compliant with extens
 
 ## Bots
 
+ * [Limnoria](https://github.com/ProgVal/Limnoria) 2015.02.08 or later
  * [Willie](http://willie.dftba.net) 4.1.0 or later
 
 ## Libraries


### PR DESCRIPTION
I hope I put it into correct spot following alphabetical order.