### PR TITLE
Make batch types lower case, as are capability names and tag names.

### DIFF
--- a/extensions/batch-3.2.md
+++ b/extensions/batch-3.2.md
@@ -78,13 +78,13 @@ For example, that happens if the type is unknown to the client.
 To submit a new batch type please follow the extension submission procedure
 [found here](/participation.html).
 
- * [IRC Version 3.2: `NETSPLIT` and `NETJOIN`](batch/netsplit.html)
+ * [IRC Version 3.2: `netsplit` and `netjoin`](batch/netsplit-3.2.html)
 
 ## Examples
 
 ### A simple batch
 
-	:irc.host BATCH +yXNAbvnRHTRBv NETSPLIT irc.hub other.host
+	:irc.host BATCH +yXNAbvnRHTRBv netsplit irc.hub other.host
 	@batch=yXNAbvnRHTRBv :aji!a@a QUIT :irc.hub other.host
 	@batch=yXNAbvnRHTRBv :nenolod!a@a QUIT :irc.hub other.host
 	:nick!user@host PRIVMSG #channel :This is not in batch, so processed immediately

--- a/extensions/batch/netsplit-3.2.md
+++ b/extensions/batch/netsplit-3.2.md
@@ -1,5 +1,5 @@
 ---
-title: IRCv3 NETSPLIT and NETJOIN Batch Types
+title: IRCv3 netsplit and netjoin Batch Types
 layout: spec
 copyrights:
   -
@@ -7,18 +7,18 @@ copyrights:
     period: "2014"
     email: "http://github.com/aji"
 ---
-## NETSPLIT and NETJOIN Batch Types
+## `netsplit` and `netjoin` Batch Types
 
-This document describes the format of the NETSPLIT and NETJOIN batch
+This document describes the format of the `netsplit` and `netjoin` batch
 types.
 
 When a netsplit occurs, the server MUST put all resulting QUITs into
-a single NETSPLIT batch. Similarly, all netjoin-related JOINs MUST be
-put into a *single* NETJOIN batch. Both types have 2 arguments, which are
+a single `netsplit` batch. Similarly, all netjoin-related JOINs MUST be
+put into a *single* `netjoin` batch. Both types have 2 arguments, which are
 the names of the servers that are splitting or joining, or *.net *.split
 and *.net *.join if the server has chosen to hide links.
 
-Clients that do not understand the NETSPLIT and NETJOIN batch subcommands
+Clients that do not understand the `netsplit` and `netjoin` batch types
 can safely interpret the batched QUITs and JOINs as standard QUITs
 and JOINs.
 
@@ -26,7 +26,7 @@ and JOINs.
 
 An example netsplit is as follows:
 
-    :irc.host BATCH +yXNAbvnRHTRBv NETSPLIT irc.hub other.host
+    :irc.host BATCH +yXNAbvnRHTRBv netsplit irc.hub other.host
     @batch=yXNAbvnRHTRBv :aji!a@a QUIT :irc.hub other.host
     @batch=yXNAbvnRHTRBv :nenolod!a@a QUIT :irc.hub other.host
     @batch=yXNAbvnRHTRBv :jilles!a@a QUIT :irc.hub other.host
@@ -34,7 +34,7 @@ An example netsplit is as follows:
 
 An example netjoin is as follows:
 
-    :irc.host BATCH +4lMeQwsaOMs6s NETJOIN irc.hub other.host
+    :irc.host BATCH +4lMeQwsaOMs6s netjoin irc.hub other.host
     @batch=4lMeQwsaOMs6s :aji!a@a JOIN #atheme
     @batch=4lMeQwsaOMs6s :nenolod!a@a JOIN #atheme
     @batch=4lMeQwsaOMs6s :jilles!a@a JOIN #atheme
@@ -42,3 +42,8 @@ An example netjoin is as follows:
     @batch=4lMeQwsaOMs6s :jilles!a@a JOIN #ircv3
     @batch=4lMeQwsaOMs6s :Elizacat!a@a JOIN #ircv3
     :irc.host BATCH -4lMeQwsaOMs6s
+
+## Errata
+
+For consistency with capabilities and tags these types was renamed to lower case
+(from `NETSPLIT` to `netsplit`).


### PR DESCRIPTION
Other examples of batch already use lower case with vendor-specific
types.