### PR TITLE
Account Management Framework

### DIFF
--- a/extensions/acc-core.md
+++ b/extensions/acc-core.md
@@ -11,146 +11,171 @@ copyrights:
     period: "2016-2019"
     email: "daniel@danieloaks.net"
 ---
+## Notes for implementing work-in-progress version
+This is a work-in-progress specification.
 
-The `ACC` command framework provides a unified, standardized interface for account management.
+Software implementing this work-in-progress specification MUST NOT use the unprefixed `acc` capability name. Instead, implementations SHOULD use the `draft/acc` capability name to be interoperable with other software implementing a compatible work-in-progress version.
 
-This specification defines the `ACC REGISTER` and `VERIFY` subcommands, which standardise account creation and validation to the network's authentication layer.  This allows for a network to provide a common interface regardless of what authentication layer they have chosen for their network to operate, i.e. traditional services, a different central authority, or a decentralized model similar to [IRCX][https://en.wikipedia.org/wiki/IRCX].
+The final version of the specification will use an unprefixed capability name.
+
+
+## Introduction
+The `ACC` command framework provides a unified, standardized interface for account management. Typically, managing this account has been done through `NickServ` or other services bots, which has made it difficult for clients to present clean, consistent interfaces to users.
+
+This specification defines the `ACC REGISTER` and `VERIFY` subcommands, which standardise account creation and validation to the network's authentication layer.  This allows for a network to provide a common interface regardless of what authentication layer they have chosen for their network to operate, i.e. traditional services, a different central authority, or a decentralized model similar to [IRCX](https://en.wikipedia.org/wiki/IRCX).
    
-We believe that the benefit of adding a common interface for account management will result in more user-focused interfaces for common account tasks including registration. Further, standardised account registration allows client authors to provide guided account creation and validation to their users, regardless of how the network performs these tasks.
+We believe that the benefit of adding a common interface for account management will result in more user-focused interfaces for common account tasks including registration (just as SASL has allowed clients to create clean account authentication interfaces). Further, standardised account registration allows client authors to provide guided account creation and validation to their users, regardless of how the network performs these tasks.
+
+
+## The `draft/acc` capability
+This capability indicates that the server supports the `ACC` command as described by this specification, and can use `ACC LS` to get a list of supported subcommands. Clients MAY request the `draft/acc` capability, but it will not affect whether or not they can use the command.
+
 
 ## The `ACC` command
+The `ACC` command exposes a number of subcommands as described below. Servers MAY send `ACC` messages to clients in response to client commands, as described by the specifications describing those commands.
 
-The `ACC` command is the main command used by the account registration subsystem.  It provides several subcommands listed in the `ACCCOMMANDS` ISUPPORT type.  The core subcommands are listed below.
+Servers MUST use the [standard replies extension](https://github.com/ircv3/ircv3-specifications/pull/357) to notify the client of failed `ACC` subcommands. The specific codes and format to use are given with each command's description.
 
-## The `ACC REGISTER` sub-command
 
-The `ACC REGISTER` command signals the intent of a client to register an account with the network's authentication layer.  It is similar to current methods of signalling that intent.
+## The `ACC LS` subcommand
+The `ACC LS` subcommand signals that a client wishes to receive a list of supported `ACC` subcommands. The response is one or more `ACC LS` messages sent to the client with this format:
 
-An `ACC REGISTER` command has the following format:
+    :<server> ACC LS :subcommand names go here
+
+If the reply contains multiple lines (due to IRC line length limitations), all but the last reply MUST have a parameter containing only an asterisk (`*`) preceding the subcommand list. This lets clients know that more `ACC LS` lines are incoming. For example:
+
+    :<server> ACC LS * :LS REGISTER VERIFY
+    :<server> ACC LS * :subcommand names go here
+    :<server> ACC LS * :subcommand names go here
+    :<server> ACC LS :final names go here
+
+If this subcommand is given with any additional parameters, servers MUST ignore these and process the subcommand as normal. This allows for future extension of this subcommand.
+
+
+## The `ACC REGISTER` subcommand
+The `ACC REGISTER` subcommand signals the intent of a client to register an account with the network's authentication layer.  It is similar to current methods of signalling that intent.
+
+An `ACC REGISTER` subcommand has the following format:
 
     ACC REGISTER <accountname> [callback_namespace:]<callback> [cred_type] :<credential>
 
-The `accountname` field specifies the account name the client wishes to register.  If the account name is `*`, it indicates that the client wishes to register with their current nickname as this field.
+The `accountname` parameter specifies the account name the client wishes to register.  If the account name is `*`, it indicates that the client wishes to register with their current nickname as the account name.  If the `REGNICK` ISUPPORT token is advertised, the client MUST send `*` for this parameter.
 
-The `credential` field specifies a credential of `cred_type`.  If there is no specified credential, then the `credential` field MUST be `*`.  A passphrase type `credential` MAY have spaces in it. New credential types may or may not allow spaces inside `credential`.
+The `callback` parameter indicates where the verification code should be sent. This parameter MAY contain an asterisk `*`, indicating that no verification code is required and that account registration shall complete immediately. Otherwise, this parameter contains a standard URI, the namespace being contained in the IANA URI Schemes registry (as per [RFC 7595](https://tools.ietf.org/html/rfc7595)) and listed in the `REGCALLBACKS` ISUPPORT token. If a callback namespace is not explicitly provided, the IRC server MUST use `mailto` as a default.
 
-The `callback` field designates an opaque value which indicates where a verification code, if any, will be sent.  The callback field SHOULD contain either a standard URI, the namespace being contained in the IANA URI Schemes registry (as per [RFC 7595][rfc7595]) and listed in the `REGCALLBACKS` ISUPPORT token, or a `*` as decribed below. An invalid callback parameter should result in the `ERR_REG_INVALID_CALLBACK` error.
+The `cred_type` parameter indicates the type of authentication that's required to login to the account once it has been registered. The supported credential types are:
 
-In the event that a callback is not provided, the client SHOULD send `*` to indicate that they are not providing a callback resource.  If a callback namespace is not explicitly provided, the IRC server MAY choose to use `mailto` as a default.
+- `passphrase`: `<credential>` is a plain-text passphrase that the client will use to authenticate with SASL once the account is registered. Passphrases MAY contain spaces.
+- `certfp`: The client's TLS certificate is used as the as the authentication mechanism for future connections. In short, if the client connects and presents the same TLS certificate, they can use the `SASL EXTERNAL` method to authenticate. The client SHOULD provide an empty credential (`*`), and the server MUST ignore the credential value provided by the client. If no certificate is presented by the client, the server MUST respond with the `REG_INVALID_CRED_TYPE` `FAIL` code.
 
-The `cred_type` field designates a value which indicates the type of supplied credential.  The accepted values of the `cred_type` field is implementation-specific, with credential types being listed using the `REGCREDTYPES` ISUPPORT token.  An invalid credential type parameter should result in the `ERR_REG_INVALID_CRED_TYPE` error.  The client SHOULD supply a `cred_type` value, however if one is not provided the IRC server SHOULD use `passphrase` as a default credential type.
+If the client does not provide the `cred_type` parameter, the server MUST use the `passphrase` credential type. If the client provides a credential type that's now supported, the server MUST respond with the `REG_INVALID_CRED_TYPE` `FAIL` code.
 
-The IRC server MAY forward the `ACC REGISTER` command to a central authority, or process it locally. Clients SHOULD NOT be sent unnecessary legacy (e.g. from NickServ) private messages or notices in response to `ACC` commands, where native numerics such as the ones defined in this document can replace them.
+Clients SHOULD NOT be sent legacy (e.g. from NickServ) privmsgs or notices in response to `ACC` commands where numerics and messages defined in this document can replace them.
 
 After this, if verification is required, the IRC server MUST send the `RPL_REG_VERIFICATION_REQUIRED` numeric. If verification is not required, the IRC server MUST instead send the `RPL_REG_SUCCESS` numeric.
 
-| No. | Label                           | Format                                                                                                       |
-| --- | ------------------------------- | ------------------------------------------------------------------------------------------------------------ |
-| 920 | `RPL_REG_SUCCESS`               | `:<server> 920 <user_nickname> <accountname> :Account created`                                               |
+| No. | Label | Format |
+| --- | ----- | ------ |
+| 920 | `RPL_REG_SUCCESS` | `:<server> 920 <user_nickname> <accountname> :Account created` |
 | 927 | `RPL_REG_VERIFICATION_REQUIRED` | `:<server> 927 <user_nickname> <accountname> <callback_namespace:><callback> :A verification token was sent` |
 
-Upon error, the IRC server MUST send an error code that is relevant.  We suggest these numerics:
+Upon error, the IRC server MUST send a [`FAIL` message](https://github.com/ircv3/ircv3-specifications/pull/357) with one of the codes below using the given format, and including an appropriate description of the error:
 
-| No. | Label                        | Format                                                                                          |
-| --- | ---------------------------- | ----------------------------------------------------------------------------------------------- |
-| 921 | `ERR_ACCOUNT_ALREADY_EXISTS` | `:<server> 921 <user_nickname> <accountname> :Account already exists`                           |
-| 922 | `ERR_REG_UNSPECIFIED_ERROR`  | `:<server> 922 <user_nickname> <accountname> :<descriptive_text>`                               |
-| 928 | `ERR_REG_INVALID_CRED_TYPE`  | `:<server> 928 <user_nickname> <accountname> <cred_type> :Credential type is invalid`           |
-| 929 | `ERR_REG_INVALID_CALLBACK`   | `:<server> 929 <user_nickname> <accountname> <callback> :Callback token is invalid`             |
-| 440 | `ERR_REG_UNAVAILABLE`        | `:<server> 440 <user_nickname> <subcommand> :Authentication services are currently unavailable` |
+| Code | Format |
+| ---- | ------ |
+| `ACCOUNT_ALREADY_EXISTS` | `:<server> FAIL ACC ACCOUNT_ALREADY_EXISTS <accountname> :Account already exists` |
+| `REG_INVALID_CALLBACK` | `:<server> FAIL ACC REG_INVALID_CALLBACK <accountname> <callback> :Callback is invalid` |
+| `REG_INVALID_CRED_TYPE` | `:<server> FAIL ACC REG_INVALID_CRED_TYPE <accountname> <cred_type> :Credential type is invalid` |
+| `REG_MUST_USE_REGNICK` | `:<server> FAIL ACC REG_MUST_USE_REGNICK <accountname> :Must register with current nickname instead of separate account name` |
+| `REG_UNAVAILABLE` | `:<server> FAIL ACC REG_UNAVAILABLE :Account registration is currently unavailable` |
+| `REG_UNSPECIFIED_ERROR` | `:<server> FAIL ACC REG_UNSPECIFIED_ERROR <accountname> [<contexts>...] <description>` |
 
-The server MAY send additional informative text upon registration success or failure using `RPL_TEXT` or `NOTICE`.
 
-## The `ACC VERIFY` sub-command
+## The `ACC VERIFY` subcommand
+The `ACC VERIFY` subcommand lets a client submit a verification token to complete their account registration.  This token is one that the server has sent to the user out-of-band with the given callback namespace and method.
 
-The `ACC VERIFY` command signals the intent of a client to submit a verification token for their account registration.  If a valid callback is specified by the client during the `ACC REGISTER` command, the server MUST send the token to the specified callback.
-
-A `ACC VERIFY` command consists of the following format:
+A `ACC VERIFY` subcommand consists of the following format:
 
     ACC VERIFY <accountname> <auth_code>
 
-The IRC server MAY forward the `ACC VERIFY` command to a central authority, or process it locally.
-
 Upon success, the IRC server MUST send the `RPL_VERIFYSUCCESS` numeric, which looks like:
 
-| No. | Label               | Format                                                                         |
-| --- | ------------------- | ------------------------------------------------------------------------------ |
+| No. | Label | Format |
+| --- | ----- | ------ |
 | 923 | `RPL_VERIFYSUCCESS` | `:<server> 923 <user_nickname> <accountname> :Account verification successful` |
 
 The IRC server MUST also send an `RPL_LOGGEDIN` (900) numeric and consider the client to be logged in to the account that has been successfully verified.
 
-Upon error, the IRC server MUST send an error code that is relevant.  We suggest these numerics:
+Upon error, the IRC server MUST send a [`FAIL` message](https://github.com/ircv3/ircv3-specifications/pull/357) with one of the codes below using the given format, and including an appropriate description of the error:
 
-| No. | Label                             | Format                                                                   |
-| --- | --------------------------------- | ------------------------------------------------------------------------ |
-| 924 | `ERR_ACCOUNT_ALREADY_VERIFIED`    | `:<server> 924 <user_nickname> <accountname> :Account already verified`  |
-| 925 | `ERR_ACCOUNT_INVALID_VERIFY_CODE` | `:<server> 925 <user_nickname> <accountname> :Invalid verification code` |
+| Code | Format |
+| `ACCOUNT_ALREADY_VERIFIED` | `:<server> FAIL ACC ACCOUNT_ALREADY_VERIFIED <accountname> :Account already verified` |
+| `ACCOUNT_INVALID_VERIFY_CODE` | `:<server> FAIL ACC ACCOUNT_INVALID_VERIFY_CODE <accountname> :Invalid verification code` |
+| `VERIFY_UNSPECIFIED_ERROR` | `:<server> FAIL ACC VERIFY_UNSPECIFIED_ERROR <accountname> [<contexts>...] <description>` |
 
-## The `ACCCOMMANDS` `RPL_ISUPPORT` token
-
-Implementations which provide these commands SHOULD signal their availability using the `ACCCOMMANDS` RPL_ISUPPORT (005) token.  The `ACCCOMMANDS` token takes a comma-separated list of supported commands.  Other extensions MAY include additional commands in the `ACCCOMMANDS` token than those documented here.
-
-A sample 005 reply indicating support for these commands is:
-
-    :irc.example.com 005 kaniini ACCCOMMANDS=REGISTER,VERIFY :are supported by this server
 
 ## The `REGCALLBACKS` `RPL_ISUPPORT` token
+Implementations which require a verification token should list the types of verification callbacks they support, using the `REGCALLBACKS` RPL_ISUPPORT (005) token.  The `REGCALLBACKS` token takes a comma-separated list of supported callback methods.  In general, the `REGCALLBACKS` token is limited to URI schemes defined in the IANA URI Schemes registry, per [RFC 7595][https://tools.ietf.org/html/rfc7595].
 
-Implementations which require a verification token should list the types of verification callbacks they support, using the `REGCALLBACKS` RPL_ISUPPORT (005) token.  The `REGCALLBACKS` token takes a comma-separated list of supported commands.  In general, the `REGCALLBACKS` token is limited to URI schemes defined in the IANA URI Schemes registry, per [RFC 7595][https://tools.ietf.org/html/rfc7595].
+If verification is not required by the implementation and account registration can complete immediately, the `REGCALLBACKS` token MUST contain an asterisk (`*`) which indicates this.
 
-In the event that verification is not required by the implementation, the `REGCALLBACKS` token should be an empty value.
-
-A sample 005 reply indicating support for verification callbacks is:
+An example 005 reply indicating that the `mailto` and `sms` callbacks are supported is:
 
     :irc.example.com 005 kaniini REGCALLBACKS=mailto,sms :are supported by this server
 
-A sample 005 reply indicating that no verification callback methods are supported is:
+An example 005 reply indicating that no verification callback methods are supported is:
 
-    :irc.example.com 005 kaniini REGCALLBACKS= :are supported by this server
+    :irc.example.com 005 kaniini REGCALLBACKS=* :are supported by this server
 
-The first callback type SHOULD be the implementation-defined default if default callback types are supported.
 
 ## The `REGCREDTYPES` `RPL_ISUPPORT` token
+Implementations which provide support for account registration using this framework MUST specify the supported credential types using the `REGCREDTYPES` RPL_ISUPPORT (005) token.  The `REGCREDTYPES` token takes a comma-separated list of supported commands.  Other extensions MAY define new credential types.
 
-Implementations which provide support for this framework SHOULD specify the allowed credential types using the `REGCREDTYPES` RPL_ISUPPORT (005) token.  The `REGCREDTYPES` token takes a comma-separated list of supported commands.  Other extensions MAY include additional credential types than those listed here.
-
-The following credential types are defined:
-
-  * `passphrase`: an unencrypted passphrase which is sent to the server.
-  * `certfp`: the client certificate fingerprint as determined by the server if available.
-    The client SHOULD provide an empty credential (`*`), and the server MUST ignore the
-    credential value provided by the client.  The server MUST calculate the credential using the
-    client certificate fingerprint (using the same method as for SASL certfp support).  If no
-    certificate is presented by the client, the server MUST respond to any registration attempts
-    with `ERR_REG_INVALID_CRED_TYPE` and SHOULD NOT advertise this credential type.
-
-A sample 005 reply indicating support for credential types is:
+An example 005 reply indicating support for credential types is:
 
     :irc.example.com 005 kaniini REGCREDTYPES=passphrase,certfp :are supported by this server
 
-The first credential type in this token SHOULD be used as the default if the client does not specify a credential type in the `ACC REGISTER` command.
+The credential types specified by this document are described above in the <a href=""><code>ACC REGISTER</code> subcommand description</a>.
+
 
 ## The `REGNICK` `RPL_ISUPPORT` token
-
 Some implementations restrict the account name that can be registered to the current nickname of the client (that is, they tie account name registration to nicknames). Implementations which restrict registration in this way MUST advertise the `REGNICK` RPL_ISUPPORT (005) token.
 
-This token has no value, and a sample 005 reply indicating this behaviour is:
+This token has no value, and an example 005 reply indicating this behaviour is:
 
     :irc.example.com 005 dan REGNICK :are supported by this server
 
-When registering on a network that enforces this policy, clients MUST send `*` as `<accountname>` in the `ACC REGISTER` command (which indicates that the server use the client's current nickname as the account name). If a client sends an incorrect accountname on a network enforcing this policy, the server MUST return the `ERR_REG_UNSPECIFIED_ERROR` (922) numeric with an appropriate description.
+When registering on a network that enforces this policy, clients MUST send `*` as `<accountname>` in the `ACC REGISTER` command (which indicates that the server use the client's current nickname as the account name). If a client sends does not send an asterisk `*` on a network enforcing this policy, the server MUST return the `REG_MUST_USE_REGNICK` `FAIL` code with an appropriate description.
+
 
 ## Account Required
 
-Certain actions on a network may require a client account to be completed. These may include connection registration, channel registration, or other actions. The `ACC_REQUIRED` numeric indicates that the client must be logged into an account in order to complete an action or continue using the network.
+Certain actions on a network may require a client to be logged-into an account. These may include registering a channel, joining specific channels, connecting to the network at all, etc. The `ACC_REQUIRED` `FAIL` code indicates that the client must be logged into an account in order to complete an action or continue using the network.
 
-Upon receiving the `ACC_REQUIRED` numeric, clients SHOULD alert users that they need to register/login and/or provide an interface to do so. The `ACC_REQUIRED` numeric MAY be received before connection registration has completed, in which case clients SHOULD alert that SASL must be used to connect to the current network.
+Upon receiving the `ACC_REQUIRED` code, clients SHOULD alert users that they need to register/login or provide an interface to do so. The `ACC_REQUIRED` code MAY be received at any time – before, during, or after connection registration.
 
-| No. | Label          | Format                                                                              |
-| --- | -------------- | ----------------------------------------------------------------------------------- |
-| ??? | `ACC_REQUIRED` | `:<server> ??? <user_nickname> [<command>] :You must login to complete this action` |
+| Code | Format |
+| ---- | ------ |
+| `ACC_REQUIRED` | `:<server> FAIL * ACC_REQUIRED :You must have an account to connect to this server` |
+
+If the response was triggered by a command, this command should be given with the `FAIL` message. If the user must register outside IRC (for example, through a web interface), a link to do so should be provided in the description.
+
 
 ## Examples
+
+These examples show how to perform common tasks with this framework.
+
+### Listing the supported subcommands
+
+    C: ACC LS
+    S: ACC LS * :REGISTER VERIFY
+    S: ACC LS :MFA RESETPASS
+
+### Listing the supported subcommands with extra parameters
+
+    C: ACC LS EXTRA_PARAMETER EXTENSION_PARAM
+    S: ACC LS * :REGISTER VERIFY
+    S: ACC LS :MFA RESETPASS
 
 ### Registering the account "kaniini" with e-mail address kaniini@example.com:
 
@@ -160,6 +185,13 @@ Upon receiving the `ACC_REQUIRED` numeric, clients SHOULD alert users that they 
     C: ACC VERIFY kaniini 3qw4tq4te4gf34
     S: 923 kaniini kaniini :Account verification successful
     S: 903 kaniini :Authentication successful
+
+### Registering the account "kaniini" with e-mail address kaniini@example.com:
+
+    C: ACC REGISTER kaniini kaniini@example.com passphrase :testpassphrase123
+    S: 920 kaniini kaniini :Account registered
+    S: 927 kaniini kaniini kaniini@example.com :A verification code was sent
+    ...
 
 ### Registering with the client's current nickname "dan-":
 
@@ -180,7 +212,7 @@ Upon receiving the `ACC_REQUIRED` numeric, clients SHOULD alert users that they 
 ### Registering the account "rabbit" with an unsupported verification method:
 
     C: ACC REGISTER rabbit 1vBjNBdhjWFFbbbbVBHJEWBHJWcfbbvjkhbea passphrase :testpassphrase123
-    S: 929 kaniini rabbit 1vBjNBdhjWFFbbbbVBHJEWBHJWcfbbvjkhbea :Callback token is not valid
+    S: FAIL ACC REG_INVALID_CALLBACK rabbit 1vBjNBdhjWFFbbbbVBHJEWBHJWcfbbvjkhbea :Callback token is not valid
 
 ### Registering the account "rabbit", but providing an invalid verification token:
 
@@ -188,7 +220,7 @@ Upon receiving the `ACC_REQUIRED` numeric, clients SHOULD alert users that they 
     S: 920 kaniini rabbit :Account registered
     S: 927 kaniini rabbit kaniini@example.com :A verification code was sent
     C: ACC VERIFY rabbit 3qw4tq4te4gf34
-    S: 925 kaniini rabbit :Invalid verification code
+    S: FAIL ACC ACCOUNT_INVALID_VERIFY_CODE rabbit :Invalid verification code
 
 ### Registering the account "rabbit" where a verification token is not required:
 
@@ -196,22 +228,22 @@ Upon receiving the `ACC_REQUIRED` numeric, clients SHOULD alert users that they 
     S: 920 kaniini rabbit :Account registered
     S: 903 kaniini :Authentication successful
 
-### Registering the account "harold" where ACCNICK is present in RPL_ISUPPORT:
+### Registering the account "harold" where REGNICK is present in RPL_ISUPPORT:
 
     C: ACC REGISTER harold * passphrase :testpassphrase123
-    S: 922 dan- harold :You can only register with your current nickname
+    S: FAIL ACC REG_MUST_USE_REGNICK harold :Must register with current nickname instead of separate account name
 
 ### Registering an account which already exists:
 
     C: ACC REGISTER rabbit sms:+11234567890 passphrase :testpassphrase123
-    S: 921 kaniini rabbit :Account already exists
+    S: FAIL ACC ACCOUNT_ALREADY_EXISTS rabbit :Account already exists
 
 ### Registering an account with an unsupported credential type:
 
     C: ACC REGISTER rabbit mailto:kaniini@example.com some_invalid_cred_type :1QXvcnFWJKFGjbnkwawFJKNJKEc254
-    S: 928 kaniini rabbit some_invalid_cred_type :Credential type is invalid
+    S: FAIL ACC REG_INVALID_CRED_TYPE rabbit some_invalid_cred_type :Credential type is invalid
 
 ### Implementation-specific registration errors:
 
     C: ACC REGISTER rabbit sms:+11234567890 passphrase :abc123
-    S: 922 kaniini rabbit :Invalid params: "rabbit" is a blocked account name
+    S: FAIL ACC REG_UNSPECIFIED_ERROR rabbit :Invalid params: "rabbit" is a restricted account name

--- a/extensions/acc-core.md
+++ b/extensions/acc-core.md
@@ -129,6 +129,7 @@ The IRC server MUST also send an `RPL_LOGGEDIN` (900) numeric and consider the c
 Upon error, the IRC server MUST send a [`FAIL` message](https://github.com/ircv3/ircv3-specifications/pull/357) with one of the codes below using the given format, and including an appropriate description of the error:
 
 | Code | Format |
+| ---- | ------ |
 | `ACCOUNT_ALREADY_VERIFIED` | `:<server> FAIL ACC ACCOUNT_ALREADY_VERIFIED <accountname> :Account already verified` |
 | `ACCOUNT_INVALID_VERIFY_CODE` | `:<server> FAIL ACC ACCOUNT_INVALID_VERIFY_CODE <accountname> :Invalid verification code` |
 | `VERIFY_UNSPECIFIED_ERROR` | `:<server> FAIL ACC VERIFY_UNSPECIFIED_ERROR <accountname> [<contexts>...] <description>` |

--- a/extensions/acc-core.md
+++ b/extensions/acc-core.md
@@ -199,7 +199,7 @@ The `nospaces` flag indicates that passphrase MAY NOT contain space characters. 
 
 ## Account Required
 
-Certain actions on a network may require a client to be logged-into an account. These may include registering a channel, joining specific channels, connecting to the network at all, etc. The `ACCOUNT_REQUIRED` `FAIL` code indicates that the client must be logged into an account in order to complete an action or continue using the network.
+Certain actions on a network may require a client to be logged-into an account. These may include registering a channel, joining specific channels, connecting to the network at all, etc. The `ACCOUNT_REQUIRED` code indicates that the client must be logged into an account in order to complete an action or continue using the network. This code may be sent using either `FAIL` or `WARN`, depending on the situation (i.e. a `FAIL` for a command not processing, a `WARN` for a notice that your nickname will be changed if you don't authenticate in time).
 
 Upon receiving the `ACCOUNT_REQUIRED` code, clients SHOULD alert users that they need to register/login or provide an interface to do so. The `ACCOUNT_REQUIRED` code MAY be received at any time – before, during, or after connection registration.
 
@@ -207,7 +207,7 @@ Upon receiving the `ACCOUNT_REQUIRED` code, clients SHOULD alert users that they
 | ---- | ------ |
 | `ACCOUNT_REQUIRED` | `:<server> FAIL * ACCOUNT_REQUIRED :You must have an account to connect to this server` |
 
-If the response was triggered by a command, this command should be given with the `FAIL` message. If the user must register outside IRC (for example, through a web interface), a link to do so should be provided in the description.
+If the response was triggered by a command, this command should be given with the message. Otherwise, the standard `*` marker is used. If the user must register their account outside IRC (for example, through a web interface), a link to do so should be provided in the description.
 
 
 ## Examples

--- a/extensions/acc-core.md
+++ b/extensions/acc-core.md
@@ -12,31 +12,33 @@ copyrights:
     email: "daniel@danieloaks.net"
 ---
 
-The `ACC` command framework provides a unified, standardized interface for account creation and
-validation to the network's authentication layer.  This allows for a network to provide a common
-interface regardless of what authentication layer they have chosen for their network to operate,
-i.e. traditional services, a different central authority, or a decentralized model similar to [IRCX][ircx].
+The `ACC` command framework provides a unified, standardized interface for account management.
+
+This specification defines the `ACC REGISTER` and `VERIFY` subcommands, which standardise account
+creation and validation to the network's authentication layer.  This allows for a network to
+provide a common interface regardless of what authentication layer they have chosen for their
+network to operate, i.e. traditional services, a different central authority, or a decentralized
+model similar to [IRCX][ircx].
 
    [ircx]: http://en.wikipedia.org/wiki/IRCX
    
-We believe that the benefit of adding a common interface for account creation and validation,
-is helpful to the end user in discovering the capabilities offered by the authentication and
-authority layer of the network.  Further, we believe it is helpful to client authors, so that
-they may provide guided account creation and validation for their users, regardless of network
-configuration.
+We believe that the benefit of adding a common interface for account management will result in
+more user-focused interfaces for common account tasks including registration. Further,
+standardised account registration allows client authors to provide guided account creation and
+validation to their users, regardless of how the network performs these tasks.
 
 ## The `ACC` command
 
 The `ACC` command is the main command used by the account registration subsystem.  It provides
-several subcommands listed in the `ACCCOMMANDS` ISUPPORT type.  The core sub-commands are listed
+several subcommands listed in the `ACCCOMMANDS` ISUPPORT type.  The core subcommands are listed
 below:
 
 ## The `ACC REGISTER` sub-command
 
-The `ACC REGISTER` command signals the intent of a client to register an account in the network's
+The `ACC REGISTER` command signals the intent of a client to register an account with the network's
 authentication layer.  It is similar to current methods of signalling that intent.
 
-A `ACC REGISTER` command consists of the following format:
+An `ACC REGISTER` command has the following format:
 
     ACC REGISTER <accountname> [callback_namespace:]<callback> [cred_type] :<credential>
 

--- a/extensions/acc-core.md
+++ b/extensions/acc-core.md
@@ -199,13 +199,13 @@ The `nospaces` flag indicates that passphrase MAY NOT contain space characters. 
 
 ## Account Required
 
-Certain actions on a network may require a client to be logged-into an account. These may include registering a channel, joining specific channels, connecting to the network at all, etc. The `ACC_REQUIRED` `FAIL` code indicates that the client must be logged into an account in order to complete an action or continue using the network.
+Certain actions on a network may require a client to be logged-into an account. These may include registering a channel, joining specific channels, connecting to the network at all, etc. The `ACCOUNT_REQUIRED` `FAIL` code indicates that the client must be logged into an account in order to complete an action or continue using the network.
 
-Upon receiving the `ACC_REQUIRED` code, clients SHOULD alert users that they need to register/login or provide an interface to do so. The `ACC_REQUIRED` code MAY be received at any time – before, during, or after connection registration.
+Upon receiving the `ACCOUNT_REQUIRED` code, clients SHOULD alert users that they need to register/login or provide an interface to do so. The `ACCOUNT_REQUIRED` code MAY be received at any time – before, during, or after connection registration.
 
 | Code | Format |
 | ---- | ------ |
-| `ACC_REQUIRED` | `:<server> FAIL * ACC_REQUIRED :You must have an account to connect to this server` |
+| `ACCOUNT_REQUIRED` | `:<server> FAIL * ACCOUNT_REQUIRED :You must have an account to connect to this server` |
 
 If the response was triggered by a command, this command should be given with the `FAIL` message. If the user must register outside IRC (for example, through a web interface), a link to do so should be provided in the description.
 

--- a/extensions/acc-core.md
+++ b/extensions/acc-core.md
@@ -1,5 +1,5 @@
 ---
-title: "The ACC command framework"
+title: "The Account Management framework"
 layout: spec
 copyrights:
   -
@@ -20,7 +20,7 @@ The final version of the specification will use an unprefixed capability name.
 
 
 ## Introduction
-The `ACC` command framework provides a unified, standardized interface for account management. Typically, managing this account has been done through `NickServ` or other services bots, which has made it difficult for clients to present clean, consistent interfaces to users.
+The Account Management framework provides a unified, standardized interface for account management using the `ACC` command. Typically, managing this account has been done through `NickServ` or other services bots, which has made it difficult for clients to present clean, consistent interfaces to users.
 
 This specification defines the `ACC REGISTER` and `VERIFY` subcommands, which standardise account creation and validation to the network's authentication layer.  This allows for a network to provide a common interface regardless of what authentication layer they have chosen for their network to operate, i.e. traditional services, a different central authority, or a decentralized model similar to [IRCX](https://en.wikipedia.org/wiki/IRCX).
    

--- a/extensions/acc-core.md
+++ b/extensions/acc-core.md
@@ -1,5 +1,5 @@
 ---
-title: "The REG command framework"
+title: "The ACC command framework"
 layout: spec
 copyrights:
   -
@@ -8,11 +8,11 @@ copyrights:
     email: "nenolod@dereferenced.org"
   -
     name: "Daniel Oaks"
-    period: "2016"
+    period: "2016-2017"
     email: "daniel@danieloaks.net"
 ---
 
-The `REG` command framework provides a unified, standardized interface for account creation and
+The `ACC` command framework provides a unified, standardized interface for account creation and
 validation to the network's authentication layer.  This allows for a network to provide a common
 interface regardless of what authentication layer they have chosen for their network to operate,
 i.e. traditional services, a different central authority, or a decentralized model similar to [IRCX][ircx].
@@ -25,20 +25,20 @@ authority layer of the network.  Further, we believe it is helpful to client aut
 they may provide guided account creation and validation for their users, regardless of network
 configuration.
 
-## The `REG` command
+## The `ACC` command
 
-The `REG` command is the main command used by the account registration subsystem.  It provides
-several subcommands listed in the `REGCOMMANDS` ISUPPORT type.  The core sub-commands are listed
+The `ACC` command is the main command used by the account registration subsystem.  It provides
+several subcommands listed in the `ACCCOMMANDS` ISUPPORT type.  The core sub-commands are listed
 below:
 
-## The `REG CREATE` sub-command
+## The `ACC REGISTER` sub-command
 
-The `REG CREATE` command signals the intent of a client to register an account in the network's
+The `ACC REGISTER` command signals the intent of a client to register an account in the network's
 authentication layer.  It is similar to current methods of signalling that intent.
 
-A `REG CREATE` command consists of the following format:
+A `ACC REGISTER` command consists of the following format:
 
-    REG CREATE <accountname> [callback_namespace:]<callback> [cred_type] :<credential>
+    ACC REGISTER <accountname> [callback_namespace:]<callback> [cred_type] :<credential>
 
 The `accountname` field specifies the account name the client wishes to register.  If the account name
 is `*`, it indicates that the client wishes to register with their current nickname as this field.
@@ -60,8 +60,8 @@ values of the `cred_type` field is implementation-specific, with credential type
 error.  The client SHOULD supply a `cred_type` value, however if one is not provided the IRC server SHOULD
 use `passphrase` as a default credential type.
 
-The IRC server MAY forward the `REG CREATE` command to a central authority, or process it locally. Clients
-SHOULD NOT be sent unnecessary legacy (e.g. from NickServ) private messages or notices in response to `REG`
+The IRC server MAY forward the `ACC REGISTER` command to a central authority, or process it locally. Clients
+SHOULD NOT be sent unnecessary legacy (e.g. from NickServ) private messages or notices in response to `ACC`
 commands, where native numerics such as the ones defined in this document can replace them.
 
 Upon success, the IRC server MUST send the `RPL_REGISTRATION_SUCCESS` numeric, which looks like:
@@ -89,17 +89,17 @@ Upon error, the IRC server MUST send an error code that is relevant.  We suggest
 
 The server MAY send additional informative text upon registration success or failure using `RPL_TEXT` or `NOTICE`.
 
-## The `REG VERIFY` sub-command
+## The `ACC VERIFY` sub-command
 
-The `REG VERIFY` command signals the intent of a client to submit a verification token for their
-account registration.  If a valid callback is specified by the client during the `REG CREATE`
+The `ACC VERIFY` command signals the intent of a client to submit a verification token for their
+account registration.  If a valid callback is specified by the client during the `ACC REGISTER`
 command, the server MUST send the token to the specified callback.
 
-A `REG VERIFY` command consists of the following format:
+A `ACC VERIFY` command consists of the following format:
 
-    REG VERIFY <accountname> <auth_code>
+    ACC VERIFY <accountname> <auth_code>
 
-The IRC server MAY forward the `REG VERIFY` command to a central authority, or process it
+The IRC server MAY forward the `ACC VERIFY` command to a central authority, or process it
 locally.
 
 Upon success, the IRC server MUST send the `RPL_VERIFYSUCCESS` numeric, which looks like:
@@ -119,16 +119,16 @@ numerics:
 | 924 | `ERR_ACCOUNT_ALREADY_VERIFIED`    | `:<server> 924 <user_nickname> <accountname> :Account already verified`  |
 | 925 | `ERR_ACCOUNT_INVALID_VERIFY_CODE` | `:<server> 925 <user_nickname> <accountname> :Invalid verification code` |
 
-## The `REGCOMMANDS` `RPL_ISUPPORT` token
+## The `ACCCOMMANDS` `RPL_ISUPPORT` token
 
-Implementations which provide these commands SHOULD signal their availability using the `REGCOMMANDS`
-RPL_ISUPPORT (005) token.  The `REGCOMMANDS` token takes a comma-separated list of supported
-commands.  Other extensions MAY include additional commands in the `REGCOMMANDS` token than those
+Implementations which provide these commands SHOULD signal their availability using the `ACCCOMMANDS`
+RPL_ISUPPORT (005) token.  The `ACCCOMMANDS` token takes a comma-separated list of supported
+commands.  Other extensions MAY include additional commands in the `ACCCOMMANDS` token than those
 documented here.
 
 A sample 005 reply indicating support for these commands is:
 
-    :irc.example.com 005 kaniini REGCOMMANDS=CREATE,VERIFY :are supported by this server
+    :irc.example.com 005 kaniini ACCCOMMANDS=REGISTER,VERIFY :are supported by this server
 
 ## The `REGCALLBACKS` `RPL_ISUPPORT` token
 
@@ -175,20 +175,20 @@ A sample 005 reply indicating support for credential types is:
     :irc.example.com 005 kaniini REGCREDTYPES=passphrase,certfp :are supported by this server
 
 The first credential type in this token SHOULD be used as the default if the client does not
-specify a credential type in the `REG CREATE` command.
+specify a credential type in the `ACC REGISTER` command.
 
-## The `REGNICK` `RPL_ISUPPORT` token
+## The `ACCNICK` `RPL_ISUPPORT` token
 
 Some implementations restrict the account name that can be registered to the current nickname of
 the client (that is, they tie account name registration to nicknames). Implementations which
-restrict registration in this way MUST advertise the `REGNICK` RPL_ISUPPORT (005) token.
+restrict registration in this way MUST advertise the `ACCNICK` RPL_ISUPPORT (005) token.
 
 This token has no value, and a sample 005 reply indicating this behaviour is:
 
-    :irc.example.com 005 dan REGNICK :are supported by this server
+    :irc.example.com 005 dan ACCNICK :are supported by this server
 
 When registering on a network that enforces this policy, clients MUST send `*` as `<accountname>`
-in the `REG CREATE` command (which indicates that the server use the client's current nickname
+in the `ACC REGISTER` command (which indicates that the server use the client's current nickname
 as the account name). If a client sends an incorrect accountname on a network enforcing this
 policy, the server MUST return the `ERR_REG_UNSPECIFIED_ERROR` (922) numeric with an appropriate
 description.
@@ -197,65 +197,64 @@ description.
 
 ### Registering the account "kaniini" with e-mail address kaniini@example.com:
 
-    C: REG CREATE kaniini mailto:kaniini@example.com passphrase :testpassphrase123
+    C: ACC REGISTER kaniini mailto:kaniini@example.com passphrase :testpassphrase123
     S: 920 kaniini kaniini :Account registered
     S: 927 kaniini kaniini kaniini@example.com :A verification code was sent
-    C: REG VERIFY kaniini 3qw4tq4te4gf34
+    C: ACC VERIFY kaniini 3qw4tq4te4gf34
     S: 923 kaniini kaniini :Account verification successful
     S: 903 kaniini :Authentication successful
 
 ### Registering with the client's current nickname "dan-":
 
-    C: REG CREATE * mailto:dan@example.com passphrase :testpassphrase123
+    C: ACC REGISTER * mailto:dan@example.com passphrase :testpassphrase123
     S: 920 dan- dan- :Account registered
     S: 927 dan- dan- dan@example.com :A verification code was sent
     ...
 
 ### Registering the account "rabbit" with SMS number +11234567890:
 
-    C: REG CREATE rabbit sms:+11234567890 passphrase :testpassphrase123
+    C: ACC REGISTER rabbit sms:+11234567890 passphrase :testpassphrase123
     S: 920 kaniini rabbit :Account registered
     S: 927 kaniini rabbit +11234567890 :A verification code was sent
-    C: REG VERIFY rabbit 123456
+    C: ACC VERIFY rabbit 123456
     S: 923 kaniini rabbit :Account verification successful
     S: 903 kaniini :Authentication successful
 
 ### Registering the account "rabbit" with an unsupported verification method:
 
-    C: REG CREATE rabbit 1vBjNBdhjWFFbbbbVBHJEWBHJWcfbbvjkhbea passphrase :testpassphrase123
+    C: ACC REGISTER rabbit 1vBjNBdhjWFFbbbbVBHJEWBHJWcfbbvjkhbea passphrase :testpassphrase123
     S: 929 kaniini rabbit 1vBjNBdhjWFFbbbbVBHJEWBHJWcfbbvjkhbea :Callback token is not valid
 
 ### Registering the account "rabbit", but providing an invalid verification token:
 
-    C: REG CREATE rabbit mailto:kaniini@example.com passphrase :testpassphrase123
+    C: ACC REGISTER rabbit mailto:kaniini@example.com passphrase :testpassphrase123
     S: 920 kaniini rabbit :Account registered
     S: 927 kaniini rabbit kaniini@example.com :A verification code was sent
-    C: REG VERIFY rabbit 3qw4tq4te4gf34
+    C: ACC VERIFY rabbit 3qw4tq4te4gf34
     S: 925 kaniini rabbit :Invalid verification code
 
 ### Registering the account "rabbit" where a verification token is not required:
 
-    C: REG CREATE rabbit * passphrase :testpassphrase123
+    C: ACC REGISTER rabbit * passphrase :testpassphrase123
     S: 920 kaniini rabbit :Account registered
     S: 903 kaniini :Authentication successful
 
-### Registering the account "harold" where REGNICK is present in RPL_ISUPPORT:
+### Registering the account "harold" where ACCNICK is present in RPL_ISUPPORT:
 
-    C: REG CREATE harold * passphrase :testpassphrase123
+    C: ACC REGISTER harold * passphrase :testpassphrase123
     S: 922 dan- harold :You can only register with your current nickname
 
 ### Registering an account which already exists:
 
-    C: REG CREATE rabbit sms:+11234567890 passphrase :testpassphrase123
+    C: ACC REGISTER rabbit sms:+11234567890 passphrase :testpassphrase123
     S: 921 kaniini rabbit :Account already exists
 
 ### Registering an account with an unsupported credential type:
 
-    C: REG CREATE rabbit mailto:kaniini@example.com some_invalid_cred_type :1QXvcnFWJKFGjbnkwawFJKNJKEc254
+    C: ACC REGISTER rabbit mailto:kaniini@example.com some_invalid_cred_type :1QXvcnFWJKFGjbnkwawFJKNJKEc254
     S: 928 kaniini rabbit some_invalid_cred_type :Credential type is invalid
 
 ### Implementation-specific registration errors:
 
-    C: REG CREATE rabbit sms:+11234567890 passphrase :abc123
+    C: ACC REGISTER rabbit sms:+11234567890 passphrase :abc123
     S: 922 kaniini rabbit :Invalid params: "rabbit" is a blocked account name
-

--- a/extensions/acc-core.md
+++ b/extensions/acc-core.md
@@ -36,6 +36,8 @@ The `ACC` command exposes a number of subcommands as described below. Servers MA
 
 Servers MUST use the [standard replies extension](https://github.com/ircv3/ircv3-specifications/pull/357) to notify the client of failed `ACC` subcommands. The specific codes and format to use are given with each command's description.
 
+Servers MUST allow the `ACC LS` subcommand to be used at any time (before, during, and after connection registration). Servers MAY allow clients to use other subcommands while connecting to the server (for example, the server may allow registering for or verifying an account while connecting). If the client attempts to run a disallowed subcommand before connection registration has completed, the server MUST return the `ERR_NOTREGISTERED (451)` numeric.
+
 
 ## The `ACC LS` subcommand
 The `ACC LS` subcommand signals that a client wishes to receive a list of supported `ACC` subcommands. The response is one or more `ACC LS` messages sent to the client with this format:
@@ -104,6 +106,7 @@ Upon error, the IRC server MUST send a [`FAIL` message](https://github.com/ircv3
 | Code | Format |
 | ---- | ------ |
 | `ACCOUNT_ALREADY_EXISTS` | `:<server> FAIL ACC ACCOUNT_ALREADY_EXISTS <accountname> :Account already exists` |
+| `REG_INVALID_ACCOUNT_NAME` | `:<server> FAIL ACC REG_INVALID_ACCOUNT_NAME <accountname> :Account name is invalid` |
 | `REG_INVALID_CALLBACK` | `:<server> FAIL ACC REG_INVALID_CALLBACK <accountname> <callback> :Callback is invalid` |
 | `REG_INVALID_CRED_TYPE` | `:<server> FAIL ACC REG_INVALID_CRED_TYPE <accountname> <cred_type> :Credential type is invalid` |
 | `REG_MUST_USE_REGNICK` | `:<server> FAIL ACC REG_MUST_USE_REGNICK <accountname> :Must register with current nickname instead of separate account name` |

--- a/extensions/acc-core.md
+++ b/extensions/acc-core.md
@@ -193,6 +193,16 @@ as the account name). If a client sends an incorrect accountname on a network en
 policy, the server MUST return the `ERR_REG_UNSPECIFIED_ERROR` (922) numeric with an appropriate
 description.
 
+## Account Required
+
+Certain actions on a network may require a client account to be completed. These may include connection registration, channel registration, or other actions. The `ACC_REQUIRED` numeric indicates that the client must be logged into an account in order to complete an action or continue using the network.
+
+Upon receiving the `ACC_REQUIRED` numeric, clients SHOULD alert users that they need to register/login and/or provide an interface to do so. The `ACC_REQUIRED` numeric MAY be received before connection registration has completed, in which case clients SHOULD alert that SASL must be used to connect to the current network.
+
+| No. | Label          | Format                                                                              |
+| --- | -------------- | ----------------------------------------------------------------------------------- |
+| ??? | `ACC_REQUIRED` | `:<server> ??? <user_nickname> [<command>] :You must login to complete this action` |
+
 ## Examples
 
 ### Registering the account "kaniini" with e-mail address kaniini@example.com:

--- a/extensions/acc-core.md
+++ b/extensions/acc-core.md
@@ -49,7 +49,7 @@ types may or may not allow spaces inside `credential`.
 
 The `callback` field designates an opaque value which indicates where a verification code, if any,
 will be sent.  The callback field SHOULD contain either a standard URI, the namespace being contained in
-the IANA URI schemes registry (as per [RFC 4395][rfc4395]) and listed in the `REGCALLBACKS` ISUPPORT
+the IANA URI Schemes registry (as per [RFC 7595][rfc7595]) and listed in the `REGCALLBACKS` ISUPPORT
 token, or a `*` as decribed below. An invalid callback parameter should result in the
 `ERR_REG_INVALID_CALLBACK` error.
 
@@ -133,9 +133,9 @@ A sample 005 reply indicating support for these commands is:
 Implementations which require a verification token should list the types of verification callbacks
 they support, using the `REGCALLBACKS` RPL_ISUPPORT (005) token.  The `REGCALLBACKS` token takes
 a comma-separated list of supported commands.  In general, the `REGCALLBACKS` token is limited to
-URI schemes defined in the IANA URI schemes registry, per [RFC 4395][rfc4395].
+URI schemes defined in the IANA URI Schemes registry, per [RFC 7595][rfc7595].
 
-  [rfc3495]: https://tools.ietf.org/html/rfc4395
+  [rfc7595]: https://tools.ietf.org/html/rfc7595
 
 In the event that verification is not required by the implementation, the `REGCALLBACKS` token should
 be an empty value.

--- a/extensions/acc-core.md
+++ b/extensions/acc-core.md
@@ -8,69 +8,41 @@ copyrights:
     email: "nenolod@dereferenced.org"
   -
     name: "Daniel Oaks"
-    period: "2016-2017"
+    period: "2016-2019"
     email: "daniel@danieloaks.net"
 ---
 
 The `ACC` command framework provides a unified, standardized interface for account management.
 
-This specification defines the `ACC REGISTER` and `VERIFY` subcommands, which standardise account
-creation and validation to the network's authentication layer.  This allows for a network to
-provide a common interface regardless of what authentication layer they have chosen for their
-network to operate, i.e. traditional services, a different central authority, or a decentralized
-model similar to [IRCX][ircx].
-
-   [ircx]: http://en.wikipedia.org/wiki/IRCX
+This specification defines the `ACC REGISTER` and `VERIFY` subcommands, which standardise account creation and validation to the network's authentication layer.  This allows for a network to provide a common interface regardless of what authentication layer they have chosen for their network to operate, i.e. traditional services, a different central authority, or a decentralized model similar to [IRCX][https://en.wikipedia.org/wiki/IRCX].
    
-We believe that the benefit of adding a common interface for account management will result in
-more user-focused interfaces for common account tasks including registration. Further,
-standardised account registration allows client authors to provide guided account creation and
-validation to their users, regardless of how the network performs these tasks.
+We believe that the benefit of adding a common interface for account management will result in more user-focused interfaces for common account tasks including registration. Further, standardised account registration allows client authors to provide guided account creation and validation to their users, regardless of how the network performs these tasks.
 
 ## The `ACC` command
 
-The `ACC` command is the main command used by the account registration subsystem.  It provides
-several subcommands listed in the `ACCCOMMANDS` ISUPPORT type.  The core subcommands are listed
-below:
+The `ACC` command is the main command used by the account registration subsystem.  It provides several subcommands listed in the `ACCCOMMANDS` ISUPPORT type.  The core subcommands are listed below.
 
 ## The `ACC REGISTER` sub-command
 
-The `ACC REGISTER` command signals the intent of a client to register an account with the network's
-authentication layer.  It is similar to current methods of signalling that intent.
+The `ACC REGISTER` command signals the intent of a client to register an account with the network's authentication layer.  It is similar to current methods of signalling that intent.
 
 An `ACC REGISTER` command has the following format:
 
     ACC REGISTER <accountname> [callback_namespace:]<callback> [cred_type] :<credential>
 
-The `accountname` field specifies the account name the client wishes to register.  If the account name
-is `*`, it indicates that the client wishes to register with their current nickname as this field.
+The `accountname` field specifies the account name the client wishes to register.  If the account name is `*`, it indicates that the client wishes to register with their current nickname as this field.
 
-The `credential` field specifies a credential of `cred_type`.  If there is no specified credential, then
-the `credential` field MUST be `*`.  A passphrase type `credential` MAY have spaces in it. New credential
-types may or may not allow spaces inside `credential`.
+The `credential` field specifies a credential of `cred_type`.  If there is no specified credential, then the `credential` field MUST be `*`.  A passphrase type `credential` MAY have spaces in it. New credential types may or may not allow spaces inside `credential`.
 
-The `callback` field designates an opaque value which indicates where a verification code, if any,
-will be sent.  The callback field SHOULD contain either a standard URI, the namespace being contained in
-the IANA URI Schemes registry (as per [RFC 7595][rfc7595]) and listed in the `REGCALLBACKS` ISUPPORT
-token, or a `*` as decribed below. An invalid callback parameter should result in the
-`ERR_REG_INVALID_CALLBACK` error.
+The `callback` field designates an opaque value which indicates where a verification code, if any, will be sent.  The callback field SHOULD contain either a standard URI, the namespace being contained in the IANA URI Schemes registry (as per [RFC 7595][rfc7595]) and listed in the `REGCALLBACKS` ISUPPORT token, or a `*` as decribed below. An invalid callback parameter should result in the `ERR_REG_INVALID_CALLBACK` error.
 
-In the event that a callback is not provided, the client SHOULD send `*` to indicate that they are not
-providing a callback resource.  If a callback namespace is not explicitly provided, the IRC server MAY
-choose to use `mailto` as a default.
+In the event that a callback is not provided, the client SHOULD send `*` to indicate that they are not providing a callback resource.  If a callback namespace is not explicitly provided, the IRC server MAY choose to use `mailto` as a default.
 
-The `cred_type` field designates a value which indicates the type of supplied credential.  The accepted
-values of the `cred_type` field is implementation-specific, with credential types being listed using the
-`REGCREDTYPES` ISUPPORT token.  An invalid credential type parameter should result in the `ERR_REG_INVALID_CRED_TYPE`
-error.  The client SHOULD supply a `cred_type` value, however if one is not provided the IRC server SHOULD
-use `passphrase` as a default credential type.
+The `cred_type` field designates a value which indicates the type of supplied credential.  The accepted values of the `cred_type` field is implementation-specific, with credential types being listed using the `REGCREDTYPES` ISUPPORT token.  An invalid credential type parameter should result in the `ERR_REG_INVALID_CRED_TYPE` error.  The client SHOULD supply a `cred_type` value, however if one is not provided the IRC server SHOULD use `passphrase` as a default credential type.
 
-The IRC server MAY forward the `ACC REGISTER` command to a central authority, or process it locally. Clients
-SHOULD NOT be sent unnecessary legacy (e.g. from NickServ) private messages or notices in response to `ACC`
-commands, where native numerics such as the ones defined in this document can replace them.
+The IRC server MAY forward the `ACC REGISTER` command to a central authority, or process it locally. Clients SHOULD NOT be sent unnecessary legacy (e.g. from NickServ) private messages or notices in response to `ACC` commands, where native numerics such as the ones defined in this document can replace them.
 
-After this, if verification is required, the IRC server MUST send the `RPL_REG_VERIFICATION_REQUIRED`
-numeric. If verification is not required, the IRC server MUST instead send the `RPL_REG_SUCCESS` numeric.
+After this, if verification is required, the IRC server MUST send the `RPL_REG_VERIFICATION_REQUIRED` numeric. If verification is not required, the IRC server MUST instead send the `RPL_REG_SUCCESS` numeric.
 
 | No. | Label                           | Format                                                                                                       |
 | --- | ------------------------------- | ------------------------------------------------------------------------------------------------------------ |
@@ -91,16 +63,13 @@ The server MAY send additional informative text upon registration success or fai
 
 ## The `ACC VERIFY` sub-command
 
-The `ACC VERIFY` command signals the intent of a client to submit a verification token for their
-account registration.  If a valid callback is specified by the client during the `ACC REGISTER`
-command, the server MUST send the token to the specified callback.
+The `ACC VERIFY` command signals the intent of a client to submit a verification token for their account registration.  If a valid callback is specified by the client during the `ACC REGISTER` command, the server MUST send the token to the specified callback.
 
 A `ACC VERIFY` command consists of the following format:
 
     ACC VERIFY <accountname> <auth_code>
 
-The IRC server MAY forward the `ACC VERIFY` command to a central authority, or process it
-locally.
+The IRC server MAY forward the `ACC VERIFY` command to a central authority, or process it locally.
 
 Upon success, the IRC server MUST send the `RPL_VERIFYSUCCESS` numeric, which looks like:
 
@@ -108,11 +77,9 @@ Upon success, the IRC server MUST send the `RPL_VERIFYSUCCESS` numeric, which lo
 | --- | ------------------- | ------------------------------------------------------------------------------ |
 | 923 | `RPL_VERIFYSUCCESS` | `:<server> 923 <user_nickname> <accountname> :Account verification successful` |
 
-The IRC server MUST also send an `RPL_LOGGEDIN` (900) numeric and consider the client to be logged in to the
-account that has been successfully verified.
+The IRC server MUST also send an `RPL_LOGGEDIN` (900) numeric and consider the client to be logged in to the account that has been successfully verified.
 
-Upon error, the IRC server MUST send an error code that is relevant.  We suggest these
-numerics:
+Upon error, the IRC server MUST send an error code that is relevant.  We suggest these numerics:
 
 | No. | Label                             | Format                                                                   |
 | --- | --------------------------------- | ------------------------------------------------------------------------ |
@@ -121,10 +88,7 @@ numerics:
 
 ## The `ACCCOMMANDS` `RPL_ISUPPORT` token
 
-Implementations which provide these commands SHOULD signal their availability using the `ACCCOMMANDS`
-RPL_ISUPPORT (005) token.  The `ACCCOMMANDS` token takes a comma-separated list of supported
-commands.  Other extensions MAY include additional commands in the `ACCCOMMANDS` token than those
-documented here.
+Implementations which provide these commands SHOULD signal their availability using the `ACCCOMMANDS` RPL_ISUPPORT (005) token.  The `ACCCOMMANDS` token takes a comma-separated list of supported commands.  Other extensions MAY include additional commands in the `ACCCOMMANDS` token than those documented here.
 
 A sample 005 reply indicating support for these commands is:
 
@@ -132,15 +96,9 @@ A sample 005 reply indicating support for these commands is:
 
 ## The `REGCALLBACKS` `RPL_ISUPPORT` token
 
-Implementations which require a verification token should list the types of verification callbacks
-they support, using the `REGCALLBACKS` RPL_ISUPPORT (005) token.  The `REGCALLBACKS` token takes
-a comma-separated list of supported commands.  In general, the `REGCALLBACKS` token is limited to
-URI schemes defined in the IANA URI Schemes registry, per [RFC 7595][rfc7595].
+Implementations which require a verification token should list the types of verification callbacks they support, using the `REGCALLBACKS` RPL_ISUPPORT (005) token.  The `REGCALLBACKS` token takes a comma-separated list of supported commands.  In general, the `REGCALLBACKS` token is limited to URI schemes defined in the IANA URI Schemes registry, per [RFC 7595][https://tools.ietf.org/html/rfc7595].
 
-  [rfc7595]: https://tools.ietf.org/html/rfc7595
-
-In the event that verification is not required by the implementation, the `REGCALLBACKS` token should
-be an empty value.
+In the event that verification is not required by the implementation, the `REGCALLBACKS` token should be an empty value.
 
 A sample 005 reply indicating support for verification callbacks is:
 
@@ -150,15 +108,11 @@ A sample 005 reply indicating that no verification callback methods are supporte
 
     :irc.example.com 005 kaniini REGCALLBACKS= :are supported by this server
 
-The first callback type SHOULD be the implementation-defined default if default callback types
-are supported.
+The first callback type SHOULD be the implementation-defined default if default callback types are supported.
 
 ## The `REGCREDTYPES` `RPL_ISUPPORT` token
 
-Implementations which provide support for this framework SHOULD specify the allowed credential
-types using the `REGCREDTYPES` RPL_ISUPPORT (005) token.  The `REGCREDTYPES` token takes a
-comma-separated list of supported commands.  Other extensions MAY include additional credential
-types than those listed here.
+Implementations which provide support for this framework SHOULD specify the allowed credential types using the `REGCREDTYPES` RPL_ISUPPORT (005) token.  The `REGCREDTYPES` token takes a comma-separated list of supported commands.  Other extensions MAY include additional credential types than those listed here.
 
 The following credential types are defined:
 
@@ -174,24 +128,17 @@ A sample 005 reply indicating support for credential types is:
 
     :irc.example.com 005 kaniini REGCREDTYPES=passphrase,certfp :are supported by this server
 
-The first credential type in this token SHOULD be used as the default if the client does not
-specify a credential type in the `ACC REGISTER` command.
+The first credential type in this token SHOULD be used as the default if the client does not specify a credential type in the `ACC REGISTER` command.
 
 ## The `REGNICK` `RPL_ISUPPORT` token
 
-Some implementations restrict the account name that can be registered to the current nickname of
-the client (that is, they tie account name registration to nicknames). Implementations which
-restrict registration in this way MUST advertise the `REGNICK` RPL_ISUPPORT (005) token.
+Some implementations restrict the account name that can be registered to the current nickname of the client (that is, they tie account name registration to nicknames). Implementations which restrict registration in this way MUST advertise the `REGNICK` RPL_ISUPPORT (005) token.
 
 This token has no value, and a sample 005 reply indicating this behaviour is:
 
     :irc.example.com 005 dan REGNICK :are supported by this server
 
-When registering on a network that enforces this policy, clients MUST send `*` as `<accountname>`
-in the `ACC REGISTER` command (which indicates that the server use the client's current nickname
-as the account name). If a client sends an incorrect accountname on a network enforcing this
-policy, the server MUST return the `ERR_REG_UNSPECIFIED_ERROR` (922) numeric with an appropriate
-description.
+When registering on a network that enforces this policy, clients MUST send `*` as `<accountname>` in the `ACC REGISTER` command (which indicates that the server use the client's current nickname as the account name). If a client sends an incorrect accountname on a network enforcing this policy, the server MUST return the `ERR_REG_UNSPECIFIED_ERROR` (922) numeric with an appropriate description.
 
 ## Account Required
 

--- a/extensions/acc-core.md
+++ b/extensions/acc-core.md
@@ -94,7 +94,7 @@ If the client does not provide the `cred_type` parameter, the server MUST use th
 
 Clients SHOULD NOT be sent legacy (e.g. from NickServ) privmsgs or notices in response to `ACC` commands where numerics and messages defined in this document can replace them.
 
-After this, if verification is required, the IRC server MUST generate and send the verification token to the user out-of-band using the given callback information, and send the client the `RPL_REG_VERIFICATION_REQUIRED` numeric. The verification token MAY NOT be an asterisk (`*`), and SHOULD be an unguessable combination of characters. If verification is not required, the IRC server MUST instead send the `RPL_REG_SUCCESS` numeric.
+After this, if verification is required, the IRC server MUST generate and send the verification token to the user out-of-band using the given callback information, and send the client the `RPL_REG_VERIFICATION_REQUIRED` numeric. The verification token MAY NOT be an asterisk (`*`), and SHOULD be an unguessable combination of characters. If verification is not required, the IRC server MUST instead send the `RPL_REG_SUCCESS` and `RPL_LOGGEDIN` (900) numerics.
 
 | No. | Label | Format |
 | --- | ----- | ------ |
@@ -229,7 +229,7 @@ These examples show how to perform common tasks with this framework.
 
     C: ACC VERIFY kaniini 3qw4tq4te4gf34
     S: 923 kaniini kaniini :Account verification successful
-    S: 903 kaniini :Authentication successful
+    S: 900 kaniini kaniini!kan@ini kaniini :You are now logged in as kaniini
 
 ### Registering the account "kaniini" with e-mail address kaniini@example.com:
 
@@ -252,7 +252,7 @@ These examples show how to perform common tasks with this framework.
 
     C: ACC VERIFY rabbit 123456
     S: 923 kaniini rabbit :Account verification successful
-    S: 903 kaniini :Authentication successful
+    S: 900 kaniini kaniini!kan@ini rabbit :You are now logged in as rabbit
 
 ### Registering the account "rabbit" with an unsupported verification method:
 
@@ -273,7 +273,7 @@ These examples show how to perform common tasks with this framework.
 
     C: ACC REGISTER rabbit * passphrase :testpassphrase123
     S: 920 kaniini rabbit :Account registered
-    S: 903 kaniini :Authentication successful
+    S: 900 kaniini kaniini!kan@ini rabbit :You are now logged in as rabbit
 
 ### Operator verifying a user's account registration:
 
@@ -285,7 +285,7 @@ In this example, C1 is the normal user and C2 is the IRC operator or other privi
     C2: ACC VERIFY pix *
     S2: 923 george pix :Account verification successful
 
-    ... C1 can now reconnect and/or perform SASL authentication to log into the account ..
+    ... C1 can now perform SASL authentication to log into the account ..
 
 ### Registering the account "harold" where regnick is advertised:
 

--- a/extensions/acc-core.md
+++ b/extensions/acc-core.md
@@ -135,6 +135,7 @@ Upon error, the IRC server MUST send a [`FAIL` message](https://github.com/ircv3
 | ---- | ------ |
 | `ACCOUNT_ALREADY_VERIFIED` | `:<server> FAIL ACC ACCOUNT_ALREADY_VERIFIED <accountname> :Account already verified` |
 | `ACCOUNT_INVALID_VERIFY_CODE` | `:<server> FAIL ACC ACCOUNT_INVALID_VERIFY_CODE <accountname> :Invalid verification code` |
+| `REG_UNAVAILABLE` | `:<server> FAIL ACC REG_UNAVAILABLE :Account registration is currently unavailable` |
 | `VERIFY_UNSPECIFIED_ERROR` | `:<server> FAIL ACC VERIFY_UNSPECIFIED_ERROR <accountname> [<contexts>...] <description>` |
 
 Servers MAY allow IRC Operators or other privileged users to verify a given account by supplying an asterisk (`*`) in place of the `<auth_code>` parameter. If a client does verify an account in this way, they are sent the `RPL_VERIFY_SUCCESS` numeric, but are not logged into the account or sent the `RPL_LOGGEDIN` numeric.

--- a/extensions/acc-core.md
+++ b/extensions/acc-core.md
@@ -194,7 +194,7 @@ The `regnick` flag indicates that when a client registers an account, the accoun
 When registering an account on a network with this flag, clients MUST send an asterisk (`*`) as the `<accountname>` in the `ACC REGISTER` command. This indicates that the server use the client's current nickname as the account name. If a client sends does not send an asterisk `*` on a network enforcing this policy, the server MUST return the `REG_MUST_USE_REGNICK` `FAIL` code.
 
 ### nospaces Flag
-The `nospaces` flag indicates that passphrase MAY NOT contain space characters. This may include just the SPACE (`0x20`) ASCII character or any other form of whitespace as well. When this flag is advertised, clients SHOULD NOT send a passphrase that contains any whitespace, as it may be rejected by the server with the `REG_INVALID_CRED_TYPE` `FAIL` code.
+The `nospaces` flag indicates that passphrase MAY NOT contain space characters. This may include just the SPACE (`0x20`) ASCII character or any other form of whitespace as well. When this flag is advertised, clients SHOULD NOT send a passphrase that contains any whitespace, as it may be rejected by the server with the `REG_INVALID_CREDENTIAL` `FAIL` code.
 
 
 ## Account Required

--- a/extensions/acc-core.md
+++ b/extensions/acc-core.md
@@ -107,7 +107,7 @@ Upon error, the IRC server MUST send a [`FAIL` message](https://github.com/ircv3
 | ---- | ------ |
 | `ACCOUNT_ALREADY_EXISTS` | `:<server> FAIL ACC ACCOUNT_ALREADY_EXISTS <accountname> :Account already exists` |
 | `REG_INVALID_ACCOUNT_NAME` | `:<server> FAIL ACC REG_INVALID_ACCOUNT_NAME <accountname> :Account name is invalid` |
-| `REG_INVALID_CALLBACK` | `:<server> FAIL ACC REG_INVALID_CALLBACK <accountname> <callback> :Callback is invalid` |
+| `REG_INVALID_CALLBACK` | `:<server> FAIL ACC REG_INVALID_CALLBACK <accountname> <callback> :Cannot send verification code there` |
 | `REG_INVALID_CRED_TYPE` | `:<server> FAIL ACC REG_INVALID_CRED_TYPE <accountname> <cred_type> :Credential type is invalid` |
 | `REG_MUST_USE_REGNICK` | `:<server> FAIL ACC REG_MUST_USE_REGNICK <accountname> :Must register with current nickname instead of separate account name` |
 | `REG_UNAVAILABLE` | `:<server> FAIL ACC REG_UNAVAILABLE :Account registration is currently unavailable` |

--- a/extensions/reg-core-3.3.md
+++ b/extensions/reg-core-3.3.md
@@ -34,7 +34,7 @@ authentication layer.  It is similar to current methods of signalling that inten
 
 A `REG CREATE` command consists of the following format:
 
-`REG CREATE <accountname> <callback> <cred_type> :<credential>`
+`REG CREATE <accountname> [callback_namespace:]<callback> [cred_type] :<credential>`
 
 A passphrase `credential` MAY have spaces in it.
 
@@ -42,12 +42,14 @@ The `callback` field designates an opaque value which indicates where a verifica
 will be sent.  The callback field is implementation-specific, with namespaces being listed using the
 `REGCALLBACKS` ISUPPORT token.  An invalid callback parameter should result in the `ERR_REG_INVALID_CALLBACK`
 error.  In the event that a callback is not provided, the client SHOULD send `*` to indicate that
-they are not providing a callback resource.
+they are not providing a callback resource.  If a callback namespace is not explicitly provided, the IRC
+server MAY choose to use `mailto` as a default.
 
 The `cred_type` field designates a value which indicates the type of supplied credential.  The accepted
 values of the `cred_type` field is implementation-specific, with credential types being listed using the
 `REGCREDTYPES` ISUPPORT token.  An invalid credential type parameter should result in the `ERR_REG_INVALID_CRED_TYPE`
-error.  The client MUST supply a `cred_type` value.
+error.  The client SHOULD supply a `cred_type` value, however if one is not provided the IRC server SHOULD
+use `passphrase` as a default credential type.
 
 The IRC server MAY forward the `REG CREATE` command to a central authority, or process it locally, however
 the authentication layer SHOULD NOT send any legacy messages in reply to a `REG CREATE` command.
@@ -59,7 +61,7 @@ Upon success, the IRC server MUST send the `RPL_REGISTRATION_SUCCESS` numeric, w
 If the server requires a verification token, it MUST also reply with the `RPL_REG_VERIFICATION_REQUIRED`
 numeric, which looks like:
 
-    :<server> 927 <user_nickname> <accountname> <callback> :A verification token was sent
+    :<server> 927 <user_nickname> <accountname> <callback_namespace:><callback> :A verification token was sent
 
 Upon error, the IRC server MUST send an error code that is relevant.  We suggest these numerics:
 
@@ -134,6 +136,9 @@ A sample 005 reply indicating that no verification callback methods are supporte
 
     :irc.example.com 005 kaniini REGCALLBACKS= :are supported by this server
 
+The first callback type SHOULD be the implementation-defined default if default callback types
+are supported.
+
 ## The `REGCREDTYPES` `RPL_ISUPPORT` token
 
 Implementations which provide support for this framework SHOULD specify the allowed credential
@@ -152,6 +157,9 @@ The following credential types are defined:
 A sample 005 reply indicating support for credential types is:
 
     :irc.example.com 005 kaniini REGCREDTYPES=passphrase,certfp :are supported by this server
+
+The first credential type SHOULD be the implementation-defined default if default credential types
+are supported.
 
 ## Examples
 

--- a/extensions/reg-core-3.3.md
+++ b/extensions/reg-core-3.3.md
@@ -100,7 +100,8 @@ Upon success, the IRC server MUST send the `RPL_VERIFYSUCCESS` numeric, which lo
 | --- | ------------------- | ------------------------------------------------------------------------------ |
 | 923 | `RPL_VERIFYSUCCESS` | `:<server> 923 <user_nickname> <accountname> :Account verification successful` |
 
-The IRC server SHOULD also send an `RPL_AUTHENTICATION_SUCCESS` numeric.
+The IRC server SHOULD also send an `RPL_LOGGEDIN` (900) numeric and consider the client to be logged in to the
+account that has been successfully verified.
 
 Upon error, the IRC server MUST send an error code that is relevant.  We suggest these
 numerics:

--- a/extensions/reg-core-3.3.md
+++ b/extensions/reg-core-3.3.md
@@ -52,30 +52,32 @@ values of the `cred_type` field is implementation-specific, with credential type
 error.  The client SHOULD supply a `cred_type` value, however if one is not provided the IRC server SHOULD
 use `passphrase` as a default credential type.
 
-The IRC server MAY forward the `REG CREATE` command to a central authority, or process it locally, however
-the authentication layer SHOULD NOT send any legacy messages in reply to a `REG CREATE` command.
+The IRC server MAY forward the `REG CREATE` command to a central authority, or process it locally. Clients
+SHOULD NOT be sent unnecessary legacy (e.g. from NickServ) private messages or notices in response to `REG`
+commands, where native numerics such as the ones defined in this document can replace them.
 
 Upon success, the IRC server MUST send the `RPL_REGISTRATION_SUCCESS` numeric, which looks like:
 
-    :<server> 920 <user_nickname> <accountname> :Account created
+| No. | Label                      | Format                                                         |
+| --- | -------------------------- | -------------------------------------------------------------- |
+| 920 | `RPL_REGISTRATION_SUCCESS` | `:<server> 920 <user_nickname> <accountname> :Account created` |
 
 If the server requires a verification token, it MUST also reply with the `RPL_REG_VERIFICATION_REQUIRED`
 numeric, which looks like:
 
-    :<server> 927 <user_nickname> <accountname> <callback_namespace:><callback> :A verification token was sent
+| No. | Label                           | Format                                                                                                       |
+| --- | ------------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| 927 | `RPL_REG_VERIFICATION_REQUIRED` | `:<server> 927 <user_nickname> <accountname> <callback_namespace:><callback> :A verification token was sent` |
 
 Upon error, the IRC server MUST send an error code that is relevant.  We suggest these numerics:
 
-`ERR_ACCOUNT_ALREADY_EXISTS`:
-    `:<server> 921 <user_nickname> <accountname> :Account already exists`
-`ERR_REG_UNSPECIFIED_ERROR`:
-    `:<server> 922 <user_nickname> <accountname> :<descriptive_text>`
-`ERR_REG_INVALID_CALLBACK`:
-    `:<server> 929 <user_nickname> <accountname> <callback> :Callback token is invalid`
-`ERR_REG_INVALID_CRED_TYPE`:
-    `:<server> 928 <user_nickname> <accountname> <cred_type> :Credential type is invalid`
-`ERR_REG_UNAVAILABLE`:
-    `:<server> 440 <user_nickname> <subcommand> :Authentication services are currently unavailable`
+| No. | Label                        | Format                                                                                          |
+| --- | ---------------------------- | ----------------------------------------------------------------------------------------------- |
+| 921 | `ERR_ACCOUNT_ALREADY_EXISTS` | `:<server> 921 <user_nickname> <accountname> :Account already exists`                           |
+| 922 | `ERR_REG_UNSPECIFIED_ERROR`  | `:<server> 922 <user_nickname> <accountname> :<descriptive_text>`                               |
+| 929 | `ERR_REG_INVALID_CALLBACK`   | `:<server> 929 <user_nickname> <accountname> <callback> :Callback token is invalid`             |
+| 982 | `ERR_REG_INVALID_CRED_TYPE`  | `:<server> 928 <user_nickname> <accountname> <cred_type> :Credential type is invalid`           |
+| 440 | `ERR_REG_UNAVAILABLE`        | `:<server> 440 <user_nickname> <subcommand> :Authentication services are currently unavailable` |
 
 The server MAY send additional informative text upon registration success or failure using `RPL_TEXT` or `NOTICE`.
 
@@ -94,17 +96,19 @@ locally.
 
 Upon success, the IRC server MUST send the `RPL_VERIFYSUCCESS` numeric, which looks like:
 
-    :<server> 923 <user_nickname> <accountname> :Account verification successful
+| No. | Label               | Format                                                                         |
+| --- | ------------------- | ------------------------------------------------------------------------------ |
+| 923 | `RPL_VERIFYSUCCESS` | `:<server> 923 <user_nickname> <accountname> :Account verification successful` |
 
 The IRC server SHOULD also send an `RPL_AUTHENTICATION_SUCCESS` numeric.
 
 Upon error, the IRC server MUST send an error code that is relevant.  We suggest these
 numerics:
 
-`ERR_ACCOUNT_ALREADY_VERIFIED`:
-    `:<server> 924 <user_nickname> <accountname> :Account already verified`
-`ERR_ACCOUNT_INVALID_VERIFY_CODE`:
-    `:<server> 925 <user_nickname> <accountname> :Invalid verification code`
+| No. | Label                             | Format                                                                   |
+| --- | --------------------------------- | ------------------------------------------------------------------------ |
+| 924 | `ERR_ACCOUNT_ALREADY_VERIFIED`    | `:<server> 924 <user_nickname> <accountname> :Account already verified`  |
+| 925 | `ERR_ACCOUNT_INVALID_VERIFY_CODE` | `:<server> 925 <user_nickname> <accountname> :Invalid verification code` |
 
 ## The `REGCOMMANDS` `RPL_ISUPPORT` token
 

--- a/extensions/reg-core-3.3.md
+++ b/extensions/reg-core-3.3.md
@@ -37,7 +37,8 @@ A `REG CREATE` command consists of the following format:
     REG CREATE <accountname> [callback_namespace:]<callback> [cred_type] :<credential>
 
 The `credential` field specifies a credential of `cred_type`.  If there is no specified credential, then
-the `credential` field MUST be `*`.  A passphrase type `credential` MAY have spaces in it.
+the `credential` field MUST be `*`.  A passphrase type `credential` MAY have spaces in it. New credential
+types may or may not allow spaces inside `credential`.
 
 The `callback` field designates an opaque value which indicates where a verification code, if any,
 will be sent.  The callback field is implementation-specific, with namespaces being listed using the

--- a/extensions/reg-core-3.3.md
+++ b/extensions/reg-core-3.3.md
@@ -85,8 +85,8 @@ The server MAY send additional informative text upon registration success or fai
 ## The `REG VERIFY` sub-command
 
 The `REG VERIFY` command signals the intent of a client to submit a verification token for their
-account to the authentication layer.  The verification token MUST be sent to a valid callback
-resource as specified by the client in the `REG CREATE` command.
+account registration.  If a valid callback is specified by the client during the `REG CREATE`
+command, the server MUST send the token to the specified callback.
 
 A `REG VERIFY` command consists of the following format:
 
@@ -157,16 +157,18 @@ The following credential types are defined:
 
   * `passphrase`: an unencrypted passphrase which is sent to the server.
   * `certfp`: the client certificate fingerprint as determined by the server if available.
-    The client MAY provide an empty credential (`*`) in this case.  The server SHOULD calculate
-    the credential using the client certificate fingerprint, if available.  If no client certificate
-    is presented, the server SHOULD NOT advertise the availability of this credential type.
+    The client SHOULD provide an empty credential (`*`), and the server MUST ignore the
+    credential value provided by the client.  The server MUST calculate the credential using the
+    client certificate fingerprint (using the same method as for SASL certfp support).  If no
+    certificate is presented by the client, the server MUST respond to any registration attempts
+    with `ERR_REG_INVALID_CRED_TYPE` and SHOULD NOT advertise this credential type.
 
 A sample 005 reply indicating support for credential types is:
 
     :irc.example.com 005 kaniini REGCREDTYPES=passphrase,certfp :are supported by this server
 
-The first credential type SHOULD be the implementation-defined default if default credential types
-are supported.
+The first credential type in this token SHOULD be used as the default if the client does not
+specify a credential type in the `REG CREATE` command.
 
 ## Examples
 

--- a/extensions/reg-core-3.3.md
+++ b/extensions/reg-core-3.3.md
@@ -173,23 +173,23 @@ A sample 005 reply indicating support for credential types is:
     S: 923 kaniini rabbit :Account verification successful
     S: 903 kaniini :Authentication successful
 
-### Registering the account with an unsupported verification method:
+### Registering the account "rabbit" with an unsupported verification method:
 
     C: REG CREATE rabbit 1vBjNBdhjWFFbbbbVBHJEWBHJWcfbbvjkhbea passphrase :testpassphrase123
     S: 929 kaniini rabbit 1vBjNBdhjWFFbbbbVBHJEWBHJWcfbbvjkhbea :Callback token is not valid
 
-### Registering the account but providing an invalid verification token:
+### Registering the account "rabbit", but providing an invalid verification token:
 
     C: REG CREATE rabbit mailto:kaniini@example.com passphrase :testpassphrase123
-    S: 920 kaniini kaniini :Account registered
-    S: 927 kaniini kaniini kaniini@example.com :A verification code was sent
-    C: REG VERIFY kaniini 3qw4tq4te4gf34
-    S: 925 kaniini kaniini :Invalid verification code
+    S: 920 kaniini rabbit :Account registered
+    S: 927 kaniini rabbit kaniini@example.com :A verification code was sent
+    C: REG VERIFY rabbit 3qw4tq4te4gf34
+    S: 925 kaniini rabbit :Invalid verification code
 
-### Registering the account where a verification token is not required:
+### Registering the account "rabbit" where a verification token is not required:
 
     C: REG CREATE rabbit * passphrase :testpassphrase123
-    S: 920 kaniini kaniini :Account registered
+    S: 920 kaniini rabbit :Account registered
     S: 903 kaniini :Authentication successful
 
 ### Registering an account which already exists:

--- a/extensions/reg-core-3.3.md
+++ b/extensions/reg-core-3.3.md
@@ -1,0 +1,209 @@
+---
+title: "The REG command framework"
+layout: spec
+copyrights:
+  -
+    name: "William Pitcock"
+    period: "2014-2015"
+    email: "nenolod@dereferenced.org"
+---
+
+The `REG` command framework provides a unified, standardized interface for account creation and
+validation to the network's authentication layer.  This allows for a network to provide a common
+interface regardless of what authentication layer they have chosen for their network to operate,
+i.e. traditional services, a different central authority, or a decentralized model similar to [IRCX][ircx].
+
+   [ircx]: http://en.wikipedia.org/wiki/IRCX
+   
+We believe that the benefit of adding a common interface for account creation and validation,
+is helpful to the end user in discovering the capabilities offered by the authentication and
+authority layer of the network.  Further, we believe it is helpful to client authors, so that
+they may provide guided account creation and validation for their users, regardless of network
+configuration.
+
+## The `REG` command
+
+The `REG` command is the main command used by the account registration subsystem.  It provides
+several subcommands listed in the `REGCOMMANDS` ISUPPORT type.  The core sub-commands are listed
+below:
+
+## The `REG CREATE` sub-command
+
+The `REG CREATE` command signals the intent of a client to register an account in the network's
+authentication layer.  It is similar to current methods of signalling that intent.
+
+A `REG CREATE` command consists of the following format:
+
+`REG CREATE <accountname> <callback> <cred_type> :<credential>`
+
+A passphrase `credential` MAY have spaces in it.
+
+The `callback` field designates an opaque value which indicates where a verification code, if any,
+will be sent.  The callback field is implementation-specific, with namespaces being listed using the
+`REGCALLBACKS` ISUPPORT token.  An invalid callback parameter should result in the `ERR_REG_INVALID_CALLBACK`
+error.  In the event that a callback is not provided, the client SHOULD send `*` to indicate that
+they are not providing a callback resource.
+
+The `cred_type` field designates a value which indicates the type of supplied credential.  The accepted
+values of the `cred_type` field is implementation-specific, with credential types being listed using the
+`REGCREDTYPES` ISUPPORT token.  An invalid credential type parameter should result in the `ERR_REG_INVALID_CRED_TYPE`
+error.  The client MUST supply a `cred_type` value.
+
+The IRC server MAY forward the `REG CREATE` command to a central authority, or process it locally, however
+the authentication layer SHOULD NOT send any legacy messages in reply to a `REG CREATE` command.
+
+Upon success, the IRC server MUST send the `RPL_REGISTRATION_SUCCESS` numeric, which looks like:
+
+    :<server> 920 <user_nickname> <accountname> :Account created
+
+If the server requires a verification token, it MUST also reply with the `RPL_REG_VERIFICATION_REQUIRED`
+numeric, which looks like:
+
+    :<server> 927 <user_nickname> <accountname> <callback> :A verification token was sent
+
+Upon error, the IRC server MUST send an error code that is relevant.  We suggest these numerics:
+
+`ERR_ACCOUNT_ALREADY_EXISTS`:
+    `:<server> 921 <user_nickname> <accountname> :Account already exists`
+`ERR_REG_UNSPECIFIED_ERROR`:
+    `:<server> 922 <user_nickname> <accountname> :<descriptive_text>`
+`ERR_REG_INVALID_CALLBACK`:
+    `:<server> 929 <user_nickname> <accountname> <callback> :Callback token is invalid`
+`ERR_REG_INVALID_CRED_TYPE`:
+    `:<server> 928 <user_nickname> <accountname> <cred_type> :Credential type is invalid`
+`ERR_REG_UNAVAILABLE`:
+    `:<server> 440 <user_nickname> <subcommand> :Authentication services are currently unavailable`
+
+The server MAY send additional informative text upon registration success or failure using `RPL_TEXT` or `NOTICE`.
+
+## The `REG VERIFY` sub-command
+
+The `REG VERIFY` command signals the intent of a client to submit a verification token for their
+account to the authentication layer.  The verification token MUST be sent to a valid callback
+resource as specified by the client in the `REG CREATE` command.
+
+A `REG VERIFY` command consists of the following format:
+
+`REG VERIFY <accountname> <auth_code>`
+
+The IRC server MAY forward the `REG VERIFY` command to a central authority, or process it
+locally.
+
+Upon success, the IRC server MUST send the `RPL_VERIFYSUCCESS` numeric, which looks like:
+
+    :<server> 923 <user_nickname> <accountname> :Account verification successful
+
+The IRC server SHOULD also send an `RPL_AUTHENTICATION_SUCCESS` numeric.
+
+Upon error, the IRC server MUST send an error code that is relevant.  We suggest these
+numerics:
+
+`ERR_ACCOUNT_ALREADY_VERIFIED`:
+    `:<server> 924 <user_nickname> <accountname> :Account already verified`
+`ERR_ACCOUNT_INVALID_VERIFY_CODE`:
+    `:<server> 925 <user_nickname> <accountname> :Invalid verification code`
+
+## The `REGCOMMANDS` `RPL_ISUPPORT` token
+
+Implementations which provide these commands SHOULD signal their availability using the `REGCOMMANDS`
+RPL_ISUPPORT (005) token.  The `REGCOMMANDS` token takes a comma-separated list of supported
+commands.  Other extensions MAY include additional commands in the `REGCOMMANDS` token than those
+documented here.
+
+A sample 005 reply indicating support for these commands is:
+
+    :irc.example.com 005 kaniini REGCOMMANDS=CREATE,VERIFY :are supported by this server
+
+## The `REGCALLBACKS` `RPL_ISUPPORT` token
+
+Implementations which require a verification token should list the types of verification callbacks
+they support, using the `REGCALLBACKS` RPL_ISUPPORT (005) token.  The `REGCALLBACKS` token takes
+a comma-separated list of supported commands.  In general, the `REGCALLBACKS` token is limited to
+URI schemes defined in the IANA URI schemes registry, per [RFC 4395][rfc4395].
+
+  [rfc3495]: https://tools.ietf.org/html/rfc4395
+
+In the event that verification is not required by the implementation, the `REGCALLBACKS` token should
+be an empty value.
+
+A sample 005 reply indicating support for verification callbacks is:
+
+    :irc.example.com 005 kaniini REGCALLBACKS=mailto,sms :are supported by this server
+
+A sample 005 reply indicating that no verification callback methods are supported is:
+
+    :irc.example.com 005 kaniini REGCALLBACKS= :are supported by this server
+
+## The `REGCREDTYPES` `RPL_ISUPPORT` token
+
+Implementations which provide support for this framework SHOULD specify the allowed credential
+types using the `REGCREDTYPES` RPL_ISUPPORT (005) token.  The `REGCREDTYPES` token takes a
+comma-separated list of supported commands.  Other extensions MAY include additional credential
+types than those listed here.
+
+The following credential types are defined:
+
+  * `passphrase`: an unencrypted passphrase which is sent to the server.
+  * `certfp`: the client certificate fingerprint as determined by the server if available.
+    The client MAY provide an empty credential (`*`) in this case.  The server SHOULD calculate
+    the credential using the client certificate fingerprint, if available.  If no client certificate
+    is presented, the server SHOULD NOT advertise the availability of this credential type.
+
+A sample 005 reply indicating support for credential types is:
+
+    :irc.example.com 005 kaniini REGCREDTYPES=passphrase,certfp :are supported by this server
+
+## Examples
+
+### Registering the account "kaniini" with e-mail address kaniini@example.com:
+
+    C: REG CREATE kaniini mailto:kaniini@example.com passphrase :testpassphrase123
+    S: 920 kaniini kaniini :Account registered
+    S: 927 kaniini kaniini kaniini@example.com :A verification code was sent
+    C: REG VERIFY kaniini 3qw4tq4te4gf34
+    S: 923 kaniini kaniini :Account verification successful
+    S: 903 kaniini :Authentication successful
+
+### Registering the account "rabbit" with SMS number +11234567890:
+
+    C: REG CREATE rabbit sms:+11234567890 passphrase :testpassphrase123
+    S: 920 kaniini rabbit :Account registered
+    S: 927 kaniini rabbit +11234567890 :A verification code was sent
+    C: REG VERIFY rabbit 123456
+    S: 923 kaniini rabbit :Account verification successful
+    S: 903 kaniini :Authentication successful
+
+### Registering the account with an unsupported verification method:
+
+    C: REG CREATE rabbit 1vBjNBdhjWFFbbbbVBHJEWBHJWcfbbvjkhbea passphrase :testpassphrase123
+    S: 929 kaniini rabbit 1vBjNBdhjWFFbbbbVBHJEWBHJWcfbbvjkhbea :Callback token is not valid
+
+### Registering the account but providing an invalid verification token:
+
+    C: REG CREATE rabbit mailto:kaniini@example.com passphrase :testpassphrase123
+    S: 920 kaniini kaniini :Account registered
+    S: 927 kaniini kaniini kaniini@example.com :A verification code was sent
+    C: REG VERIFY kaniini 3qw4tq4te4gf34
+    S: 925 kaniini kaniini :Invalid verification code
+
+### Registering the account where a verification token is not required:
+
+    C: REG CREATE rabbit * passphrase :testpassphrase123
+    S: 920 kaniini kaniini :Account registered
+    S: 903 kaniini :Authentication successful
+
+### Registering an account which already exists:
+
+    C: REG CREATE rabbit sms:+11234567890 passphrase :testpassphrase123
+    S: 921 kaniini rabbit :Account already exists
+
+### Registering an account with an unsupported credential type:
+
+    C: REG CREATE rabbit mailto:kaniini@example.com some_invalid_cred_type :1QXvcnFWJKFGjbnkwawFJKNJKEc254
+    S: 928 kaniini rabbit some_invalid_cred_type :Credential type is invalid
+
+### Implementation-specific registration errors:
+
+    C: REG CREATE rabbit sms:+11234567890 passphrase :abc123
+    S: 922 kaniini rabbit :Invalid params: "rabbit" is a blocked account name
+

--- a/extensions/reg-core-3.3.md
+++ b/extensions/reg-core-3.3.md
@@ -77,7 +77,7 @@ Upon error, the IRC server MUST send an error code that is relevant.  We suggest
 | 921 | `ERR_ACCOUNT_ALREADY_EXISTS` | `:<server> 921 <user_nickname> <accountname> :Account already exists`                           |
 | 922 | `ERR_REG_UNSPECIFIED_ERROR`  | `:<server> 922 <user_nickname> <accountname> :<descriptive_text>`                               |
 | 929 | `ERR_REG_INVALID_CALLBACK`   | `:<server> 929 <user_nickname> <accountname> <callback> :Callback token is invalid`             |
-| 982 | `ERR_REG_INVALID_CRED_TYPE`  | `:<server> 928 <user_nickname> <accountname> <cred_type> :Credential type is invalid`           |
+| 928 | `ERR_REG_INVALID_CRED_TYPE`  | `:<server> 928 <user_nickname> <accountname> <cred_type> :Credential type is invalid`           |
 | 440 | `ERR_REG_UNAVAILABLE`        | `:<server> 440 <user_nickname> <subcommand> :Authentication services are currently unavailable` |
 
 The server MAY send additional informative text upon registration success or failure using `RPL_TEXT` or `NOTICE`.

--- a/extensions/reg-core-3.3.md
+++ b/extensions/reg-core-3.3.md
@@ -34,7 +34,7 @@ authentication layer.  It is similar to current methods of signalling that inten
 
 A `REG CREATE` command consists of the following format:
 
-`REG CREATE <accountname> [callback_namespace:]<callback> [cred_type] :<credential>`
+    REG CREATE <accountname> [callback_namespace:]<callback> [cred_type] :<credential>
 
 The `credential` field specifies a credential of `cred_type`.  If there is no specified credential, then
 the `credential` field MUST be `*`.  A passphrase type `credential` MAY have spaces in it.
@@ -89,7 +89,7 @@ resource as specified by the client in the `REG CREATE` command.
 
 A `REG VERIFY` command consists of the following format:
 
-`REG VERIFY <accountname> <auth_code>`
+    REG VERIFY <accountname> <auth_code>
 
 The IRC server MAY forward the `REG VERIFY` command to a central authority, or process it
 locally.

--- a/extensions/reg-core-3.3.md
+++ b/extensions/reg-core-3.3.md
@@ -36,7 +36,8 @@ A `REG CREATE` command consists of the following format:
 
 `REG CREATE <accountname> [callback_namespace:]<callback> [cred_type] :<credential>`
 
-A passphrase `credential` MAY have spaces in it.
+The `credential` field specifies a credential of `cred_type`.  If there is no specified credential, then
+the `credential` field MUST be `*`.  A passphrase type `credential` MAY have spaces in it.
 
 The `callback` field designates an opaque value which indicates where a verification code, if any,
 will be sent.  The callback field is implementation-specific, with namespaces being listed using the


### PR DESCRIPTION
The `ACC` command framework provides a standardized way for clients to create and manage accounts. In particular, the `ACC REGISTER` and `ACC VERIFY` subcommands should allow a network to provide a consistent interface to register new accounts, no matter what services software is used on the backend. They also let clients build nice interfaces for account registration. This framework is extensible, letting us provide more commands and interfaces in future.

This is the same spec as in #152 but cleaned up and with some bugs fixed. Asked kaniini if I could submit some fixes a while back and he said I should just throw a new PR in.

*edit:* I think the last thing missing here is the ability to know whether the net uses your nickname as the account name or not. I'll take a look at that and get something worked out there