### PR TITLE
formatting: Mark WiP and deprecated specifications in the markdown

### DIFF
--- a/core/message-intents-3.3.md
+++ b/core/message-intents-3.3.md
@@ -1,6 +1,7 @@
 ---
 title: IRCv3.3 Message Intents framework
 layout: spec
+work-in-progress: true
 copyrights:
   -
     name: "William Pitcock"

--- a/core/sni-3.3.md
+++ b/core/sni-3.3.md
@@ -1,6 +1,7 @@
 ---
 title: Server Name Indication
 layout: spec
+work-in-progress: true
 copyrights:
   -
     name: "Attila Molnar"

--- a/core/sts-3.3.md
+++ b/core/sts-3.3.md
@@ -1,6 +1,7 @@
 ---
 title: IRCv3.3 Strict Transport Security
 layout: spec
+work-in-progress: true
 copyrights:
   -
     name: "Attila Molnar"

--- a/documentation/sasl-dh-aes.md
+++ b/documentation/sasl-dh-aes.md
@@ -1,6 +1,7 @@
 ---
 title: IRCv3 SASL DH-AES Authentication Mechanism
 layout: spec
+deprecated: "This mechanism has been deemed unsafe and has been deprecated. Please refer to the [SASL Mechanisms](http://ircv3.net/docs/sasl-mechs.html) page for mechanisms that the IRCv3 WG now recommends."
 copyrights:
   -
     name: "Mantas Mikulėnas"

--- a/documentation/sasl-dh-blowfish.md
+++ b/documentation/sasl-dh-blowfish.md
@@ -1,6 +1,7 @@
 ---
 title: IRCv3 SASL DH-BLOWFISH Authentication Mechanism
 layout: spec
+deprecated: "This mechanism has been deemed unsafe and has been deprecated. Please refer to the [SASL Mechanisms](http://ircv3.net/docs/sasl-mechs.html) page for mechanisms that the IRCv3 WG now recommends."
 copyrights:
   -
     name: "Mantas Mikulėnas"


### PR DESCRIPTION
This adds the `wip` and `deprecated` flags to specifications as I suggested in #216. This should make it more obvious to those who stumble on the raw Markdown files, as well as making it more intuitive and giving us more flexibility on the website (and closing https://github.com/ircv3/ircv3.github.io/issues/50 ).