### PR TITLE
Add empty tag-only message support and an increased size limit for tags

### DIFF
--- a/core/message-tags-3.3.md
+++ b/core/message-tags-3.3.md
@@ -96,7 +96,7 @@ no message body is provided. These events MUST NOT be delivered to clients who h
 negotiated the message tags capability. If neither client-only tags nor a message body
 are provided, servers MAY respond with a standard `ERR_NOTEXTTOSEND` error.
 
-Clients that receive empty events MUST not display empty messages as-is in the message history
+Clients that receive empty events MUST NOT display empty messages as-is in the message history
 unless they are using the attached tags according to their own specifications.
 
 ### Size limit

--- a/core/message-tags-3.3.md
+++ b/core/message-tags-3.3.md
@@ -151,17 +151,13 @@ This section is non-normative. The tags used in these examples may or may not ha
 
 A message sent by a client with the `example-tag` tag:
 
-```
-C: @example-tag=example-value PRIVMSG #channel :Message
-```
+    C: @example-tag=example-value PRIVMSG #channel :Message
 
 ---
 
 A message sent by a client with the `+example-client-tag` client-only tag:
 
-```
-C: @+example-client-tag=example-value PRIVMSG #channel :Message
-```
+    C: @+example-client-tag=example-value PRIVMSG #channel :Message
 
 ---
 
@@ -170,18 +166,14 @@ Server responses for:
 * The user `nick` sharing a URL in a channel (without tags)
 * The bot `url_bot` responding with the URL title in the message body and the favicon URL included as the value of the `+icon` client-only tag:
 
-```
-S: :nick!user@example.com PRIVMSG #channel :https://example.com/a-news-story
-S: @+icon=https://example.com/favicon.png :url_bot!bot@example.com PRIVMSG #channel :Example.com: A News Story
-```
+    S: :nick!user@example.com PRIVMSG #channel :https://example.com/a-news-story
+    S: @+icon=https://example.com/favicon.png :url_bot!bot@example.com PRIVMSG #channel :Example.com: A News Story
 
 ---
 
 An example of a vendor-prefixed client-only tag:
 
-```
-C: @+example.com/foo=bar :irc.example.com NOTICE #channel :A vendor-prefixed client-only tagged message
-```
+    C: @+example.com/foo=bar :irc.example.com NOTICE #channel :A vendor-prefixed client-only tagged message
 
 ---
 
@@ -192,41 +184,31 @@ A client-only tag `+example` with a value containing valid raw and escaped chara
 
 In this example, plus signs, colons, equals signs and commas are transmitted raw in tag values; while semicolons, spaces and backslashes are escaped. [Escaping rules](./message-tags-3.2.html#escaping-values) are unchanged from IRCv3.2 tags.
 
-```
-C: @+example=raw+:=,escaped\:\s\\ :irc.example.com NOTICE #channel :Message
-```
+    C: @+example=raw+:=,escaped\:\s\\ :irc.example.com NOTICE #channel :Message
 
 ---
 
 A TAGMSG event sent by a client with the `+example-client-tag` client-only tag:
 
-```
-C: @+example-client-tag=example-value TAGMSG #channel
-```
+    C: @+example-client-tag=example-value TAGMSG #channel
 
 ---
 
 A TAGMSG event sent by a client to channel ops with a client-only tag and `STATUSMSG` prefix:
 
-```
-C: @+example-client-tag=example-value TAGMSG @#channel
-```
+    C: @+example-client-tag=example-value TAGMSG @#channel
 
 ---
 
 A TAGMSG event sent to a channel with [`labeled-response`](../extensions/labeled-response.html) and client-only tags. The event is returned by the server with a [`msgid`](../extensions/message-ids.html) tag via labeled `echo-message` to the originating client and as normal to other clients in the channel.
 
-```
-C1-S: @label=123;+example-client-tag=example-value TAGMSG #channel
-S-C1: @label=123;msgid=abc;+example-client-tag=example-value :nick!user@example.com TAGMSG #channel
-S-C2: @msgid=abc;+example-client-tag=example-value :nick!user@example.com TAGMSG #channel
-```
+    C1-S: @label=123;+example-client-tag=example-value TAGMSG #channel
+    S-C1: @label=123;msgid=abc;+example-client-tag=example-value :nick!user@example.com TAGMSG #channel
+    S-C2: @msgid=abc;+example-client-tag=example-value :nick!user@example.com TAGMSG #channel
 
 ---
 
 A TAGMSG event sent by a client without any tags and rejected by the server with an `ERR_NEEDMOREPARAMS` (`461`) error numeric.
 
-```
-C: TAGMSG #channel
-S: :server.example.com 461 nick TAGMSG :Not enough parameters
-```
+    C: TAGMSG #channel
+    S: :server.example.com 461 nick TAGMSG :Not enough parameters

--- a/core/message-tags-3.3.md
+++ b/core/message-tags-3.3.md
@@ -100,11 +100,11 @@ prefixes, etc.
 Servers MAY apply moderation to this event using existing or newly specified modes or
 configuration.
 
-These events MUST NOT be delivered to clients that haven't negotiated the message tags
-capability and MAY be rejected if no tags are included.
+This event MUST NOT be delivered to clients that haven't negotiated the message tags
+capability.
 
-If this event is sent without any tags, servers SHOULD reject it with a standard
-`ERR_NEEDMOREPARAMS` error numeric.
+If this event is sent without any tags, servers SHOULD reject it. In this case, they
+MUST use the standard `ERR_NEEDMOREPARAMS` error numeric.
 
 See [`PRIVMSG` in RFC1459](https://tools.ietf.org/html/rfc1459#section-4.4.1) for more details on replies and examples.
 

--- a/core/message-tags-3.3.md
+++ b/core/message-tags-3.3.md
@@ -99,7 +99,7 @@ are provided, servers MAY respond with a standard `ERR_NOTEXTTOSEND` error.
 ### Size limit
 
 The size limit for message tags is increased to 512 to 4096 bytes, including the leading
-`@` and trailing space characters, leaving 3094 bytes for tags themselves. The size limit
+`@` and trailing space characters, leaving 4094 bytes for tags themselves. The size limit
 for the rest of the message is unchanged.
 
 ## Security considerations

--- a/core/message-tags-3.3.md
+++ b/core/message-tags-3.3.md
@@ -105,7 +105,7 @@ Servers MUST NOT deliver `TAGMSG` to clients that haven't negotiated the message
 
 Servers SHOULD reject any `TAGMSG` command sent without tags. In this case, they MUST use the `ERR_NEEDMOREPARAMS` (`461`) error numeric.
 
-See [`PRIVMSG` in RFC1459](https://tools.ietf.org/html/rfc1459#section-4.4.1) for more details on replies and examples.
+See [`PRIVMSG` in RFC2812](https://tools.ietf.org/html/rfc2812#section-3.3.1) for more details on replies and examples.
 
 Clients that receive a `TAGMSG` command MUST NOT display them in the message history by default. Display guidelines are defined in the specifications of tags attached to the command.
 

--- a/core/message-tags-3.3.md
+++ b/core/message-tags-3.3.md
@@ -92,13 +92,18 @@ but the final occurrence.
 ### Empty tagged messages
 
 Servers MUST accept `PRIVMSG` and `NOTICE` events sent with client-only tags even if
-the message content parameter is omitted. These events MUST NOT be delivered to clients
+the message content parameter is empty. These events MUST NOT be delivered to clients
 that haven't negotiated the message tags capability. If neither client-only tags nor a
-message parameter are included, servers MAY respond with a standard `ERR_NEEDMOREPARAMS`
+message body are included, servers MAY respond with a standard `ERR_NOTEXTTOSEND`
 error.
 
-Clients that receive events without a message text MUST NOT display empty messages as-is
-in the message history unless one of the attached tags is specified to require such a display.
+Clients that receive events without any message text MUST NOT display content-less
+messages as-is in the message history unless one of the attached tags is specified
+to require such a display.
+
+The pseudo-BNF for empty tagged messages is as follows:
+
+    <message> ::= '@' <tags> <SPACE> [':' <prefix> <SPACE> ] ('PRIVMSG' | 'NOTICE') <SPACE> <target> <SPACE> ':' <crlf>
 
 ### Size limit
 
@@ -183,8 +188,8 @@ In this example, plus signs, colons, equals signs and commas are transmitted raw
 
 ---
 
-An empty message sent by a client with the `+example-client-tag` client-only tag, where the last parameter is omitted:
+An empty message sent by a client with the `+example-client-tag` client-only tag, where the last parameter is empty:
 
 ```
-@+example-client-tag=example-value PRIVMSG #channel
+@+example-client-tag=example-value PRIVMSG #channel :
 ```

--- a/core/message-tags-3.3.md
+++ b/core/message-tags-3.3.md
@@ -161,11 +161,12 @@ A message sent by a client with the `+example-client-tag` client-only tag:
 
 ---
 
-Server responses for:
+In this example
 
-* The user `nick` sharing a URL in a channel (without tags)
-* The bot `url_bot` responding with the URL title in the message body and the favicon URL included as the value of the `+icon` client-only tag:
+* The user `nick!user@example.com` shares a URL in a channel (without tags)
+* The bot `url_bot!bot@example.com` responds with the URL title in the message body and the favicon URL included as the value of the `+icon` client-only tag:
 
+The server sends these events:
 
     S: :nick!user@example.com PRIVMSG #channel :https://example.com/a-news-story
     S: @+icon=https://example.com/favicon.png :url_bot!bot@example.com PRIVMSG #channel :Example.com: A News Story

--- a/core/message-tags-3.3.md
+++ b/core/message-tags-3.3.md
@@ -96,6 +96,9 @@ no message body is provided. These events MUST NOT be delivered to clients who h
 negotiated the message tags capability. If neither client-only tags nor a message body
 are provided, servers MAY respond with a standard `ERR_NOTEXTTOSEND` error.
 
+Clients that receive empty events MUST not display empty messages as-is in the message history
+unless they are using the attached tags according to their own specifications.
+
 ### Size limit
 
 The size limit for message tags is increased to 512 to 4096 bytes, including the leading

--- a/core/message-tags-3.3.md
+++ b/core/message-tags-3.3.md
@@ -98,8 +98,7 @@ message parameter are included, servers MAY respond with a standard `ERR_NEEDMOR
 error.
 
 Clients that receive events without a message text MUST NOT display empty messages as-is
-in the message history unless they are using the attached tags according to their own
-specifications.
+in the message history unless one of the attached tags is specified to require such a display.
 
 ### Size limit
 

--- a/core/message-tags-3.3.md
+++ b/core/message-tags-3.3.md
@@ -198,7 +198,7 @@ C: @+example=raw+:=,escaped\:\s\\ :irc.example.com NOTICE #channel :Message
 
 ---
 
-A tag-only message sent by a client with the `+example-client-tag` client-only tag:
+A TAGMSG event sent by a client with the `+example-client-tag` client-only tag:
 
 ```
 C: @+example-client-tag=example-value TAGMSG #channel
@@ -206,7 +206,7 @@ C: @+example-client-tag=example-value TAGMSG #channel
 
 ---
 
-A tag-only message sent by a client to channel ops with a client-only tag and `STATUSMSG` prefix:
+A TAGMSG event sent by a client to channel ops with a client-only tag and `STATUSMSG` prefix:
 
 ```
 C: @+example-client-tag=example-value TAGMSG @#channel
@@ -214,9 +214,10 @@ C: @+example-client-tag=example-value TAGMSG @#channel
 
 ---
 
-A tag-only message sent with a client-only tag and returned by the server as an `echo-message` with `msgid` tag:
+A TAGMSG event sent to a channel with [`labeled-response`](../extensions/labeled-response.html) and client-only tags. The event is returned by the server with a [`msgid`](../extensions/message-ids.html) tag via labeled `echo-message` to the originating client and as normal to other clients in the channel.
 
 ```
-C: @+example-client-tag=example-value TAGMSG @#channel
-S: @msgid=123abc;+example-client-tag=example-value :nick!user@example.com TAGMSG @#channel
+C1-S: @label=123;+example-client-tag=example-value TAGMSG #channel
+S-C1: @label=123;msgid=abc;+example-client-tag=example-value :nick!user@example.com TAGMSG #channel
+S-C2: @msgid=abc;+example-client-tag=example-value :nick!user@example.com TAGMSG #channel
 ```

--- a/core/message-tags-3.3.md
+++ b/core/message-tags-3.3.md
@@ -92,7 +92,10 @@ but the final occurrence.
 
 A new event `TAGMSG` is defined for sending messages with tags but no text content.
 This event MUST be delivered to targets in the same way as `PRIVMSG` and `NOTICE`
-events, taking into account channel membership and modes.
+events. This means for example, honouring channel membership, modes,
+[`echo-message`](../extensions/echo-message-3.2.html),
+[`STATUSMSG`](https://tools.ietf.org/html/draft-hardy-irc-isupport-00#section-4.18)
+prefixes, etc.
 
 Servers MAY apply moderation to this event using existing or newly specified modes or
 configuration.
@@ -149,7 +152,7 @@ This section is non-normative. The tags used in these examples may or may not ha
 A message sent by a client with the `example-tag` tag:
 
 ```
-@example-tag=example-value PRIVMSG #channel :Message
+C: @example-tag=example-value PRIVMSG #channel :Message
 ```
 
 ---
@@ -157,7 +160,7 @@ A message sent by a client with the `example-tag` tag:
 A message sent by a client with the `+example-client-tag` client-only tag:
 
 ```
-@+example-client-tag=example-value PRIVMSG #channel :Message
+C: @+example-client-tag=example-value PRIVMSG #channel :Message
 ```
 
 ---
@@ -168,8 +171,8 @@ Server responses for:
 * The bot `url_bot` responding with the URL title in the message body and the favicon URL included as the value of the `+icon` client-only tag:
 
 ```
-:nick!user@example.com PRIVMSG #channel :https://example.com/a-news-story
-@+icon=https://example.com/favicon.png :url_bot!bot@example.com PRIVMSG #channel :Example.com: A News Story
+S: :nick!user@example.com PRIVMSG #channel :https://example.com/a-news-story
+S: @+icon=https://example.com/favicon.png :url_bot!bot@example.com PRIVMSG #channel :Example.com: A News Story
 ```
 
 ---
@@ -177,7 +180,7 @@ Server responses for:
 An example of a vendor-prefixed client-only tag:
 
 ```
-@+example.com/foo=bar :irc.example.com NOTICE #channel :A vendor-prefixed client-only tagged message
+C: @+example.com/foo=bar :irc.example.com NOTICE #channel :A vendor-prefixed client-only tagged message
 ```
 
 ---
@@ -190,13 +193,30 @@ A client-only tag `+example` with a value containing valid raw and escaped chara
 In this example, plus signs, colons, equals signs and commas are transmitted raw in tag values; while semicolons, spaces and backslashes are escaped. [Escaping rules](./message-tags-3.2.html#escaping-values) are unchanged from IRCv3.2 tags.
 
 ```
-@+example=raw+:=,escaped\:\s\\ :irc.example.com NOTICE #channel :Message
+C: @+example=raw+:=,escaped\:\s\\ :irc.example.com NOTICE #channel :Message
 ```
 
 ---
 
-An tag-only message sent by a client with the `+example-client-tag` client-only tag:
+A tag-only message sent by a client with the `+example-client-tag` client-only tag:
 
 ```
-@+example-client-tag=example-value TAGMSG #channel
+C: @+example-client-tag=example-value TAGMSG #channel
+```
+
+---
+
+A tag-only message sent by a client to channel ops with a client-only tag and `STATUSMSG` prefix:
+
+```
+C: @+example-client-tag=example-value TAGMSG @#channel
+```
+
+---
+
+A tag-only message sent with a client-only tag and returned by the server as an `echo-message` with `msgid` tag:
+
+```
+C: @+example-client-tag=example-value TAGMSG @#channel
+S: @msgid=123abc;+example-client-tag=example-value :nick!user@example.com TAGMSG @#channel
 ```

--- a/core/message-tags-3.3.md
+++ b/core/message-tags-3.3.md
@@ -19,7 +19,7 @@ This is a work-in-progress specification.
 
 Software implementing this work-in-progress specification MUST NOT use the
 unprefixed `message-tags` capability name. Instead, implementations SHOULD use
-the `draft/message-tags` capability name to be interoperable with other software
+the `draft/message-tags-0.2` capability name to be interoperable with other software
 implementing a compatible work-in-progress version.
 
 The final version of the specification will use an unprefixed capability name.
@@ -54,7 +54,7 @@ result, an increased limit is implied by negotiating the new capability.
 
 ### Capabilities
 
-This specification adds the `draft/message-tags` capability. Clients requesting
+This specification adds the `draft/message-tags-0.2` capability. Clients requesting
 this capability indicate that they are capable of parsing all well-formed tags,
 even if they don't handle them specifically.
 

--- a/core/message-tags-3.3.md
+++ b/core/message-tags-3.3.md
@@ -107,7 +107,7 @@ Servers SHOULD reject any `TAGMSG` command sent without tags. In this case, they
 
 See [`PRIVMSG` in RFC2812](https://tools.ietf.org/html/rfc2812#section-3.3.1) for more details on replies and examples.
 
-Clients that receive a `TAGMSG` command MUST NOT display them in the message history by default. Display guidelines are defined in the specifications of tags attached to the command.
+Clients that receive a `TAGMSG` command MUST NOT display them in the message history by default. Display guidelines are defined in the specifications of tags attached to the message.
 
 ### Size limit
 
@@ -165,7 +165,7 @@ In this example
 * The user `nick!user@example.com` shares a URL in a channel (without tags)
 * The bot `url_bot!bot@example.com` responds with the URL title in the message body and the favicon URL included as the value of the `+icon` client-only tag:
 
-The server sends these commands:
+The server sends these messages:
 
     S: :nick!user@example.com PRIVMSG #channel :https://example.com/a-news-story
     S: @+icon=https://example.com/favicon.png :url_bot!bot@example.com PRIVMSG #channel :Example.com: A News Story

--- a/core/message-tags-3.3.md
+++ b/core/message-tags-3.3.md
@@ -115,6 +115,11 @@ The size limit for message tags is increased from 512 to 4096 bytes, including t
 `@` and trailing space characters, leaving 4094 bytes for tags themselves. The size limit
 for the rest of the message is unchanged.
 
+Servers MUST reply with the `ERR_INPUTTOOLONG` (`417`) error numeric if a client sends a message with more than the allowed limit. Servers MUST NOT truncate tags to allow lines that exceed this limit.
+
+    417    ERR_INPUTTOOLONG
+          ":Input line was too long"
+
 ## Security considerations
 
 Client-only tags should be treated as untrusted data. They can contain any value
@@ -208,3 +213,10 @@ A `TAGMSG` sent by a client without any tags and rejected by the server with an 
 
     C: TAGMSG #channel
     S: :server.example.com 461 nick TAGMSG :Not enough parameters
+
+---
+
+A `TAGMSG` sent by a client with tags that exceed the size limit and rejected by the server with an `ERR_INPUTTOOLONG` (`417`) error numeric. `[...]` is used to represent tags omitted for readability.
+
+    C: @+tag1;+tag2;+tag[...];+tag5000 TAGMSG #channel
+    S: :server.example.com 417 nick :Input line was too long

--- a/core/message-tags-3.3.md
+++ b/core/message-tags-3.3.md
@@ -27,7 +27,8 @@ The final version of the specification will use an unprefixed capability name.
 ## Introduction
 
 This specification adds a new capability for general message tags support and
-a prefix for expressing client-only tags.
+a prefix for expressing client-only tags. It also defines behaviour for empty
+tag-only messages, and increases the byte limit for tags.
 
 ## Motivation
 
@@ -40,6 +41,14 @@ response.
 
 The client-only tag prefix allows servers to safely relay untrusted client tags,
 keeping them distinct from server-initiated tags that carry verified meaning.
+
+To allow for tagged data to be sent to channels and users without any accompanying
+message text, a format for tag-only messages is needed. Since servers do not normally
+accept messages with a missing body, new behaviour is defined for tagged messages.
+
+With the scope of tags expanded for use as general purpose message metadata, the
+number and size of tags attached to a message will potentially increase. As a
+result, an increased limit is defined when advertising the new capability.
 
 ## Architecture
 
@@ -79,6 +88,19 @@ The updated pseudo-BNF for keys is as follows:
 Individual tag keys MUST only be used a maximum of once per message. Clients
 receiving messages with more than one occurrence of a tag key SHOULD discard all
 but the final occurrence.
+
+### Empty tagged messages
+
+Servers MUST accept `PRIVMSG` and `NOTICE` events sent with client-only tags even if
+no message body is provided. These events MUST NOT be delivered to clients who haven't
+negotiated the message tags capability. If neither client-only tags nor a message body
+are provided, servers MAY respond with a standard `ERR_NOTEXTTOSEND` error.
+
+### Size limit
+
+The size limit for message tags is increased to 512 to 4096 bytes, including the leading
+`@` and trailing space characters, leaving 3094 bytes for tags themselves. The size limit
+for the rest of the message is unchanged.
 
 ## Security considerations
 

--- a/core/message-tags-3.3.md
+++ b/core/message-tags-3.3.md
@@ -104,7 +104,7 @@ This event MUST NOT be delivered to clients that haven't negotiated the message 
 capability.
 
 If this event is sent without any tags, servers SHOULD reject it. In this case, they
-MUST use the standard `ERR_NEEDMOREPARAMS` error numeric.
+MUST use the standard `ERR_NEEDMOREPARAMS` (`461`) error numeric.
 
 See [`PRIVMSG` in RFC1459](https://tools.ietf.org/html/rfc1459#section-4.4.1) for more details on replies and examples.
 
@@ -220,4 +220,13 @@ A TAGMSG event sent to a channel with [`labeled-response`](../extensions/labeled
 C1-S: @label=123;+example-client-tag=example-value TAGMSG #channel
 S-C1: @label=123;msgid=abc;+example-client-tag=example-value :nick!user@example.com TAGMSG #channel
 S-C2: @msgid=abc;+example-client-tag=example-value :nick!user@example.com TAGMSG #channel
+```
+
+---
+
+A TAGMSG event sent by a client without any tags and rejected by the server with an `ERR_NEEDMOREPARAMS` (`461`) error numeric.
+
+```
+C: TAGMSG #channel
+S: :server.example.com 461 nick TAGMSG :Not enough parameters
 ```

--- a/core/message-tags-3.3.md
+++ b/core/message-tags-3.3.md
@@ -48,7 +48,7 @@ accept messages without any content, new behaviour is defined for tagged message
 
 With the scope of tags expanded for use as general purpose message metadata, the
 number and size of tags attached to a message will potentially increase. As a
-result, an increased limit is defined when advertising the new capability.
+result, an increased limit is implied by negotiating the new capability.
 
 ## Architecture
 
@@ -103,7 +103,7 @@ specifications.
 
 ### Size limit
 
-The size limit for message tags is increased to 512 to 4096 bytes, including the leading
+The size limit for message tags is increased from 512 to 4096 bytes, including the leading
 `@` and trailing space characters, leaving 4094 bytes for tags themselves. The size limit
 for the rest of the message is unchanged.
 

--- a/core/message-tags-3.3.md
+++ b/core/message-tags-3.3.md
@@ -44,7 +44,7 @@ keeping them distinct from server-initiated tags that carry verified meaning.
 
 To allow for tagged data to be sent to channels and users without any accompanying
 message text, a format for tag-only messages is needed. Since servers do not normally
-accept messages with a missing body, new behaviour is defined for tagged messages.
+accept messages without any content, new behaviour is defined for tagged messages.
 
 With the scope of tags expanded for use as general purpose message metadata, the
 number and size of tags attached to a message will potentially increase. As a
@@ -92,12 +92,14 @@ but the final occurrence.
 ### Empty tagged messages
 
 Servers MUST accept `PRIVMSG` and `NOTICE` events sent with client-only tags even if
-no message body is provided. These events MUST NOT be delivered to clients who haven't
-negotiated the message tags capability. If neither client-only tags nor a message body
-are provided, servers MAY respond with a standard `ERR_NOTEXTTOSEND` error.
+the message content parameter is omitted. These events MUST NOT be delivered to clients
+that haven't negotiated the message tags capability. If neither client-only tags nor a
+message parameter are included, servers MAY respond with a standard `ERR_NEEDMOREPARAMS`
+error.
 
-Clients that receive empty events MUST NOT display empty messages as-is in the message history
-unless they are using the attached tags according to their own specifications.
+Clients that receive events without a message text MUST NOT display empty messages as-is
+in the message history unless they are using the attached tags according to their own
+specifications.
 
 ### Size limit
 
@@ -182,15 +184,7 @@ In this example, plus signs, colons, equals signs and commas are transmitted raw
 
 ---
 
-An empty message sent by a client with the `+example-client-tag` client-only tag:
-
-```
-@+example-client-tag=example-value PRIVMSG #channel :
-```
-
----
-
-An alternate form of an empty message sent by a client with the `+example-client-tag` client-only tag, where the last parameter is omitted
+An empty message sent by a client with the `+example-client-tag` client-only tag, where the last parameter is omitted:
 
 ```
 @+example-client-tag=example-value PRIVMSG #channel

--- a/core/message-tags-3.3.md
+++ b/core/message-tags-3.3.md
@@ -103,7 +103,7 @@ capability and MAY be rejected if no tags are included.
 If this event is sent without any tags, servers SHOULD reject it with a standard
 `ERR_NEEDMOREPARAMS` error numeric.
 
-See `PRIVMSG` for more details on replies and examples.
+See [`PRIVMSG` in RFC1459](https://tools.ietf.org/html/rfc1459#section-4.4.1) for more details on replies and examples.
 
 Clients that receive the `TAGMSG` event MUST NOT display them in the message history
 except according to the specifications of the attached tags.

--- a/core/message-tags-3.3.md
+++ b/core/message-tags-3.3.md
@@ -166,6 +166,7 @@ Server responses for:
 * The user `nick` sharing a URL in a channel (without tags)
 * The bot `url_bot` responding with the URL title in the message body and the favicon URL included as the value of the `+icon` client-only tag:
 
+
     S: :nick!user@example.com PRIVMSG #channel :https://example.com/a-news-story
     S: @+icon=https://example.com/favicon.png :url_bot!bot@example.com PRIVMSG #channel :Example.com: A News Story
 

--- a/core/message-tags-3.3.md
+++ b/core/message-tags-3.3.md
@@ -179,3 +179,19 @@ In this example, plus signs, colons, equals signs and commas are transmitted raw
 ```
 @+example=raw+:=,escaped\:\s\\ :irc.example.com NOTICE #channel :Message
 ```
+
+---
+
+An empty message sent by a client with the `+example-client-tag` client-only tag:
+
+```
+@+example-client-tag=example-value PRIVMSG #channel :
+```
+
+---
+
+An alternate form of an empty message sent by a client with the `+example-client-tag` client-only tag, where the last parameter is omitted
+
+```
+@+example-client-tag=example-value PRIVMSG #channel
+```

--- a/core/message-tags-3.3.md
+++ b/core/message-tags-3.3.md
@@ -70,7 +70,7 @@ with a plus sign (`+`) and otherwise conforms to the format specified in
 Client-only tags MUST be relayed on `PRIVMSG` and `NOTICE` messages, and MAY be relayed on other messages.
 
 Any server-initiated tags attached to messages MUST be included before client-only
-tags to prevent them from being pushed outside of the 512 byte tag limit.
+tags to prevent them from being pushed outside of the byte limit.
 
 The expected client behaviour of individual client-only tags SHOULD be defined
 in separate specifications, in the same way as server-initiated tags.
@@ -111,11 +111,13 @@ Clients that receive a `TAGMSG` command MUST NOT display them in the message his
 
 ### Size limit
 
-The size limit for message tags is increased from 512 to 4096 bytes, including the leading
-`@` and trailing space characters, leaving 4094 bytes for tags themselves. The size limit
+The size limit for message tags is increased from 512 to 4608 bytes, including the leading
+`@` and trailing space characters, leaving 4606 bytes for tags themselves. The size limit
 for the rest of the message is unchanged.
 
-Servers MUST reply with the `ERR_INPUTTOOLONG` (`417`) error numeric if a client sends a message with more than the allowed limit. Servers MUST NOT truncate tags to allow lines that exceed this limit.
+This limit is separated between server-initiated and client-initiated tags. Server tags MUST NOT exceed 510 bytes and client tags MUST NOT exceed 4096 bytes. Client-initiated tags include any tags sent by a client without the client-only prefix. This prevents servers from overflowing the overall limit by adding tags to a valid client message that comes within the limit. 
+
+Servers MUST reply with the `ERR_INPUTTOOLONG` (`417`) error numeric if a client sends a message with more tags than the respective allowed limit. Servers MUST NOT truncate tags to allow lines that exceed this limit.
 
     417    ERR_INPUTTOOLONG
           ":Input line was too long"


### PR DESCRIPTION
* Specs a TAGMSG tag-only event. Enables things like content-less reactions/faving, message deletion, message seen notifications (ircv3/ircv3-ideas#1)
* Increases the size limit for tags to 4096
* Cap name version bump to `draft/message-tags-0.2`