### PR TITLE
metadata-3.2: Fix 766 numeric spec to match examples

### DIFF
--- a/core/metadata-3.2.md
+++ b/core/metadata-3.2.md
@@ -191,7 +191,7 @@ following labels and formats:
 | 762 | `RPL_METADATAEND`     | `:end of metadata`                       |
 | 764 | `ERR_METADATALIMIT`   | `<Target> :metadata limit reached`       |
 | 765 | `ERR_TARGETINVALID`   | `<Target> :invalid metadata target`      |
-| 766 | `ERR_NOMATCHINGKEY`   | `<Key> :no matching key`                 |
+| 766 | `ERR_NOMATCHINGKEY`   | `<Target> <Key> :no matching key`        |
 | 767 | `ERR_KEYINVALID`      | `<Key> :invalid metadata key`            |
 | 768 | `ERR_KEYNOTSET`       | `<Target> <Key> :key not set`            |
 | 769 | `ERR_KEYNOPERMISSION` | `<Target> <Key> :permission denied`      |
@@ -270,3 +270,7 @@ Notification for a user becoming an operator:
 
     :OperServ!OperServ@services.int METADATA user1 services.operclass oper:auspex :services-root
 
+## Errata
+
+* Earlier version of this spec specified ERR_NOMATCHINGKEY with no `<Target>`.
+  This did not match examples and being specific with this numeric was desired.


### PR DESCRIPTION
```
2015-12-14 05:59:43      sim642 My problem is the 766 numeric's format defined in metadata-3.2
2015-12-14 05:59:58      sim642 the numerics section has no <Target> argument for the reply
2015-12-14 06:00:10      ElementAlchemist       OK, yes, so I implemented it strictly as defined in the spec
2015-12-14 06:00:11      sim642 below in the examples, a target is being used with the same numeric
2015-12-14 06:00:45      sim642 it feels a lot like 766 should have a <Target>
2015-12-14 06:00:52      sim642 because otherwise the reply seems kind of... pointless
2015-12-14 06:01:16      sim642 it just tells you that there wasn't the key you wanted, in a target it doesn't specify
2015-12-14 06:01:20      ElementAlchemist       ... the examples look really inconsistent actually
2015-12-14 06:01:46      sim642 what other inconsistency is there?
2015-12-14 06:01:51     --      cats is now known as santacat
2015-12-14 06:02:52      ElementAlchemist       That or 766 is wrong AND every example numeric omits the numeric target
2015-12-14 06:03:00      ElementAlchemist       Is that something we're doing with all new numerics?
2015-12-14 06:04:37      sim642 is there really any need to have the message target nick in the arguments though?
2015-12-14 06:05:42      ElementAlchemist       Not really, but every numeric has it
2015-12-14 06:06:24      sim642 ahh maybe, I haven't implemented that much of IRC things to know for sure
2015-12-14 06:14:34     -->     fractal (~fractal@unaffiliated/scounder) has joined #ircv3
2015-12-14 06:14:36      sim642 I just purposefully misimplemented 766 according to the example, not the numeric definition there
2015-12-14 06:15:52      dx     uuhhh what's going on here
2015-12-14 06:16:07      dx     errata updates are certainly possible if there's an inconsistency
2015-12-14 06:16:39      sim642 that'd probably help
2015-12-14 06:18:03      AttilaM        yeah 766 needs a target param
2015-12-14 06:18:10      AttilaM        thats an oversight
```