### PR TITLE
Allow increased IRC message lengths

### DIFF
--- a/extensions/line-lengths-3.3.md
+++ b/extensions/line-lengths-3.3.md
@@ -1,0 +1,83 @@
+---
+title: IRCv3.3 `maxline` Extension
+layout: spec
+copyrights:
+  -
+    name: "Daniel Oaks"
+    period: "2016"
+    email: "daniel@danieloaks.net"
+---
+A method for negotiating longer protocol lines.
+
+## Introduction
+
+Currently, IRC lines are limited to 512 octets. There has been much desire to allow longer lines while sending or receiving IRC traffic, allowing longer lines with `PRIVMSG`/`NOTICE`, and solving related issues that come into play while working with the IRC protocol. These issues in particular come into play as the protocol is extended to provide greater functionality.
+
+The `maxline` capability specifies the maximum length of the tags, and of the rest of the message, that the server allows. As appropriate, lines will be truncated or split to account for clients which are still restricted to the standard (pre-maxline) limit.
+
+## Architecture
+
+### The `maxline` Capability
+
+The `maxline` capability, when advertised, MUST have a value which is a positive integer. For example:
+
+    C: CAP LS
+    S: CAP * LS :maxline=2048 
+
+Similarly to standard message handling, tags and the rest of the message have separate length values. The value of the `maxline` capability represents the maximum number of octets that the tags section, and that the rest of the message, can take up. Line length calculation is done this way in order to better integrate with methods currently used by IRC software to limit line lengths.
+
+As an example, if `maxline` is 1024 then the maximum size of a full IRC message would be 2048 bytes (1024 for the tags, 1024 for the rest of the message).
+
+Servers MUST truncate incoming messages to their `maxline` values before processing them.
+
+`maxline` MUST be at least 512 and SHOULD default to at least 2048.
+
+### Interaction with PRIVMSG and NOTICE
+
+If a client has negotiated the `maxline` capability and sends a `PRIVMSG` or a `NOTICE` message that is longer than 512 octets, the receiving server MUST split this into multiple regular (512-octet) length messages when sending it to clients that have not negotiated the `maxline` capability.
+
+Servers SHOULD split on whitespace, but may use whatever method is easiest for them to implement. Splitting does not need to occur at the exact max length of the message, and servers can instead opt to split a number of characters earlier to simplify processing.
+
+Servers MAY split other commands/numerics into multiple lines in a way similar to `PRIVMSG` and `NOTICE` above, if it is purely for display purposes.
+
+### The `truncated` Tag
+
+The `truncated` tag, when present, indicates that a message has been truncated due to the client's line length. It may be sent to any client which supports message tags, as deemed appropriate by the IRCd.
+
+As an example, this tag may be used when a long channel `TOPIC` is set, but cannot correctly be relayed to the given user due to its length.
+
+### Examples
+
+In the following examples, the default message length is presumed to be 100 octets (rather than 512) and the extended length is presumed to be 400 octets (rather than 2048). This is done purely to simplify presentation and convey the concept more easily.
+
+### Sending a long privmsg to someone else
+
+In this example, C1 and C2 have negotiated `maxlen`.
+
+    C1  -> PRIVMSG coolfriend :Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+    C2 <- :c1!test@localhost PRIVMSG coolfriend :Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+
+In this example, C1 has negotiated `maxlen` but C2 has not.
+
+    C1  -> PRIVMSG coolfriend :Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+    C2 <- :c1!test@localhost PRIVMSG coolfriend :Lorem ipsum dolor sit amet, consectetur adipiscing elit,
+    C2 <- :c1!test@localhost PRIVMSG coolfriend :sed do eiusmod tempor incididunt ut labore et dolore
+    C2 <- :c1!test@localhost PRIVMSG coolfriend :magna aliqua.
+
+### Setting a long topic and having another user run into it
+
+In this example, C1 and C2 have negotiated `maxlen`.
+
+    C1  -> TOPIC #coolchan :Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+    C1 <-  332 c1 #coolchan :Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+
+    C2  -> TOPIC #coolchan
+    C2 <-  332 c1 #coolchan :Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+
+In this example, C1 has negotiated `maxlen` but C2 has not.
+
+    C1  -> TOPIC #coolchan :Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+    C1 <-  332 c1 #coolchan :Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+
+    C2  -> TOPIC #coolchan
+    C2 <-  @truncated 332 c1 #coolchan :Lorem ipsum dolor sit amet, consectetur adipiscing elit,

--- a/extensions/line-lengths-3.3.md
+++ b/extensions/line-lengths-3.3.md
@@ -36,9 +36,9 @@ Servers MUST truncate incoming messages to their `maxline` values before process
 
 If a client has negotiated the `maxline` capability and sends a `PRIVMSG` or a `NOTICE` message that is longer than 512 bytes, the receiving server MUST split this into multiple regular (512-byte) length messages when sending it to clients that have not negotiated the `maxline` capability.
 
-Servers SHOULD split on whitespace, but may use whatever method is easiest for them to implement. Splitting does not need to occur at the exact max length of the message, and servers can instead opt to split a number of characters earlier to simplify processing.
+Servers SHOULD split on whitespace, but may use whatever method is easiest for them to implement. Splitting does not need to occur at the exact max length of the message, and servers can instead opt to split a number of characters earlier to simplify processing. Lines SHOULD NOT be split in the middle of a UTF-8 character.
 
-Servers MAY split other commands/numerics into multiple lines in a way similar to `PRIVMSG` and `NOTICE` above, if it is purely for display purposes.
+Servers MAY split other commands/numerics into multiple lines in a way similar to `PRIVMSG` and `NOTICE` above.
 
 ### The `truncated` Tag
 

--- a/extensions/line-lengths-3.3.md
+++ b/extensions/line-lengths-3.3.md
@@ -50,19 +50,22 @@ As an example, this tag may be used when a long channel `TOPIC` is set, but cann
 
 In the following examples, the default message length is presumed to be 100 octets (rather than 512) and the extended length is presumed to be 400 octets (rather than 2048). This is done purely to simplify presentation and convey the concept more easily.
 
+* ` ->` conveys lines being sent from this client to the IRC server.
+* `<- ` conveys lines being sent from the server to this client.
+
 ### Sending a long privmsg to someone else
 
 In this example, C1 and C2 have negotiated `maxlen`.
 
     C1  -> PRIVMSG coolfriend :Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
-    C2 <- :c1!test@localhost PRIVMSG coolfriend :Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+    C2 <-  :c1!test@localhost PRIVMSG coolfriend :Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
 
 In this example, C1 has negotiated `maxlen` but C2 has not.
 
     C1  -> PRIVMSG coolfriend :Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
-    C2 <- :c1!test@localhost PRIVMSG coolfriend :Lorem ipsum dolor sit amet, consectetur adipiscing elit,
-    C2 <- :c1!test@localhost PRIVMSG coolfriend :sed do eiusmod tempor incididunt ut labore et dolore
-    C2 <- :c1!test@localhost PRIVMSG coolfriend :magna aliqua.
+    C2 <-  :c1!test@localhost PRIVMSG coolfriend :Lorem ipsum dolor sit amet, consectetur adipiscing elit,
+    C2 <-  :c1!test@localhost PRIVMSG coolfriend :sed do eiusmod tempor incididunt ut labore et dolore
+    C2 <-  :c1!test@localhost PRIVMSG coolfriend :magna aliqua.
 
 ### Setting a long topic and having another user run into it
 

--- a/extensions/line-lengths-3.3.md
+++ b/extensions/line-lengths-3.3.md
@@ -11,7 +11,7 @@ A method for negotiating longer protocol lines.
 
 ## Introduction
 
-Currently, IRC lines are limited to 512 octets. There has been much desire to allow longer lines while sending or receiving IRC traffic, allowing longer lines with `PRIVMSG`/`NOTICE`, and solving related issues that come into play while working with the IRC protocol. These issues in particular come into play as the protocol is extended to provide greater functionality.
+Currently, IRC lines are limited to 512 bytes. There has been much desire to allow longer lines while sending or receiving IRC traffic, allowing longer lines with `PRIVMSG`/`NOTICE`, and solving related issues that come into play while working with the IRC protocol. These issues in particular come into play as the protocol is extended to provide greater functionality.
 
 The `maxline` capability specifies the maximum length of the tags, and of the rest of the message, that the server allows. As appropriate, lines will be truncated or split to account for clients which are still restricted to the standard (pre-maxline) limit.
 
@@ -24,7 +24,7 @@ The `maxline` capability, when advertised, MUST have a value which is a positive
     C: CAP LS
     S: CAP * LS :maxline=2048 
 
-Similarly to standard message handling, tags and the rest of the message have separate length values. The value of the `maxline` capability represents the maximum number of octets that the tags section, and that the rest of the message, can take up. Line length calculation is done this way in order to better integrate with methods currently used by IRC software to limit line lengths.
+Similarly to standard message handling, tags and the rest of the message have separate length values. The value of the `maxline` capability represents the maximum number of bytes that the tags section, and that the rest of the message, can take up. Line length calculation is done this way in order to better integrate with methods currently used by IRC software to limit line lengths.
 
 As an example, if `maxline` is 1024 then the maximum size of a full IRC message would be 2048 bytes (1024 for the tags, 1024 for the rest of the message).
 
@@ -34,7 +34,7 @@ Servers MUST truncate incoming messages to their `maxline` values before process
 
 ### Interaction with PRIVMSG and NOTICE
 
-If a client has negotiated the `maxline` capability and sends a `PRIVMSG` or a `NOTICE` message that is longer than 512 octets, the receiving server MUST split this into multiple regular (512-octet) length messages when sending it to clients that have not negotiated the `maxline` capability.
+If a client has negotiated the `maxline` capability and sends a `PRIVMSG` or a `NOTICE` message that is longer than 512 bytes, the receiving server MUST split this into multiple regular (512-byte) length messages when sending it to clients that have not negotiated the `maxline` capability.
 
 Servers SHOULD split on whitespace, but may use whatever method is easiest for them to implement. Splitting does not need to occur at the exact max length of the message, and servers can instead opt to split a number of characters earlier to simplify processing.
 
@@ -48,7 +48,7 @@ As an example, this tag may be used when a long channel `TOPIC` is set, but cann
 
 ### Examples
 
-In the following examples, the default message length is presumed to be 100 octets (rather than 512) and the extended length is presumed to be 400 octets (rather than 2048). This is done purely to simplify presentation and convey the concept more easily.
+In the following examples, the default message length is presumed to be 100 bytes (rather than 512) and the extended length is presumed to be 400 bytes (rather than 2048). This is done purely to simplify presentation and convey the concept more easily.
 
 * ` ->` conveys lines being sent from this client to the IRC server.
 * `<- ` conveys lines being sent from the server to this client.

--- a/extensions/line-lengths.md
+++ b/extensions/line-lengths.md
@@ -4,7 +4,7 @@ layout: spec
 copyrights:
   -
     name: "Daniel Oaks"
-    period: "2016"
+    period: "2016-2017"
     email: "daniel@danieloaks.net"
 ---
 A method for negotiating longer protocol lines.

--- a/extensions/line-lengths.md
+++ b/extensions/line-lengths.md
@@ -19,18 +19,20 @@ The `maxline` capability specifies the maximum length of the tags, and of the re
 
 ### The `maxline` Capability
 
-The `maxline` capability, when advertised, MUST have a value which is a positive integer. For example:
+The `maxline` capability, when advertised, MUST have a value which is two positive integers, separated by a comma character.
+
+For example:
 
     C: CAP LS
-    S: CAP * LS :maxline=2048 
+    S: CAP * LS :maxline=2048,2048
 
-Similarly to standard message handling, tags and the rest of the message have separate length values. The value of the `maxline` capability represents the maximum number of bytes that the tags section, and that the rest of the message, can take up. Line length calculation is done this way in order to better integrate with methods currently used by IRC software to limit line lengths.
+Similarly to standard message handling, tags and the rest of the message have separate length values. The value of the `maxline` capability represents the maximum number of bytes that the tags section, and that the rest of the message can take up, respectively. Line length calculation is done this way in order to better integrate with methods currently used by IRC software to limit line lengths.
 
-As an example, if `maxline` is 1024 then the maximum size of a full IRC message would be 2048 bytes (1024 for the tags, 1024 for the rest of the message).
+As an example, if `maxline` is `1024,1024` then the maximum size of a full IRC message would be 2048 bytes (1024 for the tags, 1024 for the rest of the message).
 
 Servers MUST truncate incoming messages to their `maxline` values before processing them.
 
-`maxline` MUST be at least 512 and SHOULD default to at least 2048.
+Both `maxline` values MUST be at least `512` and SHOULD default to at least `2048`.
 
 ### Interaction with PRIVMSG and NOTICE
 
@@ -48,7 +50,7 @@ As an example, this tag may be used when a long channel `TOPIC` is set, but cann
 
 ### Examples
 
-In the following examples, the default message length is presumed to be 100 bytes (rather than 512) and the extended length is presumed to be 400 bytes (rather than 2048). This is done purely to simplify presentation and convey the concept more easily.
+In the following examples, the default message length is presumed to be `100,100` (rather than `512,512`) and the extended length is presumed to be `400,400`. This is done purely to simplify presentation and convey the concept more easily.
 
 * ` ->` conveys lines being sent from this client to the IRC server.
 * `<- ` conveys lines being sent from the server to this client.

--- a/extensions/line-lengths.md
+++ b/extensions/line-lengths.md
@@ -23,7 +23,7 @@ The `maxline` capability, when advertised, MUST have a value which is two positi
 
 For example:
 
-    C: CAP LS
+    C: CAP LS 302
     S: CAP * LS :maxline=2048,2048
 
 Similarly to standard message handling, tags and the rest of the message have separate length values. The value of the `maxline` capability represents the maximum number of bytes that the tags section, and that the rest of the message can take up, respectively. Line length calculation is done this way in order to better integrate with methods currently used by IRC software to limit line lengths.


### PR DESCRIPTION
One of the big issues we want to solve is that IRC lines are capped at 512 octets. This... works, but it would be very nice to allow for longer messages and things like longer topics without needing to implement dodgy hacks for every single command we want to allow longer lengths on.

This should ensure that things stay 100% backwards compatible and work correctly for clients that do not support longer lines, while allowing more up-to-date clients to negotiate the longer message length allowed by the server.

This is gonna be something that is a bit controversial, but it would be extremely useful to allow and something we've been looking at for a while.