### PR TITLE
3.3 tags

### DIFF
--- a/core/message-tags-3.3.md
+++ b/core/message-tags-3.3.md
@@ -37,6 +37,9 @@ The updated BNF for keys is as follows:
 
     <key>           ::= [ '+' ] [ <vendor> '/' ] <sequence of letters, digits, hyphens (`-`)>
 
+Client-to-client tags MUST be forwarded on `PRIVMSG` and `NOTICE` events, and
+MAY be forwarded on other events.
+
 ### Examples
 
 `@+znc.in/network PRIVMSG user :lol`

--- a/core/message-tags-3.3.md
+++ b/core/message-tags-3.3.md
@@ -43,11 +43,4 @@ The updated BNF for keys is as follows:
 
 `@+displayname=user2 PRIVMSG #channel :"..."`
 
-## Security Considerations
-
-There are no security considerations that implementations should note when
-implementing this specification.
-
-## Errata
-
 [irctags]: http://ircv3.net/specs/core/message-tags-3.2.html

--- a/core/message-tags-3.3.md
+++ b/core/message-tags-3.3.md
@@ -1,0 +1,53 @@
+---
+title: IRCv3.3 Message Tags
+layout: spec
+copyrights:
+  -
+    name: "Kiyoshi Aman"
+    period: 2016
+    email: "kiyoshi.aman@gmail.com"
+---
+## Introduction
+
+This specification adds a new capability for general message tags support and
+a prefix for expressing client-to-client tags.
+
+## Motivation
+
+A new capability is required in order to indicate support for client-to-client
+tags. Additionally, some implementations felt constrained to apply filtering
+rules to prevent clients from receiving tags they didn't request.
+
+## Architecture
+
+### Capabilities
+
+This specification adds the `message-tags` capability. Clients which request
+this capability indicate that they are capable of parsing all tags, regardless
+of support for tags specified in other IRCv3.2 or later specifications.
+
+### Tags
+
+Client-to-client tags are tags which the server forwards from the client which
+sent them to all other clients which received the relevant event. A
+client-to-client tag starts with a plus sign (`+`) and otherwise obeys the
+format provided in [IRCv3.2 tags][irctags].
+
+The updated BNF for keys is as follows:
+
+    <key>           ::= [ '+' ] [ <vendor> '/' ] <sequence of letters, digits, hyphens (`-`)>
+
+### Examples
+
+`@+znc.in/network PRIVMSG user :lol`
+
+`@+displayname=user2 PRIVMSG #channel :"..."`
+
+## Security Considerations
+
+There are no security considerations that implementations should note when
+implementing this specification.
+
+## Errata
+
+[irctags]: http://ircv3.net/specs/core/message-tags-3.2.html


### PR DESCRIPTION
This initial specification for IRCv3.3 message tags adds support for key/value pairs and lists (and the combination) for message tags and defines a capability to indicate general support for message tags.