### PR TITLE
metadata-3.2: Fix METADATA event to allow notification of removed keys

### DIFF
--- a/core/metadata-3.2.md
+++ b/core/metadata-3.2.md
@@ -130,7 +130,7 @@ the channel, regardless of `MONITOR` state.
 
 Notifications use the `METADATA` event, the format of which is as follows:
 
-    METADATA <Target> <Key> <Visibility> :<Value>
+    METADATA <Target> <Key> <Visibility>[ :<Value>]
 
 `<Target>` refers to the entity which had its metadata changed. `<Visibility>`
 MUST be `*` for keys visible to everyone, or a token which describes the
@@ -274,3 +274,6 @@ Notification for a user becoming an operator:
 
 * Earlier version of this spec specified ERR_NOMATCHINGKEY with no `<Target>`.
   This did not match examples and being specific with this numeric was desired.
+* Earlier version of this spec specified that the `<Value>` parameter of
+  `METADATA` events was required. It was decided `METADATA` events should also
+  be able to tell clients about metadata keys that have been removed.


### PR DESCRIPTION
This looks like it was just a typo/oversight, as I'm fairly sure being able to notify clients about keys that have been removed is desired. [mammon](https://github.com/mammon-ircd/mammon) actually already implements the `METADATA` event as shown here, sending out an event without the `<Value>` param on removed keys.

Pointed out by @sim642