### PR TITLE
Add a warning about name collision in capabilities and tags.

### DIFF
--- a/core/capability-negotiation-3.1.md
+++ b/core/capability-negotiation-3.1.md
@@ -183,6 +183,10 @@ Names for which a corresponding document sits in the IRCv3 Extension Registry.
 
 Names in the IRCv3 Extension Registry are reserved for your capability.
 
+The IRCv3 Working Group reserves the right to reuse names which have not been submitted to the
+registry. If you do not wish to submit your capability then you MUST use a vendor-specific name
+(see above).
+
 ## Capability Modifiers
 
 There are three capability modifiers specified by this standard.  If a capability modifier is

--- a/core/message-tags-3.2.md
+++ b/core/message-tags-3.2.md
@@ -89,6 +89,10 @@ Names for which a corresponding document sits in the IRCv3 Extension Registry.
 
 Names in the IRCv3 Extension Registry are reserved for your tag.
 
+The IRCv3 Working Group reserves the right to reuse names which have not been submitted
+to the registry. If you do not wish to submit your tag then you MUST use a vendor-specific
+name (see above).
+
 ## Examples
 
 Message with 0 tags:


### PR DESCRIPTION
Apparently the existing warnings were not strong enough. Added a bigger one to attempt to fix that.