### PR TITLE
message-tags-3.2: move example to fix code block formatting

### DIFF
--- a/core/message-tags-3.2.md
+++ b/core/message-tags-3.2.md
@@ -97,13 +97,14 @@ Message with 0 tags:
 
 Message with 3 tags:
 
+	@aaa=bbb;ccc;example.com/ddd=eee :nick!ident@host.com PRIVMSG me :Hello
+
 * standardized tag `aaa` with value `bbb`
 
 * message is tagged with standardized tag `ccc`
 
 * tag `ddd` specific to software of `example.com` with value `eee`
 
-    @aaa=bbb;ccc;example.com/ddd=eee :nick!ident@host.com PRIVMSG me :Hello
 
 
 [rfc1459]: http://tools.ietf.org/html/rfc1459#section-2.3.1


### PR DESCRIPTION
Markdown parsed it as if it were another plaintext line of the third
list item. Keeping it after the list and using six spaces could have
worked too, but this is clearer imo.

Also uses tabs just like the other code blocks, for consistency.

------

Before:

![](http://dump.dequis.org/DK2Hp.png)

After:

![](http://dump.dequis.org/mDx-u.png)