### PR TITLE
cap/tags: Specify that idents are to be parsed as opaque identifiers

### DIFF
--- a/core/capability-negotiation-3.1.md
+++ b/core/capability-negotiation-3.1.md
@@ -166,6 +166,9 @@ continue as normal.
 
 ## Rules for naming capabilities
 
+Clients MUST NOT attempt to parse the full capability name as anything more an an opaque
+identifier.
+
 There are two capability namespaces:
 
 ### Vendor-Specific
@@ -219,3 +222,6 @@ specification.
 
 Previous versions of this spec did not specify how to handle CAP LS when a server did not support
 any capabilities.  This was clarified to match CAP LIST, requiring a reply with an empty parameter.
+
+Previous versions of this spec did not specify that the full capability name should be parsed as
+nothing more than an opaque identifier. This was added to better suit real-world usage.

--- a/core/capability-negotiation-3.1.md
+++ b/core/capability-negotiation-3.1.md
@@ -166,7 +166,7 @@ continue as normal.
 
 ## Rules for naming capabilities
 
-Clients MUST NOT attempt to parse the full capability name as anything more an an opaque
+Clients MUST NOT attempt to parse the full capability name as anything more than an opaque
 identifier.
 
 There are two capability namespaces:

--- a/core/capability-negotiation-3.1.md
+++ b/core/capability-negotiation-3.1.md
@@ -166,8 +166,7 @@ continue as normal.
 
 ## Rules for naming capabilities
 
-Clients MUST NOT attempt to parse the full capability name as anything more than an opaque
-identifier.
+The full capability name MUST be treated as an opaque identifier.
 
 There are two capability namespaces:
 
@@ -223,6 +222,6 @@ specification.
 Previous versions of this spec did not specify how to handle CAP LS when a server did not support
 any capabilities.  This was clarified to match CAP LIST, requiring a reply with an empty parameter.
 
-Previous versions of this spec did not specify that the full capability name should be parsed as
-nothing more than an opaque identifier. This was added to better suit real-world usage and to improve
-client resiliency.
+Previous versions of this spec did not specify that the full capability name MUST be treated as
+an opaque identifier. This was added to better suit real-world usage and to improve client
+resiliency.

--- a/core/capability-negotiation-3.1.md
+++ b/core/capability-negotiation-3.1.md
@@ -224,4 +224,5 @@ Previous versions of this spec did not specify how to handle CAP LS when a serve
 any capabilities.  This was clarified to match CAP LIST, requiring a reply with an empty parameter.
 
 Previous versions of this spec did not specify that the full capability name should be parsed as
-nothing more than an opaque identifier. This was added to better suit real-world usage.
+nothing more than an opaque identifier. This was added to better suit real-world usage and to improve
+client resiliency.

--- a/core/capability-negotiation-3.1.md
+++ b/core/capability-negotiation-3.1.md
@@ -179,7 +179,7 @@ These names are prefixed by a valid DNS domain name.
 
 For example: `znc.in/server-time`.
 
-In cases if the domain name contains non-ASCII characters, punycode MUST be used,
+In cases where the prefix contains non-ASCII characters, punycode MUST be used,
 e.g. `xn--e1afmkfd.org/foo`.
 
 Vendor-Specific capabilities should be submitted to the IRCv3 working group for consideration.

--- a/core/message-tags-3.2.md
+++ b/core/message-tags-3.2.md
@@ -69,7 +69,7 @@ Also having semicolon as `\:` makes it easy to split the `<tags>` string by `;` 
 
 ## Rules for naming message tags
 
-Clients MUST NOT attempt to parse the full tag name as anything more than an opaque identifier.
+The full tag name MUST be treated as an opaque identifier.
 
 There are two tag namespaces:
 
@@ -113,9 +113,8 @@ Message with 3 tags:
 
 ## Errata
 
-Previous versions of this spec did not specify that the full tag name should be parsed as nothing
-more than an opaque identifier. This was added to better suit real-world usage and to improve
-client resiliency.
+Previous versions of this spec did not specify that the full tag name MUST be parsed as
+an opaque identifier. This was added to improve client resiliency.
 
 
 [rfc1459]: http://tools.ietf.org/html/rfc1459#section-2.3.1

--- a/core/message-tags-3.2.md
+++ b/core/message-tags-3.2.md
@@ -69,7 +69,7 @@ Also having semicolon as `\:` makes it easy to split the `<tags>` string by `;` 
 
 ## Rules for naming message tags
 
-Clients MUST NOT attempt to parse the full tag name as anything more an an opaque identifier.
+Clients MUST NOT attempt to parse the full tag name as anything more than an opaque identifier.
 
 There are two tag namespaces:
 

--- a/core/message-tags-3.2.md
+++ b/core/message-tags-3.2.md
@@ -69,6 +69,8 @@ Also having semicolon as `\:` makes it easy to split the `<tags>` string by `;` 
 
 ## Rules for naming message tags
 
+Clients MUST NOT attempt to parse the full tag name as anything more an an opaque identifier.
+
 There are two tag namespaces:
 
 ### Vendor-Specific
@@ -109,6 +111,10 @@ Message with 3 tags:
 
 * tag `ddd` specific to software of `example.com` with value `eee`
 
+## Errata
+
+Previous versions of this spec did not specify that the full tag name should be parsed as nothing
+more than an opaque identifier. This was added to better suit real-world usage.
 
 
 [rfc1459]: http://tools.ietf.org/html/rfc1459#section-2.3.1

--- a/core/message-tags-3.2.md
+++ b/core/message-tags-3.2.md
@@ -80,7 +80,7 @@ These names are prefixed by a valid DNS domain name.
 
 For example: `znc.in/server-time`.
 
-In cases if the domain name contains non-ASCII characters, punycode MUST be used,
+In cases where the prefix contains non-ASCII characters, punycode MUST be used,
 e.g. `xn--e1afmkfd.org/foo`.
 
 Vendor-Specific tags should be submitted to the IRCv3 working group for consideration.

--- a/core/message-tags-3.2.md
+++ b/core/message-tags-3.2.md
@@ -114,7 +114,8 @@ Message with 3 tags:
 ## Errata
 
 Previous versions of this spec did not specify that the full tag name should be parsed as nothing
-more than an opaque identifier. This was added to better suit real-world usage.
+more than an opaque identifier. This was added to better suit real-world usage and to improve
+client resiliency.
 
 
 [rfc1459]: http://tools.ietf.org/html/rfc1459#section-2.3.1

--- a/extensions/batch-3.2.md
+++ b/extensions/batch-3.2.md
@@ -66,6 +66,8 @@ prefixed the same way as how vendor-specific capabilities are prefixed.
 See [capability negotiation](../core/capability-negotiation-3.1.html) for the
 exact details.
 
+Clients MUST NOT attempt to parse the full batch type name as anything more an an opaque identifier.
+
 While batch types are similar to capabilities in this aspect, unlike
 capabilities, batch types are not advertised by servers nor explicitly
 requested by clients.
@@ -117,3 +119,8 @@ Notice that PRIVMSG line will be processed when batch `outer` ends,
 because end of batch `inner` is tagged by batch `outer`.
 The order in which these two batches start doesn't matter.
 
+
+## Errata
+
+Previous versions of this spec did not specify that the full batch type name should be parsed as
+nothing more than an opaque identifier. This was added to improve client resiliency.

--- a/extensions/batch-3.2.md
+++ b/extensions/batch-3.2.md
@@ -66,7 +66,7 @@ prefixed the same way as how vendor-specific capabilities are prefixed.
 See [capability negotiation](../core/capability-negotiation-3.1.html) for the
 exact details.
 
-Clients MUST NOT attempt to parse the full batch type name as anything more an an opaque identifier.
+Clients MUST NOT attempt to parse the full batch type name as anything more than an opaque identifier.
 
 While batch types are similar to capabilities in this aspect, unlike
 capabilities, batch types are not advertised by servers nor explicitly

--- a/extensions/batch-3.2.md
+++ b/extensions/batch-3.2.md
@@ -66,7 +66,7 @@ prefixed the same way as how vendor-specific capabilities are prefixed.
 See [capability negotiation](../core/capability-negotiation-3.1.html) for the
 exact details.
 
-Clients MUST NOT attempt to parse the full batch type name as anything more than an opaque identifier.
+The full batch type name MUST be treated as an opaque identifier.
 
 While batch types are similar to capabilities in this aspect, unlike
 capabilities, batch types are not advertised by servers nor explicitly
@@ -122,5 +122,5 @@ The order in which these two batches start doesn't matter.
 
 ## Errata
 
-Previous versions of this spec did not specify that the full batch type name should be parsed as
-nothing more than an opaque identifier. This was added to improve client resiliency.
+Previous versions of this spec did not specify that the full batch type name MUST be parsed as
+an opaque identifier. This was added to improve client resiliency.


### PR DESCRIPTION
Mentioned in IRC with projects implementing draft support for specs with names like `draft/client-tags` and such, and subsequently some clients having issues with names like that since they were looking at parsing out and validating vendor prefixes.

It makes much sense to just make sure clients treat them as opaque identifiers, makes clients more resilient and leaves it open for further future clarification/expansion.