### PR TITLE
There are cases where the client may not follow the STS policy

### DIFF
--- a/core/sts-3.3.md
+++ b/core/sts-3.3.md
@@ -46,10 +46,11 @@ connection, it MUST first establish a secure connection and confirm that the
 `sts` capability is still present.
 
 Once the client has confirmed that the `sts` capability is indeed offered over
-a secure connection, it then MUST only attempt secure connections to the
+a secure connection, it then SHOULD only attempt secure connections to the
 server from now on until the policy expires (see the `duration` key).
-It MUST refuse to connect if a secure connection cannot be established with the
-server for any reason during the lifetime of the policy.
+It MUST refuse to connect if establishing a secure connection with the server
+failed for any reason during the lifetime of the policy.
+
 
 However, if the client fails to connect securely for any reason, the connection
 attempt SHOULD be considered a failure, similar to a network error.


### PR DESCRIPTION
According to [RFC 1459](https://tools.ietf.org/html/rfc1459#section-1.2):
>    A client is anything connecting to a server that is not another
>   server.  Each client is distinguished from other clients by a unique
>   nickname having a maximum length of nine (9) characters.

This looks quite old-fashioned, so I'll assume instead a client is a set of code and configuration files, both of which can evolve over time. (I truly started asking myself philosophical questions about the essence of what a “client” is)

But I think raises an interesting point about the feasibility of the STS spec as it currently is.
Indeed, the spec assumes the client can always remember past STS messages, and makes it a requirement. I see different cases where it can not be done:

1. The client has no writeable persistant storage, or no space left on it,
2. The client's storage has been altered (purposively or not),
3. The client is not able to recover the STS policy from its storage, for some reason (eg. an upgrade or a downgrade).
4. The client's system time may changed without the client knowing (eg. while it is stopped)

This pull request changes the verb from MUST to SHOULD to allow the client to not respect this policy such cases.

I also rephrased “a secure connection cannot be established with the server” to “establishing a secure connection with the server failed”, because a client not being able to remember could be interpreted as falling under the former formulation.