### PR TITLE
Deprecate metadata-3.2 for the time being.

### DIFF
--- a/core/metadata-3.2.md
+++ b/core/metadata-3.2.md
@@ -1,6 +1,7 @@
 ---
 title: IRCv3.2 Metadata
 layout: spec
+deprecated: true
 copyrights:
   -
     name: "Kiyoshi Aman"
@@ -286,3 +287,5 @@ Notification for a user becoming an operator:
 * Earlier versions of this spec were ambiguous about the behavior of
   `METADATA SET`.
 * Earlier versions of this spec did not specify `metadata-notify` as OPTIONAL.
+* Due to discovered issues around rate-limiting and notifications being solved,
+  this specification has been deprecated for the time being.


### PR DESCRIPTION
We already practically don't recommend implementing it right now due to issues being solved in 3.3 (see various issues/PRs on this repo for more context here).

The IRCv3 version of metadata can include the basic metadata stuff and whatever new notify spec we have, so that we have one document we can point people towards to implement it. Right now, having this displayed as a regular, recommended spec on our site does more harm than good I feel.