### PR TITLE
Copyright metadata

### DIFF
--- a/core/capability-negotiation-3.1.md
+++ b/core/capability-negotiation-3.1.md
@@ -1,21 +1,24 @@
 ---
 title: IRCv3.1 Client Capability Negotiation
 layout: spec
+copyrights:
+  -
+    name: "Kevin L. Mitchell"
+    period: "2004-2012"
+    email: "klmitch@mit.edu"
+  -
+    name: "Perry Lorier"
+    period: "2004-2012"
+    email: "isomer@undernet.org"
+  -
+    name: "Lee Hardy"
+    period: "2004-2012"
+    email: "lee@leeh.co.uk"
+  -
+    name: "William Pitcock"
+    period: "2009-2012"
+    email: "nenolod@dereferenced.org"
 ---
-# IRCv3.1 Client Capability Negotiation
-
-Copyright (c) 2004-2012 Kevin L. Mitchell <klmitch@mit.edu>.
-
-Copyright (c) 2004-2012 Perry Lorier <isomer@undernet.org>.
-
-Copyright (c) 2004-2012 Lee Hardy <lee@leeh.co.uk>.
-
-Copyright (c) 2009-2012 William Pitcock <nenolod@atheme.org>.
-
-Unlimited redistribution and modification of this document is allowed
-provided that the above copyright notice and this permission notice
-remains in tact.
-
 ## What IRCv3 Client Capability Negotiation attempts to solve
 
 IRC is an asynchronous protocol, which means that IRC clients may issue additional

--- a/core/capability-negotiation-3.2.md
+++ b/core/capability-negotiation-3.2.md
@@ -1,23 +1,28 @@
 ---
 title: IRCv3.2 Client Capability Negotiation
 layout: spec
+copyrights:
+  -
+    name: "Kevin L. Mitchell"
+    period: "2004-2012"
+    email: "klmitch@mit.edu"
+  -
+    name: "Perry Lorier"
+    period: "2004-2012"
+    email: "isomer@undernet.org"
+  -
+    name: "Lee Hardy"
+    period: "2004-2012"
+    email: "lee@leeh.co.uk"
+  -
+    name: "William Pitcock"
+    period: "2009-2012"
+    email: "nenolod@dereferenced.org"
+  -
+    name: "Attila Molnar"
+    period: "2014"
+    email: "attilamolnar@hush.com"
 ---
-# IRCv3.2 Client Capability Negotiation
-
-Copyright (c) 2004-2012 Kevin L. Mitchell <klmitch@mit.edu>.
-
-Copyright (c) 2004-2012 Perry Lorier <isomer@undernet.org>.
-
-Copyright (c) 2004-2012 Lee Hardy <lee@leeh.co.uk>.
-
-Copyright (c) 2009-2012 William Pitcock <nenolod@atheme.org>.
-
-Copyright (c) 2014 Attila Molnar <attilamolnar@hush.com>.
-
-Unlimited redistribution and modification of this document is allowed
-provided that the above copyright notice and this permission notice
-remains in tact.
-
 ## New in version 3.2
 
 ### Version in `CAP LS`

--- a/core/message-intents-3.3.md
+++ b/core/message-intents-3.3.md
@@ -1,14 +1,12 @@
 ---
 title: IRCv3.3 Message Intents framework
 layout: spec
+copyrights:
+  -
+    name: "William Pitcock"
+    period: "2012"
+    email: "nenolod@dereferenced.org"
 ---
-# Message Intents framework
-
-Copyright (c) 2012 William Pitcock <nenolod@dereferenced.org>.
-
-Unlimited redistribution and modification is allowed provided that the above
-copyright notice and this permission notice remains intact.
-
 This specification concerns adding an optional out-of-band message tag to messages
 using the message tagging framework.  Message intent tags should be considered an
 initial step in replacing CTCP.

--- a/core/message-tags-3.2.md
+++ b/core/message-tags-3.2.md
@@ -1,15 +1,20 @@
 ---
 title: IRCv3.2 Message Tags
 layout: spec
+copyrights:
+  -
+    name: "Alexey Sokolov"
+    period: "2012-2014"
+    email: "alexey-irc@asokolov.org"
+  -
+    name: "Stéphan Kochen"
+    period: "2012"
+    email: "stephan@kochen.nl"
+  -
+    name: "Kyle Fuller"
+    period: "2012"
+    email: "inbox@kylefuller.co.uk"
 ---
-# IRCv3.2 Message Tags
-
-Copyright (c) 2012 Alexey Sokolov <alexey-irc@asokolov.org>.
-
-Copyright (c) 2012 Stéphan Kochen <stephan@kochen.nl>.
-
-Copyright (c) 2012 Kyle Fuller <inbox@kylefuller.co.uk>.
-
 Additional optional tags are added to the start of each message.
 
 The message pseudo-BNF, as defined in [RFC 1459, section 2.3.1][rfc1459] is extended to look as follows:

--- a/core/metadata-3.2.md
+++ b/core/metadata-3.2.md
@@ -1,14 +1,12 @@
 ---
 title: IRCv3.2 Metadata
 layout: spec
+copyrights:
+  -
+    name: "Kiyoshi Aman"
+    period: "2012"
+    email: "kiyoshi.aman@gmail.com"
 ---
-# IRCv3.2 Metadata
-
-Copyright (c) 2012 Kiyoshi Aman <kiyoshi.aman@gmail.com>.
-
-Unlimited redistribution and modification is allowed provided that the above
-copyright notice and this permission notice remains intact.
-
 ## Introduction
 
 It is generally useful to associate metadata with one's IRC presence, e.g. to

--- a/core/monitor-3.2.md
+++ b/core/monitor-3.2.md
@@ -1,16 +1,21 @@
 ---
 title: IRCv3.2 Monitor
 layout: spec
+copyrights:
+  -
+    name: "Lee Hardy"
+    period: "2004-2015"
+    email: "lee@leeh.co.uk"
+  -
+    name: "Kiyoshi Aman"
+    period: "2013-2015"
+    email: "kiyoshi.aman@gmail.com"
+  -
+    name: "William Pitcock"
+    period: "2015"
+    email: "nenolod@dereferenced.org"
 ---
-# IRCv3.2 Monitor
-
-Protocol for notification of when clients become online/offline
-
-Copyright (c) Lee Hardy <lee@leeh.co.uk>.
-
-Copyright (c) Kiyoshi Aman <kiyoshi.aman@gmail.com>.
-
-Copyright (c) William Pitcock <nenolod@dereferenced.org>.
+A protocol for notification of when clients become online/offline
 
 ## Introduction
 

--- a/documentation/sasl-dh-aes.md
+++ b/documentation/sasl-dh-aes.md
@@ -1,11 +1,14 @@
 ---
 title: IRCv3 SASL DH-AES Authentication Mechanism
 layout: spec
+copyrights:
+  -
+    name: "Mantas Mikulėnas"
+    period: "2013-2015"
+    email: "grawity@gmail.com"
 ---
-# SASL DH-AES Authentication Mechanism
-
 This specification documents the `DH-AES` SASL mechanism currently implemented
-by some IRC clients and services.`
+by some IRC clients and services.
 
 The mechanism is non-standard, and specific to IRC software. It uses
 Diffie-Hellman key exchange to choose a shared encryption key, which is then

--- a/documentation/sasl-dh-blowfish.md
+++ b/documentation/sasl-dh-blowfish.md
@@ -1,11 +1,14 @@
 ---
 title: IRCv3 SASL DH-BLOWFISH Authentication Mechanism
 layout: spec
+copyrights:
+  -
+    name: "Mantas Mikulėnas"
+    period: "2013-2015"
+    email: "grawity@gmail.com"
 ---
-# SASL DH-BLOWFISH Authentication Mechanism
-
 This specification documents the `DH-BLOWFISH` SASL mechanism currently
-implemented by various IRC clients and services.`
+implemented by various IRC clients and services.
 
 The mechanism is non-standard, and specific to IRC software. It uses
 Diffie-Hellman key exchange to choose a shared encryption key, which is then

--- a/extensions/account-notify-3.1.md
+++ b/extensions/account-notify-3.1.md
@@ -1,15 +1,12 @@
 ---
 title: IRCv3.1 `account-notify` Extension
 layout: spec
+copyrights:
+  -
+    name: "William Pitcock"
+    period: "2010"
+    email: "nenolod@dereferenced.org"
 ---
-# IRCv3.1 `account-notify` Extension
-
-Copyright (c) 2010 William Pitcock <nenolod@atheme.org>.
-
-Unlimited redistribution and modification of this document is allowed
-provided that the above copyright notice and this permission notice
-remains in tact.
-
 The account-notify client capability allows a client to be notified
 when another client's accountname changes.  This capability MUST be
 referred to as 'account-notify' at capability negotiation time.

--- a/extensions/account-tag-3.2.md
+++ b/extensions/account-tag-3.2.md
@@ -1,9 +1,12 @@
 ---
 title: IRCv3.2 `account-tag` Extension
 layout: spec
+copyrights:
+  -
+    name: "Mantas Mikulėnas"
+    period: "2013-2015"
+    email: "grawity@gmail.com"
 ---
-# IRCv3.2 `account-tag` Extension
-
 The `account-tag` capability causes the server to add a message-tag containing
 the command sender's services account to commands sent to the client that has
 requested this capability. It supersedes the `identify-msg` extension.

--- a/extensions/away-notify-3.1.md
+++ b/extensions/away-notify-3.1.md
@@ -1,15 +1,12 @@
 ---
 title: IRCv3.1 `away-notify` Extension
 layout: spec
+copyrights:
+  -
+    name: "Keith Buck"
+    period: "2012"
+    email: "mr_flea@esper.net"
 ---
-# IRCv3.1 `away-notify` Extension
-
-Copyright (c) 2012 Keith Buck <mr_flea@esper.net>.
-
-Unlimited redistribution and modification of this document is allowed
-provided that the above copyright notice and this permission notice
-remains in tact.
-
 The away-notify client capability allows a client to specify that it
 would like to be notified when users are marked/unmarked as away. This
 capability is referred to as 'away-notify' at capability negotiation

--- a/extensions/batch-3.2.md
+++ b/extensions/batch-3.2.md
@@ -1,18 +1,20 @@
 ---
 title: IRCv3.2 `batch` Extension
 layout: spec
+copyrights:
+  -
+    name: "William Pitcock"
+    period: "2012"
+    email: "nenolod@dereferenced.org"
+  -
+    name: "Kythyria Tieran"
+    period: "2014"
+    email: "kythyria@berigora.net"
+  -
+    name: "Alexey Sokolov"
+    period: "2014"
+    email: "alexey-irc@asokolov.org"
 ---
-# IRCv3.2 `batch` Extension
-
-Copyright (c) 2012 William Pitcock <nenolod@dereferenced.org>.
-
-Copyright (c) 2014 Kythyria Tieran <kythyria@berigora.net>.
-
-Copyright (c) 2014 Alexey Sokolov <alexey-irc@asokolov.org>.
-
-Unlimited redistribution and modification is allowed provided that the above
-copyright notice and this permission notice remains intact.
-
 ## The `batch` client capability
 
 This extension describes a capability which causes a new verb to be sent to

--- a/extensions/batch/netsplit.md
+++ b/extensions/batch/netsplit.md
@@ -1,14 +1,12 @@
 ---
 title: IRCv3 NETSPLIT and NETJOIN Batch Types
 layout: spec
+copyrights:
+  -
+    name: "Alex Iadicicco"
+    period: "2014"
+    email: "http://github.com/aji"
 ---
-# NETSPLIT and NETJOIN Batch Types
-
-Copyright (C) 2014 Alex Iadicicco <http://github.com/aji>.
-
-Unlimited redistribution and modification is allowed provided that the
-above copyright notice and this permission notice remains intact.
-
 ## NETSPLIT and NETJOIN Batch Types
 
 This document describes the format of the NETSPLIT and NETJOIN batch

--- a/extensions/cap-notify-3.2.md
+++ b/extensions/cap-notify-3.2.md
@@ -1,15 +1,12 @@
 ---
 title: IRCv3.2 `cap-notify` Extension
 layout: spec
+copyrights:
+  -
+    name: "Attila Molnar"
+    period: "2014"
+    email: "attilamolnar@hush.com"
 ---
-# IRCv3.2 `cap-notify` Extension
-
-Copyright (c) 2014 Attila Molnar <attilamolnar@hush.com>.
-
-Unlimited redistribution and modification of this document is allowed
-provided that the above copyright notice and this permission notice
-remains in tact.
-
 ## Description
 
 This client capability MUST be named `cap-notify`.

--- a/extensions/chghost-3.2.md
+++ b/extensions/chghost-3.2.md
@@ -1,15 +1,12 @@
 ---
 title: IRCv3.2 `chghost` Extension
 layout: spec
+copyrights:
+  -
+    name: "Christine Dodrill"
+    period: "2013"
+    email: "xena@yolo-swag.com"
 ---
-# IRCv3.2 `chghost` Extension
-
-Copyright (c) 2013 Sam Dodrill <shadow.h511@gmail.com>.
-
-Unlimited redistribution and modification of this document is allowed
-provided that the above copyright notice and this permission notice
-remains in tact.
-
 The chghost client capability allows a server to directly inform clients about a
 host or user change without having to send a fake quit and join. This capability
 MUST be referred to as 'chghost' at capability negotiation time.

--- a/extensions/echo-message-3.2.md
+++ b/extensions/echo-message-3.2.md
@@ -1,17 +1,16 @@
 ---
 title: IRCv3.2 `echo-message` Extension
 layout: spec
+copyrights:
+  -
+    name: "Attila Molnar"
+    period: "2014"
+    email: "attilamolnar@hush.com"
+  -
+    name: "J-P Nurmi"
+    period: "2014"
+    email: "jpnurmi@gmail.com"
 ---
-# IRCv3.2 `echo-message` Extension
-
-Copyright (c) 2014 Attila Molnar <attilamolnar@hush.com>.
-
-Copyright (c) 2014 J-P Nurmi <jpnurmi@gmail.com>.
-
-Unlimited redistribution and modification of this document is allowed
-provided that the above copyright notice and this permission notice
-remains in tact.
-
 ## Description
 
 This client capability MUST be named `echo-message`.

--- a/extensions/extended-join-3.1.md
+++ b/extensions/extended-join-3.1.md
@@ -1,6 +1,11 @@
 ---
 title: IRCv3.1 `extended-join` Extension
 layout: spec
+copyrights:
+  -
+    name: "Kiyoshi Aman"
+    period: "2011"
+    email: "kiyoshi.aman@gmail.com"
 ---
 # IRCv3.1 `extended-join` Extension
 

--- a/extensions/invite-notify-3.2.md
+++ b/extensions/invite-notify-3.2.md
@@ -1,17 +1,16 @@
 ---
 title: IRCv3.2 `invite-notify` Extension
 layout: spec
+copyrights:
+  -
+    name: "Adam"
+    period: "2013"
+    email: "adam@anope.org"
+  -
+    name: "Attila Molnar"
+    period: "2014"
+    email: "attilamolnar@hush.com"
 ---
-# IRCv3.2 `invite-notify` Extension
-
-Copyright (c) 2013 Adam <Adam@anope.org>.
-
-Copyright (c) 2014 Attila Molnar <attilamolnar@hush.com>.
-
-Unlimited redistribution and modification of this document is allowed
-provided that the above copyright notice and this permission notice
-remains in tact.
-
 ## Description
 
 The `invite-notify` client capability allows a client to specify that it

--- a/extensions/multi-prefix-3.1.md
+++ b/extensions/multi-prefix-3.1.md
@@ -1,14 +1,12 @@
 ---
 title: IRCv3.1 `multi-prefix` Extension
 layout: spec
+copyrights:
+  -
+    name: "William Pitcock"
+    period: "2012"
+    email: "nenolod@dereferenced.org"
 ---
-# IRCv3.1 `multi-prefix` Extension
-
-Copyright (c) 2012 William Pitcock <nenolod@atheme.org>.
-
-Unlimited redistribution and modification of this document is allowed provided
-that the above copyright notice and this permission notice remains in tact.
-
 ## The multi-prefix Client Capability
 
 When requested, the multi-prefix client capability will cause the IRC server to send

--- a/extensions/sasl-3.1.md
+++ b/extensions/sasl-3.1.md
@@ -1,9 +1,16 @@
 ---
 title: IRCv3.1 SASL Authentication
 layout: spec
+copyrights:
+  -
+    name: "Jilles Tjoelker"
+    period: "2009-2012"
+    email: "jilles@stack.nl"
+  -
+    name: "William Pitcock"
+    period: "2009-2012"
+    email: "nenolod@dereferenced.org"
 ---
-# IRCv3.1 SASL Authentication
-
 This document describes the client protocol for SASL authentication, as
 implemented in Charybdis and Atheme.
 

--- a/extensions/sasl-3.2.md
+++ b/extensions/sasl-3.2.md
@@ -1,17 +1,16 @@
 ---
 title: IRCv3.2 SASL Authentication
 layout: spec
+copyrights:
+  -
+    name: "Attila Molnar"
+    period: "2014"
+    email: "attilamolnar@hush.com"
+  -
+    name: "William Pitcock"
+    period: "2015"
+    email: "nenolod@dereferenced.org"
 ---
-# IRCv3.2 SASL Authentication
-
-Copyright (c) 2014 Attila Molnar <attilamolnar@hush.com>.
-
-Copyright (c) 2015 William Pitcock <nenolod@dereferenced.org>.
-
-Unlimited redistribution and modification of this document is allowed
-provided that the above copyright notice and this permission notice
-remains in tact.
-
 ## Description
 
 This document describes how [SASL authentication](/extensions/sasl-3.1)

--- a/extensions/server-time-3.2.md
+++ b/extensions/server-time-3.2.md
@@ -1,15 +1,20 @@
 ---
 title: IRCv3.2 `server-time` Extension
 layout: spec
+copyrights:
+  -
+    name: "Stéphan Kochen"
+    period: "2012"
+    email: "stephan@kochen.nl"
+  -
+    name: "Alexey Sokolov"
+    period: "2012"
+    email: "alexey-irc@asokolov.org"
+  -
+    name: "Kyle Fuller"
+    period: "2012"
+    email: "inbox@kylefuller.co.uk"
 ---
-# IRCv3.2 `server-time` Extension
-
-Copyright (c) 2012 Stéphan Kochen <stephan@kochen.nl>.
-
-Copyright (c) 2012 Alexey Sokolov <alexey-irc@asokolov.org>.
-
-Copyright (c) 2012 Kyle Fuller <inbox@kylefuller.co.uk>.
-
 Clients indicate support for the extension by requesting a capability server-time as per the [IRC Client Capabilities Extension][cap].
 
 	CAP REQ :server-time

--- a/extensions/tls-3.1.md
+++ b/extensions/tls-3.1.md
@@ -1,16 +1,16 @@
 ---
 title: IRCv3.1 `tls` Extension
 layout: spec
+copyrights:
+  -
+    name: "William Pitcock"
+    period: "2012"
+    email: "nenolod@dereferenced.org"
+  -
+    name: "Attila Molnar"
+    period: "2014"
+    email: "attilamolnar@hush.com"
 ---
-# IRCv3.1 `tls` Extension
-
-Copyright (c) 2012 William Pitcock <nenolod@atheme.org>.
-
-Copyright (c) 2014 Attila Molnar <attilamolnar@hush.com>.
-
-Unlimited redistribution and modification of this document is allowed provided
-that the above copyright notice and this permission notice remains in tact.
-
 ## The tls Client Capability
 
 The tls client capability indicates that the server supports the STARTTLS command.

--- a/extensions/userhost-in-names-3.2.md
+++ b/extensions/userhost-in-names-3.2.md
@@ -1,9 +1,12 @@
 ---
 title: IRCv3.2 `userhost-in-names` Extension
 layout: spec
+copyrights:
+  -
+    name: "Mantas Mikulėnas"
+    period: "2013"
+    email: "grawity@gmail.com"
 ---
-# IRCv3.2 `userhost-in-names` Extension
-
 The `userhost-in-names` capability extends the NAMES reply messages
 (`RPL_NAMREPLY`) to contain the full hostmask (nick!user@host) of every user
 listed.


### PR DESCRIPTION
This moves the copyright data to YAML front matter so that it is parseable.  There is a companion commit in ircv3/ircv3.github.io#1 which makes use of this data.

This also adds copyright data where it was missing based on git logs.