### PR TITLE
Clarify CAP LS reply for when no caps available

### DIFF
--- a/core/capability-negotiation-3.1.md
+++ b/core/capability-negotiation-3.1.md
@@ -72,7 +72,7 @@ The LS subcommand is used to list the capabilities supported by the server.  The
 should send an LS subcommand with no other arguments to solicit a list of all capabilities.
 
 If a client issues an LS subcommand, registration must be suspended until an END subcommand
-is received.
+is received.  If no capabilities are available, an empty parameter must be sent.
 
 Example:
 
@@ -216,3 +216,6 @@ rationale for this clarification.
 Previous versions of this spec did not include specific references to re-enabling or re-disabling a
 capability in the CAP REQ subcommand section. This was clarified in later versions of the
 specification.
+
+Previous versions of this spec did not specify how to handle CAP LS when a server did not support
+any capabilities.  This was clarified to match CAP LIST, requiring a reply with an empty parameter.


### PR DESCRIPTION
For ```CAP LS```, clarify that servers which support negotiation but do not have any available capabilities must send an empty parameter in reply.  This matches the behavior of ```CAP LIST```.

For example:
```
Client: CAP LS
Server: CAP * LS :
```

Without this, clients have no way to determine that they should send ```CAP END``` to continue nick registration.