### PR TITLE
Clarify where cap values may be shown

### DIFF
--- a/core/capability-negotiation-3.2.md
+++ b/core/capability-negotiation-3.2.md
@@ -42,7 +42,7 @@ If no other arguments are present, version 3.1 is assumed.
 ### Capabilities with values
 
 Servers MAY specify additional data for each capability using the
-`<name>[=<value>]` format.
+`<name>[=<value>]` format for `CAP LS` and `CAP NEW`.
 
 The meaning of the value (if present) depends on the capability in question.
 
@@ -91,3 +91,9 @@ reply:
     Client: CAP LIST
     Server: CAP modernclient LIST * :example.org/example-cap example.org/second-example-cap account-notify
     Server: CAP modernclient LIST :invite-notify batch example.org/third-example-cap
+
+## Errata
+
+A previous version of this specification did not specify when to use
+the `<name>[=<value>]` format.  This was clarified to limit capability
+values to `CAP LS` and `CAP NEW` replies.


### PR DESCRIPTION
For ```CAP LS 302```, clarify that ```<name>[=<value>]``` only apply to ```CAP LS``` and ```CAP NEW``` replies.

For example, this is valid:
```
Server: CAP * LS :sasl=EXTERNAL,FOO,PLAIN batch cap-notify
Client: CAP REQ :sasl
Server: CAP modernclient ACK :sasl
```

While this is **not** valid:
```
Server: CAP * LS :sasl=EXTERNAL,FOO,PLAIN batch cap-notify
Client: CAP REQ :sasl
Server: CAP modernclient ACK :sasl=EXTERNAL,FOO,PLAIN
```

This simplifies logic for clients by ensuring new values don't need parsed and tracked in ```CAP ACK``` and ```CAP NAK``` replies.