### PR TITLE
cap 3.1: Use GitHub syntax for referring to #134

### DIFF
--- a/core/capability-negotiation-3.1.md
+++ b/core/capability-negotiation-3.1.md
@@ -206,5 +206,5 @@ The capability modifiers are:
 
 Previous versions of this specification referred to a CAP CLEAR command, which has been removed
 because it is not useful.  We do not recommend implementing or supporting CAP CLEAR.  See
-[issue #134](https://github.com/ircv3/ircv3-specifications/issues/134) for more information, including
+[issue ircv3/ircv3-specifications#134](https://github.com/ircv3/ircv3-specifications/issues/134) for more information, including
 rationale for this clarification.


### PR DESCRIPTION
This isn't so important, but it came to mind with weechat/weechat#641.

If the errata is quoted directly to issue/PR of software that is located
at GitHub, this change makes GitHub make it a link. See above mentioned
WeeChat issue for example.