### PR TITLE
Modified echo-message for 3.2

### DIFF
--- a/extensions/echo-message-3.2.md
+++ b/extensions/echo-message-3.2.md
@@ -1,0 +1,56 @@
+echo-message client capability specification
+--------------------------------------------
+
+Copyright (c) 2014 Attila Molnar <attilamolnar@hush.com>
+Copyright (c) 2014 J-P Nurmi <jpnurmi@gmail.com>
+
+Unlimited redistribution and modification of this document is allowed
+provided that the above copyright notice and this permission notice
+remains in tact.
+
+## Description
+
+This client capability MUST be named `echo-message`.
+
+If enabled, servers MUST send `PRIVMSG` and `NOTICE` messages back to
+the client that sent them. If servers apply any modifications to these
+messages, they MUST send the final version of the message back to the
+originating client.
+
+For clients, receiving a message with themselves as the sender acts as
+an acknowledgement that the message has been delivered to the server.
+Clients that receive self-sent `PRIVMSG` and `NOTICE` messages, MUST
+treat them the same way as if the client itself would have sent the
+message to the target. Clients may choose to disable local echoing
+of sent `PRIVMSG` and `NOTICE` messages altogether, or present them
+in pending state.
+
+## Use cases
+
+The capability is useful for clients to get an acknowledgement that a
+message was delivered. It can be also used for measuring lag between
+client and server, that is, the time it takes from sending a message
+to receiving it back.
+
+Furthermore, the capability is useful for users that have multiple
+clients attached to a bouncer. In this scenario, when users send
+messages from one client, the messages get automatically relayed to
+other attached clients. This allows all attached clients to display
+full conversation.
+
+## Examples
+
+In the following examples, `example!ex@example.com` presents a client
+that has enabled the `echo-message` capability.
+
+    --> PRIVMSG Attila :hi
+    :example!ex@example.com PRIVMSG Attila :hi
+
+The client interprets the received message as if it had sent a `PRIVMSG`
+with contents "hi" to `Attila`.
+
+Another example where a server modifies a message by filtering out text
+formatting and sends the final version back:
+
+    --> PRIVMSG #ircv3 :back from \02lunch\0F
+    :example!ex@example.com PRIVMSG #ircv3 :back from lunch

--- a/index
+++ b/index
@@ -87,9 +87,9 @@ on [freenode](https://freenode.net)).  Extension specifications should be submit
  * [IRC Version 3.2: `batch` Extension](/extensions/batch-3.2.md)
  * [IRC Version 3.2: `cap-notify` Extension](/extensions/cap-notify-3.2.md)
  * [IRC Version 3.2: `chghost` Extension](/extensions/chghost-3.2.md)
+ * [IRC Version 3.2: `echo-message` Extension](/extensions/echo-message-3.2.md)
  * [IRC Version 3.2: `invite-notify` Extension](/extensions/invite-notify-3.2.md)
  * [IRC Version 3.2: `sasl` Extension](/extensions/sasl-3.2.md)
- * [IRC Version 3.2: `self-message` Extension](/extensions/self-message-3.2.md)
  * [IRC Version 3.2: `server-time` Extension](/extensions/server-time-3.2.md)
  * [IRC Version 3.2: `userhost-in-names` Extension](/extensions/userhost-in-names-3.2.md)
 


### PR DESCRIPTION
This pull request provides a modified `echo-message` capability for 3.2.  The modification removes the example which takes advantage of 3.3's labeled replies proposal.

Closes #100, #135.