### PR TITLE
Add a `certificate-transparency` key to sts for requiring CT validation

### DIFF
--- a/core/sts-3.3.md
+++ b/core/sts-3.3.md
@@ -141,6 +141,12 @@ Servers MUST send this key to non-securely connected clients.
 Servers MAY send this key to securely connected clients, but it will be
 ignored.
 
+### The `certificate-transparency` key
+
+This key indicates that the server supports certificate transparency and
+clients SHOULD require connections to the server to validate the certificate
+logs as per [RFC6962](https://tools.ietf.org/html/rfc6962).
+
 ### Handling disconnection
 
 IRC connections may be long-lived. Connections lasting for more than a month


### PR DESCRIPTION
#### Why

> "TLS is strong, but it's not enough. You also need to have confidence that the certificate that you're using to validate that TLS connection represents the right server."

It's possible for an attacker to get a certificate with a hostname matching an IRC server, and then the attacker could use that certificate. It's hard for client to distinguish the attackers certificate from our real certificates. This is possible if a certificate authority makes a mistake, or if their keys get compromised and someone else uses their private keys to sign a certificate.

Certificate transparency attempt to make is harder for an attacker to do this.

#### What

This key allows a server to instruct clients that they SHOULD perform CT validation when connecting to the server. I've worded this as SHOULD so that clients that don't support CT validation do not have to, but it is highly recommended.

#### Resources

- [What is CT?](https://www.certificate-transparency.org/what-is-ct)
- [How it works](https://www.certificate-transparency.org/how-ct-works)
- [Comparison with Other Technologies](https://www.certificate-transparency.org/comparison)
- [RFC 6962](https://tools.ietf.org/html/rfc6962)