### PR TITLE
sasl-3.2: Change SASL reauth to a SHOULD

### DIFF
--- a/extensions/sasl-3.2.md
+++ b/extensions/sasl-3.2.md
@@ -56,8 +56,10 @@ requested the `cap-notify` notification.
 
 ## SASL Reauthentication
 
-Servers MUST allow a client, authenticated or otherwise, to reauthenticate by
-sending a new `AUTHENTICATE` message at any time.
+Servers SHOULD allow a client, authenticated or otherwise, to reauthenticate by
+sending a new `AUTHENTICATE` message at any time. If reauthentication is not
+available, an error appropriate to the circumstances MUST be sent (for instance,
+`ERR_SASLALREADY` is appropriate if changing accounts is not supported).
 
 Servers MAY disconnect ANY client at any time as a result of failed authentication,
 including both unregistered and registered clients, but MUST provide the reason
@@ -119,3 +121,12 @@ Example where the server disconnects a client for excessive reauthentications:
     Client: AUTHENTICATE ...
     Server: :irc.server.tld 904 modernclient :SASL authentication failed
     Server: ERROR :Too many SASL authentication failures
+
+## Errata
+
+A previous version of this specification had reauthentication listed as a MUST
+requirement. This was weakened to SHOULD, to allow servers that cannot
+implement reauthentication for technical or policy reasons to be compliant.
+
+See [issue #192](https://github.com/ircv3/ircv3-specifications/issues/192)
+for more information.


### PR DESCRIPTION
This changes SASL reauth from a MUST to a SHOULD. We want to encourage reauth where possible, but where it's not either for policy or technical reasons, servers can send `ERR_SASLALREADY` to let the client know it's not supported.

Most of the language in this PR comes from #203.