### PR TITLE
Add Instantbird and Thunderbird to the list of v3.1 Compliant Software

### DIFF
--- a/index
+++ b/index
@@ -126,9 +126,11 @@ This software is compliant natively; other software may be compliant with extens
  * [Colloquy](http://www.colloquy.info) 2.4 or later
  * [Conspire](http://tortois.es/conspire) 0.20 or later
  * [HexChat](http://hexchat.github.io) 2.9.4 or later
+ * [Instantbird](http://instantbird.com) 1.4 or later
  * [Konversation](http://konversation.kde.org/) 1.5 or later
  * [KVIrc](http://www.kvirc.net) 4.0 or later
  * [Limechat](http://limechat.net/mac/) 2.23 or later
+ * [Mozilla Thunderbird](https://www.mozilla.org/thunderbird) 21 or later
  * [Quassel](http://www.quassel-irc.org) 0.6.1 or later
  * [Textual](http://www.codeux.com/textual) 2.1 or later
  * [Weechat](http://www.weechat.org) 0.3.2 or later


### PR DESCRIPTION
SASL was supported in [IB 1.3](https://bugzilla.mozilla.org/show_bug.cgi?id=955004)/[TB 19](https://bugzilla.mozilla.org/show_bug.cgi?id=812921)
NAMESX/multi-prefix was supported in [IB 1.4](https://bugzilla.mozilla.org/show_bug.cgi?id=955179)/[TB 21](https://bugzilla.mozilla.org/show_bug.cgi?id=842183)

Please let me know if you have any questions as I'm the [official owner of the IRC code](https://wiki.mozilla.org/Modules/Chat) in both these products (additionally @aleth is a peer). I wasn't sure whether to list Mozilla as a [participant](https://github.com/ircv3/ircv3-specifications/blob/434239790c9a5764c3d68cde99c6ddb007f5cbbe/index#L15) or not, is there a process for that or...?

Thanks!