### PR TITLE
Rework links to be relative rather than absolute.

### DIFF
--- a/core/capability-negotiation-3.2.md
+++ b/core/capability-negotiation-3.2.md
@@ -60,7 +60,7 @@ or later support in the initial `CAP LS`.
 ### Subcommands
 
 Two new CAP subcommands are introduced: `NEW` and `DEL`.
-Refer to [the specification of `cap-notify`](specs/extensions/cap-notify-3.2.html) for details about them.
+Refer to [the specification of `cap-notify`](../extensions/cap-notify-3.2.html) for details about them.
 
 ### Deprecation of sticky (`=`) and ack-required (`~`) capability modifiers
 

--- a/extensions/batch-3.2.md
+++ b/extensions/batch-3.2.md
@@ -63,7 +63,7 @@ Client MAY delay processing messages of inner batches to the end of outermost ba
 
 Batch types are specified by IRCv3 extensions, vendor-specific types MUST be
 prefixed the same way as how vendor-specific capabilities are prefixed.
-See [capability negotiation](/specs/core/capability-negotiation-3.1.html) for the
+See [capability negotiation](../core/capability-negotiation-3.1.html) for the
 exact details.
 
 While batch types are similar to capabilities in this aspect, unlike
@@ -78,7 +78,7 @@ For example, that happens if the type is unknown to the client.
 To submit a new batch type please follow the extension submission procedure
 [found here](/participation.html).
 
- * [IRC Version 3.2: `NETSPLIT` and `NETJOIN`](/specs/extensions/batch/netsplit.html)
+ * [IRC Version 3.2: `NETSPLIT` and `NETJOIN`](batch/netsplit.html)
 
 ## Examples
 

--- a/extensions/cap-notify-3.2.md
+++ b/extensions/cap-notify-3.2.md
@@ -21,7 +21,7 @@ specified in this document.
 
 The `cap-notify` capability MUST be implicitly enabled if the client requests
 `CAP LS` with a version of 302 or newer (`CAP LS 302`), as described in the
-[capability negotiation 3.2 specification](/specs/core/capability-negotiation-3.2.html).
+[capability negotiation 3.2 specification](../core/capability-negotiation-3.2.html).
 Further, the `cap-notify` capability MAY NOT be disabled if the client requests
 `CAP LS` with a version of 302 or newer.
 

--- a/extensions/extended-join-3.1.md
+++ b/extensions/extended-join-3.1.md
@@ -9,12 +9,6 @@ copyrights:
 ---
 # IRCv3.1 `extended-join` Extension
 
-Copyright (c) 2011 Kiyoshi Aman <kiyoshi.aman@gmail.com>.
-
-Unlimited redistribution and modification of this document is allowed
-provided that the above copyright notice and this permission notice
-remains intact.
-
 The extended-join capability extends the JOIN message to include the
 account name, or a placeholder if the user hasn't identified with
 services. This capability MUST be referred to as 'extended-join' at
@@ -39,5 +33,5 @@ prior to channel ingress. As the penultimate parameter is an asterisk,
 this means that an asterisk is not a valid account name (which it is
 not in P10 or TS6 or ESVID).
 
-Please see the documentation in account-notify.txt for how to take
-advantage of this capability.
+Please see [`account-notify`](account-notify-3.1.html) for information
+on how to take advantage of this capability.

--- a/extensions/sasl-3.1.md
+++ b/extensions/sasl-3.1.md
@@ -20,7 +20,7 @@ mechanism. The most commonly used 'PLAIN' mechanism is documented in
 [RFC 4616](https://tools.ietf.org/html/rfc4616).
 
 SASL authentication relies on the
-[CAP client capability framework](/specs/core/capability-negotiation-3.1.html).
+[CAP client capability framework](../core/capability-negotiation-3.1.html).
 
 Support for SASL authentication is indicated with the "sasl" capability.
 The client MUST enable the sasl capability before using the AUTHENTICATE

--- a/extensions/sasl-3.2.md
+++ b/extensions/sasl-3.2.md
@@ -13,10 +13,10 @@ copyrights:
 ---
 ## Description
 
-This document describes how [SASL authentication](/specs/extensions/sasl-3.1.html)
+This document describes how [SASL authentication](sasl-3.1.html)
 makes use of the
-[capability negotiation protocol updates introduced in 3.2](/specs/core/capability-negotiation-3.2.html),
-and adds support for reauthentication if authentication is lost via the [cap-notify](/specs/extensions/cap-notify-3.2.html)
+[capability negotiation protocol updates introduced in 3.2](../core/capability-negotiation-3.2.html),
+and adds support for reauthentication if authentication is lost via the [cap-notify](cap-notify-3.2.html)
 capability.
 
 ## Advertisement of `sasl` capability when authentication is unavailable

--- a/extensions/server-time-3.2.md
+++ b/extensions/server-time-3.2.md
@@ -46,5 +46,5 @@ John joined #chan during the leap second of June 2012 (notice the :60)
 	@time=2012-06-30T23:59:60.419Z :John!~john@1.2.3.4 JOIN #chan
 
 
-[cap]: /specification/capability-negotiation-3.1
-[message tag]: /specification/message-tags-3.2
+[cap]: ../core/capability-negotiation-3.1.html
+[message tag]: ../core/message-tags-3.2.html


### PR DESCRIPTION
This commit also fixes a couple links that weren't corrected prior to the site going live.