### PR TITLE
Remove duplicated header in extended-join spec

### DIFF
--- a/extensions/extended-join-3.1.md
+++ b/extensions/extended-join-3.1.md
@@ -7,8 +7,6 @@ copyrights:
     period: "2011"
     email: "kiyoshi.aman@gmail.com"
 ---
-# IRCv3.1 `extended-join` Extension
-
 The extended-join capability extends the JOIN message to include the
 account name, or a placeholder if the user hasn't identified with
 services. This capability MUST be referred to as 'extended-join' at


### PR DESCRIPTION
Just a small formatting bug with the extended-join spec.