### PR TITLE
STS edits

### DIFF
--- a/extensions/sts.md
+++ b/extensions/sts.md
@@ -165,11 +165,9 @@ Clients might consider allowing users to explicitly define an STS policy for a g
 
 ### STS policy deletion or rejection
 
-Clients should consider allowing users or administrators to delete cached STS policies on a per-host basis, in case a server's policy is accidentally or maliciously injected on a secure connection.
+Clients might consider allowing users or administrators to reject or delete cached STS policies on a per-host basis, in case a server's policy is accidentally or maliciously injected on a secure connection.
 
-Clients might additionally provide the ability to reject STS policies on a per-host basis as an additional mitigation.
-
-These features should be made available very carefully in both user interface and security senses. Deleting or rejecting a cache entry for a known STS host should be a very deliberate and well-considered act -- it shouldn't be something that users get used to doing as a matter of course: e.g., just "clicking through" in order to get work done. In other words, these features should not violate the [no immediate user recourse](#no-immediate-user-recourse) section.
+Such a feature should be made available very carefully from both user interface and security standpoints. Deleting or rejecting a cache entry for a known STS host should be a very deliberate and well-considered act -- it shouldn't be something that users get used to doing as a matter of course: e.g., just "clicking through" in order to get work done. In other words, these features should not violate the [no immediate user recourse](#no-immediate-user-recourse) section.
 
 ## Server implementation considerations
 

--- a/extensions/sts.md
+++ b/extensions/sts.md
@@ -161,7 +161,7 @@ This advice is intended to avoid teaching users that strict security errors can 
 
 ### User-declared STS policy
 
-Clients might consider allowing users to explicitly define an STS policy for a given host, before any interaction with the host. This could help prevent a bootstrap MITM vulnerability as discussed in the (STS policy stripping)[#sts-policy-stripping] section.
+Clients might consider allowing users to explicitly define an STS policy for a given host, before any interaction with the host. This could help prevent a bootstrap MITM vulnerability as discussed in the [STS policy stripping](#sts-policy-stripping) section.
 
 ### STS policy deletion or rejection
 

--- a/extensions/sts.md
+++ b/extensions/sts.md
@@ -49,7 +49,6 @@ An STS policy has several parts:
 * A **persistence policy**, expressed via the [`duration` key](#the-duration-key) over a secure connection. *REQUIRED*
 * A **preload policy**, expressed via the [`preload` key](#the-preload-key) over a secure connection. *OPTIONAL*
 
-
 See [capability negotiation 3.2](../core/capability-negotiation-3.2.html) for more information about capabilities with values.
 
 ### Mechanism
@@ -61,6 +60,8 @@ Once a client has connected securely, and it has verified that an STS persistenc
 If the secure connection succeeds but an STS persistence policy is not present, the client SHOULD continue using the secure connection for that session. This allows servers to upgrade client connections without committing to a more permanent STS policy.
 
 Clients MUST NOT request this capability with `CAP REQ`. Servers MAY reply with a `CAP NAK` message if a client requests this capability.
+
+Servers MAY communicate changes to their STS persistence policy using the `CAP NEW` command provided by `cap-notify` or [capability negotiation 3.2](../core/capability-negotiation-3.2.html). Clients MUST store or update an STS policy for the hostname of a securely connected server if they receive a new STS capability notification.
 
 Servers MUST NOT send `CAP DEL` to disable this capability, and clients MUST ignore any attempts to do so. The mechanism for disabling an STS persistence policy is described in the `duration` key section.
 
@@ -287,6 +288,22 @@ After 48 hours, the client disconnects.
     Secure Client: QUIT :Bye
 
 The policy is still valid, so the client reschedules expiry for 2592000 seconds from the time of disconnection.
+
+### Updating an STS policy with CAP NEW
+
+A server updates an sts policy by sending a CAP NEW notification.
+
+    Server: CAP * NEW :draft/sts=duration=31536000
+
+If the client has an STS policy stored for the host it updates the policy to expire after 31536000 seconds. Otherwise a new policy is saved for the server.
+
+### Removing an STS policy with CAP NEW
+
+A server removes an sts policy by sending a CAP NEW notification.
+
+    Server: CAP * NEW :draft/sts=duration=0
+
+If the client has an STS policy stored for the host it clears the policy. Future attempts to connect insecurely will be allowed.
 
 ### Receiving CAP DEL
 

--- a/extensions/sts.md
+++ b/extensions/sts.md
@@ -97,15 +97,17 @@ Servers SHOULD consider the duration of their persistence policies when enabling
 
 ### Server Name Indication
 
-Before advertising an STS policy, servers SHOULD verify whether the hostname provided by clients, for example, via TLS Server Name Indication (SNI), has been whitelisted by administrators in the server configuration.
+Before advertising an STS persistence policy over a secure connection, servers SHOULD verify whether the hostname provided by clients, for example, via TLS Server Name Indication (SNI), has been whitelisted by administrators in the server configuration.
 
-If no hostname has been provided for the connection, an STS policy SHOULD NOT be advertised.
+If no hostname has been provided for the connection, an STS persistence policy SHOULD NOT be advertised.
 
 This allows server administrators to retain control over which hostnames are STS-enabled in case the server is accessible on multiple hostnames. It is possible that a server uses a wildcard certificate or a certificate with Subject Alternative Names but its administrators only wish to advertise STS on a subset of its hostnames.
 
 Take for example a server presenting a wildcard certificate for `*.example.net`. The hostnames `irc.example.net`, `example.net`, `www.example.net` and `test.example.net` all point to the same IP address. The server administrators may only wish to have STS enabled for `irc.example.net`, but no other hostname.
 
 IRCd software SHOULD allow for each part of the STS policy to be configured per hostname. This allows server administrators to, for example, enable STS persistence on all hostnames, but only enable a preload policy for a subset of them.
+
+SNI hostname verification is not available on insecure connections, so it might not be possible to configure a variable upgrade policy for multiple hostnames that share an IP address.
 
 ### Rescheduling expiry on disconnect
 

--- a/extensions/sts.md
+++ b/extensions/sts.md
@@ -85,9 +85,9 @@ To enforce an STS persistence policy, servers MUST send this key to securely con
 
 Clients MUST reset the STS policy expiry time for a requested hostname every time a valid persistence policy with a `duration` key is received from a server.
 
-A duration value of 0 indicates an immediate expiry of the STS persistence policy. This value MAY be used by servers to remove a previously set policy.
+A duration value of 0 indicates a disabled STS persistence policy with an immediate expiry. This value MAY be used by servers to remove a previously set policy.
 
-When an STS persistence policy expires, clients MAY continue to connect securely to the server at the requested hostname, but they are no longer required to upgrade non-secure connections.
+When an STS persistence policy expires, clients MAY continue to connect securely to the server at the requested hostname, but they are no longer required to pre-emptively upgrade non-secure connections. Clients MUST still respect any STS upgrade policies encountered when a persistence policy is expired or disabled.
 
 ### The `port` key
 

--- a/extensions/sts.md
+++ b/extensions/sts.md
@@ -93,7 +93,9 @@ Servers MAY send this key to all clients, but insecurely connected clients MUST 
 
 Preload list providers MUST only consider hosts for inclusion after validating their connection security and ensuring a valid STS policy with a `preload` key is in place. This allows IRC network administrators to opt-in for inclusion in preload lists.
 
-Servers SHOULD consider the duration of their persistence policies when enabling a preload policy and clients SHOULD consider their release cycles when using preload lists. Implementations SHOULD be able to provide updates to installed preload lists within an appropriate time frame of host policies expiring to avoid [denial of service issues](#denial-of-service).
+Servers SHOULD be prepared to offer secure connections for the long term when enabling a preload policy. Timely removal of hostnames from preload lists might not be possible.
+
+Preload list providers SHOULD consider STS persistence policy durations and MAY set minimum duration requirements prior to inclusion. Clients using preload lists SHOULD consider how their release cycle compares to any duration requirements imposed by list providers.
 
 ### Server Name Indication
 

--- a/extensions/sts.md
+++ b/extensions/sts.md
@@ -73,7 +73,7 @@ Once a client has connected securely, and it has verified that an STS persistenc
 
 If the secure connection succeeds but the STS persistence policy is not present, the client SHOULD continue using the secure connection for that session. This allows servers to upgrade client connections without committing to a more permanent STS policy.
 
-Clients MUST NOT request this capability (`CAP REQ`). Servers MUST reply with an appropriate `CAP NAK` message if a client requests this capability.
+Clients MUST NOT request this capability (`CAP REQ`). Servers MAY reply with a `CAP NAK` message if a client requests this capability.
 
 Servers MUST NOT send `CAP DEL` to disable this capability, and clients MUST ignore any attempts to do so. The mechanism for disabling an STS persistence policy is described in the `duration` key section.
 

--- a/extensions/sts.md
+++ b/extensions/sts.md
@@ -42,17 +42,17 @@ MUST only connect to the server securely (using TLS, aka. SSL), and the port
 number to use for secure connections.
 
 Clients MUST use sufficient certificate verification to ensure the connection
-is secure without any errors. This may involve validation against a system root
+is secure without any errors. This might involve validation against a system root
 certificate bundle or a user-specified trust root.
 
 In compliant server software, this capability MUST be made available as an optional
-configuration setting. Server administrators may have valid reasons not to enable it.
+configuration setting. Server administrators might have valid reasons not to enable it.
 
 ## Details
 
 When enabled, the capability has a REQUIRED value: a comma (`,`) separated
-list of tokens. Each token is a key which may have a value attached. If there
-is a value attached, the value is separated from the key by a `=`. That is,
+list of tokens. Each token consists of a key which might have a value attached.
+If there is a value attached, the value is separated from the key by a `=`. That is,
 `<key>[=<value>][,<key2>[=<value2>][,<keyN>[=<valueN>]]]`. Keys specified in
 this document MUST only occur at most once.
 
@@ -130,9 +130,7 @@ man-in-the-middle attack.
 
 ### User-declared STS policy
 
-Clients may allow users to explicitly define an STS policy for a given host, before any
-interaction with the host. This could help prevent a "Bootstrap MITM vulnerability" as
-discussed in General security considerations.
+Clients might consider allowing users to explicitly define an STS policy for a given host, before any interaction with the host. This could help prevent a "Bootstrap MITM vulnerability" as discussed in General security considerations.
 
 ### Pre-loaded STS policies
 
@@ -147,12 +145,9 @@ to user installed pre-load lists within an appropriate time frame of host polici
 
 ### STS policy deletion or rejection
 
-Clients should allow users or administrators to delete cached STS policies on a per-host
-basis, in case a server's policy is accidentally or maliciously injected on
-a secure connection.
+Clients should consider allowing users or administrators to delete cached STS policies on a per-host basis, in case a server's policy is accidentally or maliciously injected on a secure connection.
 
-Clients may additionally provide the ability to reject STS policies on a
-per-host basis as an additional mitigation.
+Clients might additionally provide the ability to reject STS policies on a per-host basis as an additional mitigation.
 
 These features should be made available very carefully in both the user interface
 and security senses. Deleting or rejecting a cache entry for a known STS host should
@@ -175,12 +170,12 @@ sent in the `duration` key on each connection attempt.
 Fixed expiry times will involve a dynamic `duration` value being calculated on each
 connection attempt.
 
-Server implementers should be aware that fixed expiry times may not be precisely
+Server implementers should be aware that fixed expiry times might not be precisely
 guaranteed in the case where clients reschedule policy expiry on disconnect.
 
 Which approach to take will depend on a number of considerations. For example, a server
-may wish their STS Policy to expire at the same time as their hostname certificate.
-Alternatively, a server may wish their STS policy to last for as long as possible.
+might wish their STS Policy to expire at the same time as their hostname certificate.
+Alternatively, a server might wish their STS policy to last for as long as possible.
 
 Server implementations should consider using a value of `duration=0` in their example
 configurations. This will require server administrators to deliberately set an expiry
@@ -190,7 +185,7 @@ according to their specific needs rather than an arbitrary generic value.
 
 The STS policy is imposed for all connections to a hostname. This means that mixing
 STS-enabled and non-secure IRC servers, or running multiple STS-enabled IRC servers
-on the same hostname may on different ports will result in some clients only being
+on the same hostname on different ports will result in some clients only being
 able to connect to a single IRC server on that host, depending on which IRC
 server they connected to first.
 
@@ -211,7 +206,7 @@ It's possible for an attacker to remove the STS `port` value from an initial con
 established via an insecure connection, before the policy has been cached by the client.
 This represents a Bootstrap MITM (man-in-the-middle) vulnerability.
 
-Clients may choose to mitigate this risk by implementing features such as user-declared
+Clients might choose to mitigate this risk by implementing features such as user-declared
 and pre-loaded STS policies, as described in the "Client implementation considerations"
 section.
 
@@ -220,7 +215,7 @@ section.
 It is possible that a client successfully receives an STS policy from a server
 but later on attackers begin to block all secure connection attempts from the
 client to the server until the policy expires. At that time, the client might
-revert back to a non-secure connection. Servers SHOULD advertise a long enough
+revert back to a non-secure connection. Servers should advertise a long enough
 duration which makes this scenario less likely to happen.
 
 Servers should choose an appropriate `duration` value with reference to the "Server implementation considerations" section to avoid inadvertent expiry issues.
@@ -239,11 +234,11 @@ considerations" section.
 
 * A 3rd party host with DNS pointing to an STS-enabled host, where the 3rd party
 isn't listed on the server's certificate. This configuration would fail certificate validation
-even without STS, but users may be relying on it for non-secure access.
+even without STS, but users might be relying on it for non-secure access.
 
 * An attacker could trick a user into declaring a manual STS policy in their client.
 
-* A server administrator may configure an STS policy for a server whose secure capabilities
+* A server administrator might configure an STS policy for a server whose secure capabilities
 are later disabled. For example, their host certificate is allowed to expire without being
 renewed, or is deemed insecure by newly exposed weak cipher suites. Care must be taken when
 choosing policy expiry times, as discussed in "Server implementation considerations", in
@@ -307,8 +302,7 @@ hostname on port 6697.
 
 ### Setting an STS persistence policy with a duration
 
-A server tells a client that is already connected securely that the client must
-only use secure connections for roughly 6 months.
+A server tells a secure client to only use secure connections for roughly 6 months.
 
     Secure Client: CAP LS 302
            Server: CAP * LS :draft/sts=duration=15552000
@@ -319,8 +313,7 @@ Until the policy expires:
 
 ### Ignoring an invalid request
 
-A server tells a client that is connected non-securely that the client must
-use secure connections for roughly 6 months. There is no port advertised.
+A server tells a non-secure client to use secure connections for roughly 6 months. There is no port advertised.
 
     Non-secure Client: CAP LS 302
                Server: CAP * LS :draft/sts=duration=15552000
@@ -330,9 +323,7 @@ connection and the STS cap doesn't contain an upgrade policy.
 
 ### Handling tokens with unknown keys
 
-A server tells a client that is already connected securely that the client must
-use secure connections for roughly a year, but the value of the STS capability
-also contains some tokens whose keys the client does not understand.
+A server tells a secure client to use secure connections for roughly a year, but the value of the STS capability also contains tokens the client doesn't recognise.
 
     Secure Client: CAP LS 302
            Server: CAP * LS :draft/sts=unknown,duration=31536000,foo=bar

--- a/extensions/sts.md
+++ b/extensions/sts.md
@@ -19,42 +19,27 @@ copyrights:
 
 This is a work-in-progress specification.
 
-Software implementing this work-in-progress specification MUST NOT use the
-unprefixed `sts` capability name. Instead, implementations SHOULD use the
-`draft/sts` capability name to be interoperable with other software
-implementing a compatible work-in-progress version.
+Software implementing this work-in-progress specification MUST NOT use the unprefixed `sts` capability name. Instead, implementations SHOULD use the `draft/sts` capability name to be interoperable with other software implementing a compatible work-in-progress version.
 
 The final version of the specification will use an unprefixed capability name.
 
 ## Description
 
-Strict Transport Security (STS) is a mechanism which allows servers to
-communicate that complying clients should only connect to them over a secure
-connection.
+Strict Transport Security (STS) is a mechanism which allows servers to communicate that complying clients should only connect to them over a secure connection.
 
-The policy is communicated to the client via the STS capability and should
-be processed by the client at capability negotiation time.
+The policy is communicated to the client via the STS capability and should be processed by the client at capability negotiation time.
 
 The name of the STS capability is `draft/sts`.
 
-The value of the capability specifies the duration during which the client
-MUST only connect to the server securely (using TLS, aka. SSL), and the port
-number to use for secure connections.
+The value of the capability specifies the duration during which the client MUST only connect to the server securely (using TLS, aka. SSL), and the port number to use for secure connections.
 
-Clients MUST use sufficient certificate verification to ensure the connection
-is secure without any errors. This might involve validation against a system root
-certificate bundle or a user-specified trust root.
+Clients MUST use sufficient certificate verification to ensure the connection is secure without any errors. This might involve validation against a system root certificate bundle or a user-specified trust root.
 
-In compliant server software, this capability MUST be made available as an optional
-configuration setting. Server administrators might have valid reasons not to enable it.
+In compliant server software, this capability MUST be made available as an optional configuration setting. Server administrators might have valid reasons not to enable it.
 
 ## Details
 
-When enabled, the capability has a REQUIRED value: a comma (`,`) separated
-list of tokens. Each token consists of a key which might have a value attached.
-If there is a value attached, the value is separated from the key by a `=`. That is,
-`<key>[=<value>][,<key2>[=<value2>][,<keyN>[=<valueN>]]]`. Keys specified in
-this document MUST only occur at most once.
+When enabled, the capability has a REQUIRED value: a comma (`,`) separated list of tokens. Each token consists of a key which might have a value attached. If there is a value attached, the value is separated from the key by a `=`. That is, `<key>[=<value>][,<key2>[=<value2>][,<keyN>[=<valueN>]]]`. Keys specified in this document MUST only occur at most once.
 
 Clients MUST ignore every token with a key that they don't understand.
 
@@ -62,8 +47,7 @@ An STS capability advertised on a secure connection with at least a `duration` k
 
 An STS capability advertised on an insecure connection with at least a `port` key present expresses an **STS upgrade policy** for the server at the requested hostname.
 
-See [capability negotiation 3.2](capability-negotiation-3.2.html) for more
-information about capabilities with values.
+See [capability negotiation 3.2](capability-negotiation-3.2.html) for more information about capabilities with values.
 
 ### Mechanism
 
@@ -99,39 +83,25 @@ To enforce an STS upgrade policy, servers MUST send this key to non-securely con
 
 ### The `preload` key
 
-This OPTIONAL key, if present, indicates that the server agrees to be
-included in STS preload lists. If it has a value, the value MUST be ignored.
+This OPTIONAL key, if present, indicates that the server agrees to be included in STS preload lists. If it has a value, the value MUST be ignored.
 
-Clients not looking to confirm whether the server agrees to be included
-in STS preload lists MAY ignore the presence of this key.
+Clients not looking to confirm whether the server agrees to be included in STS preload lists MAY ignore the presence of this key.
 
-If a client receives a `preload` key on a non-secure connection, it is
-invalid and MUST be ignored.
+If a client receives a `preload` key on a non-secure connection, it is invalid and MUST be ignored.
 
-See the [Pre-loaded STS policies section](#pre-loaded-sts-policies) for more
-information on preload lists.
+See the [Pre-loaded STS policies section](#pre-loaded-sts-policies) for more information on preload lists.
 
 ### Server Name Indication
 
-Before advertising an STS policy, servers SHOULD verify whether the hostname
-provided by clients, for example, via TLS Server Name Indication (SNI), has been
-whitelisted by administrators in the server configuration.
+Before advertising an STS policy, servers SHOULD verify whether the hostname provided by clients, for example, via TLS Server Name Indication (SNI), has been whitelisted by administrators in the server configuration.
 
 If no hostname has been provided for the connection, an STS policy SHOULD NOT be advertised.
 
-This allows server administrators to retain control over which hostnames are STS-enabled
-in case the server is accessible on multiple hostnames. It is possible that a server
-uses a wildcard certificate or a certificate with Subject Alternative Names but
-its administrators only wish to advertise STS on a subset of its hostnames.
+This allows server administrators to retain control over which hostnames are STS-enabled in case the server is accessible on multiple hostnames. It is possible that a server uses a wildcard certificate or a certificate with Subject Alternative Names but its administrators only wish to advertise STS on a subset of its hostnames.
 
-For example a server presents a wildcard certificate for `*.example.net`.
-`irc.example.net`, `example.net`, `www.example.net` and `test.example.net` all
-point to the IP address of the server. The administrators may not wish to have
-STS enabled for `test.example.net` or `www.example.net`.
+For example a server presents a wildcard certificate for `*.example.net`. `irc.example.net`, `example.net`, `www.example.net` and `test.example.net` all point to the IP address of the server. The administrators may not wish to have STS enabled for `test.example.net` or `www.example.net`.
 
-IRCd software SHOULD allow for each part of the STS policy to be configured per hostname.
-This allows server administrators to, for example enable STS persistence on all hostnames,
-but only enable a preload policy for a subset.
+IRCd software SHOULD allow for each part of the STS policy to be configured per hostname. This allows server administrators to, for example enable STS persistence on all hostnames, but only enable a preload policy for a subset.
 
 ### Rescheduling expiry on disconnect
 
@@ -145,49 +115,27 @@ This section is non-normative.
 
 ### STS policy stripping
 
-It's possible for an attacker to remove the STS `port` value from an initial connection
-established via an insecure connection, before the policy has been cached by the client.
-This represents a bootstrap MITM (man-in-the-middle) vulnerability.
+It's possible for an attacker to remove the STS `port` value from an initial connection established via an insecure connection, before the policy has been cached by the client. This represents a bootstrap MITM (man-in-the-middle) vulnerability.
 
-Clients might choose to mitigate this risk by implementing features such as user-declared
-and pre-loaded STS policies, as described in the "Client implementation considerations"
-section.
+Clients might choose to mitigate this risk by implementing features such as user-declared and pre-loaded STS policies, as described in the "Client implementation considerations" section.
 
 ### Policy expiry
 
-It is possible that a client successfully receives an STS policy from a server
-but later on attackers begin to block all secure connection attempts from the
-client to the server until the policy expires. At that time, the client might
-revert back to a non-secure connection. Servers should advertise a long enough
-duration which makes this scenario less likely to happen.
+It is possible that a client successfully receives an STS policy from a server but later on attackers begin to block all secure connection attempts from the client to the server until the policy expires. At that time, the client might revert back to a non-secure connection. Servers should advertise a long enough duration which makes this scenario less likely to happen.
 
 Servers should choose an appropriate `duration` value with reference to the "Server implementation considerations" section to avoid inadvertent expiry issues.
 
 ### Denial of Service
 
-STS could result in a Denial of Service (DoS) on IRC servers in a number of ways.
-Some non-exhaustive examples include:
+STS could result in a Denial of Service (DoS) on IRC servers in a number of ways. Some non-exhaustive examples include:
 
-* An attacker could inject an STS policy into an insecure connection that causes clients
-to reconnect on a secure port under the attacker's control. If this secure connection
-succeeds, an unwanted policy could be set for the host and persist in clients even after
-an administrator has regained control of their server. This can be mitigated in clients
-by allowing for STS policy rejection as described in the "Client implementation
-considerations" section.
+* An attacker could inject an STS policy into an insecure connection that causes clients to reconnect on a secure port under the attacker's control. If this secure connection succeeds, an unwanted policy could be set for the host and persist in clients even after an administrator has regained control of their server. This can be mitigated in clients by allowing for STS policy rejection as described in the "Client implementation considerations" section.
 
-* A 3rd party host with DNS pointing to an STS-enabled host, where the 3rd party
-isn't listed on the server's certificate. This configuration would fail certificate validation
-even without STS, but users might be relying on it for non-secure access.
+* A 3rd party host with DNS pointing to an STS-enabled host, where the 3rd party isn't listed on the server's certificate. This configuration would fail certificate validation even without STS, but users might be relying on it for non-secure access.
 
 * An attacker could trick a user into declaring a manual STS policy in their client.
 
-* A server administrator might configure an STS policy for a server whose secure capabilities
-are later disabled. For example, their host certificate is allowed to expire without being
-renewed, or is deemed insecure by newly exposed weak cipher suites. Care must be taken when
-choosing policy expiry times, as discussed in "Server implementation considerations", in
-particular when hosts are included in client pre-load policy lists. The ability to set a
-`duration=0` value at any time to revoke an STS policy is also a useful protection against
-such errors.
+* A server administrator might configure an STS policy for a server whose secure capabilities are later disabled. For example, their host certificate is allowed to expire without being renewed, or is deemed insecure by newly exposed weak cipher suites. Care must be taken when choosing policy expiry times, as discussed in "Server implementation considerations", in particular when hosts are included in client pre-load policy lists. The ability to set a `duration=0` value at any time to revoke an STS policy is also a useful protection against such errors.
 
 These issues are not vulnerabilities with STS itself, but rather are compounding issues for configuration errors, or issues involving vulnerable systems exploited by other means.
 
@@ -195,26 +143,19 @@ These issues are not vulnerabilities with STS itself, but rather are compounding
 
 This section is non-normative.
 
-For increased user protection and more advanced management of cached STS policies,
-clients might consider implementing features such as the following:
+For increased user protection and more advanced management of cached STS policies, clients might consider implementing features such as the following:
 
 ### Rescheduling while connected
 
-A client might choose to periodically reschedule policy expiry
-while connected as well, to protect against sudden power failures, for example.
+A client might choose to periodically reschedule policy expiry while connected as well, to protect against sudden power failures, for example.
 
 An appropriate period for rescheduling expiry while connected might depend on the policy's duration. For instance, a longer policy duration might warrant less frequent rescheduling.
 
 ### No immediate user recourse
 
-If a client fails to establish a secure connection for any reason to a hostname with an active STS policy, there should be no immediate user recourse to bypass the failure. For example
-the user should not be presented with a dialog that allows them to proceed with
-the connection. A failure to establish a secure connection should be treated similarly
-to a server error that the user is unable to do anything about except retrying at a
-later time.
+If a client fails to establish a secure connection for any reason to a hostname with an active STS policy, there should be no immediate user recourse to bypass the failure. For example the user should not be presented with a dialog that allows them to proceed with the connection. A failure to establish a secure connection should be treated similarly to a server error that the user is unable to do anything about except retrying at a later time.
 
-This is to ensure that it is not possible to fool users into allowing a
-man-in-the-middle attack.
+This is to ensure that it is not possible to fool users into allowing a man-in-the-middle attack.
 
 ### User-declared STS policy
 
@@ -222,15 +163,9 @@ Clients might consider allowing users to explicitly define an STS policy for a g
 
 ### Pre-loaded STS policies
 
-As further protection against bootstrap MITM vulnerabilities, clients might choose to
-include a pre-loaded list of known hosts with STS policies. Such lists should only include
-hosts with valid certificates and STS policies, and their [preload policy](#the-preload-key)
-should be in place. This allows IRC network administrators to opt-in to inclusion in preload
-lists.
+As further protection against bootstrap MITM vulnerabilities, clients might choose to include a pre-loaded list of known hosts with STS policies. Such lists should only include hosts with valid certificates and STS policies, and their [preload policy](#the-preload-key) should be in place. This allows IRC network administrators to opt-in to inclusion in preload lists.
 
-Clients should consider how their release upgrade cycle compares to server policy expiry
-times when compiling pre-loaded lists. Implementations should be able to provide updates
-to user installed pre-load lists within an appropriate time frame of host policies expiring.
+Clients should consider how their release upgrade cycle compares to server policy expiry times when compiling pre-loaded lists. Implementations should be able to provide updates to user installed pre-load lists within an appropriate time frame of host policies expiring.
 
 ### STS policy deletion or rejection
 
@@ -238,12 +173,7 @@ Clients should consider allowing users or administrators to delete cached STS po
 
 Clients might additionally provide the ability to reject STS policies on a per-host basis as an additional mitigation.
 
-These features should be made available very carefully in both the user interface
-and security senses. Deleting or rejecting a cache entry for a known STS host should
-be a very deliberate and well-considered act -- it shouldn't be something that users
-get used to doing as a matter of course: e.g., just "clicking through" in order
-to get work done. In other words, these features should not violate the "no immediate
-user recourse" section.
+These features should be made available very carefully in both the user interface and security senses. Deleting or rejecting a cache entry for a known STS host should be a very deliberate and well-considered act -- it shouldn't be something that users get used to doing as a matter of course: e.g., just "clicking through" in order to get work done. In other words, these features should not violate the "no immediate user recourse" section.
 
 ## Server implementation considerations
 
@@ -253,37 +183,23 @@ This section is non-normative.
 
 Network administrators should consider whether their policy duration represents a constant value into the future, or a fixed expiry time.
 
-Constant values into the future can be achieved by a configured number of seconds being
-sent in the `duration` key on each connection attempt.
+Constant values into the future can be achieved by a configured number of seconds being sent in the `duration` key on each connection attempt.
 
-Fixed expiry times will involve a dynamic `duration` value being calculated on each
-connection attempt.
+Fixed expiry times will involve a dynamic `duration` value being calculated on each connection attempt.
 
-Server implementers should be aware that fixed expiry times might not be precisely
-guaranteed in the case where clients reschedule policy expiry on disconnect.
+Server implementers should be aware that fixed expiry times might not be precisely guaranteed in the case where clients reschedule policy expiry on disconnect.
 
-Which approach to take will depend on a number of considerations. For example, a server
-might wish their STS Policy to expire at the same time as their hostname certificate.
-Alternatively, a server might wish their STS policy to last for as long as possible.
+Which approach to take will depend on a number of considerations. For example, a server might wish their STS Policy to expire at the same time as their hostname certificate. Alternatively, a server might wish their STS policy to last for as long as possible.
 
-Server implementations should consider using a value of `duration=0` in their example
-configurations. This will require server administrators to deliberately set an expiry
-according to their specific needs rather than an arbitrary generic value.
+Server implementations should consider using a value of `duration=0` in their example configurations. This will require server administrators to deliberately set an expiry according to their specific needs rather than an arbitrary generic value.
 
 ### Offering multiple IRC servers at alternate ports on the same hostname
 
-The STS policy is imposed for all connections to a hostname. This means that mixing
-STS-enabled and non-secure IRC servers, or running multiple STS-enabled IRC servers
-on the same hostname on different ports will result in some clients only being
-able to connect to a single IRC server on that host, depending on which IRC
-server they connected to first.
+The STS policy is imposed for all connections to a hostname. This means that mixing STS-enabled and non-secure IRC servers, or running multiple STS-enabled IRC servers on the same hostname on different ports will result in some clients only being able to connect to a single IRC server on that host, depending on which IRC server they connected to first.
 
-For example, a single host might run a production IRC server which advertises
-an STS policy and another, unrelated IRC server on a different port for
-testing purposes which does not offer secure connections.
+For example, a single host might run a production IRC server which advertises an STS policy and another, unrelated IRC server on a different port for testing purposes which does not offer secure connections.
 
-In this case, to allow clients to connect to both IRC servers the non-secure IRC
-server can be offered at a different hostname, for example a subdomain.
+In this case, to allow clients to connect to both IRC servers the non-secure IRC server can be offered at a different hostname, for example a subdomain.
 
 ## Relationship with other specifications
 
@@ -291,39 +207,23 @@ This section is non-normative.
 
 ### Relationship with STARTTLS
 
-STARTTLS is a mechanism for upgrading a connection which has started out as a
-non-secure connection to a secure connection without reconnecting to a
-different port. This means a server can offer both non-secure and secure
-connections on the same port for compatible clients at the cost of more
-complex implementations in both clients and servers.
+STARTTLS is a mechanism for upgrading a connection which has started out as a non-secure connection to a secure connection without reconnecting to a different port. This means a server can offer both non-secure and secure connections on the same port for compatible clients at the cost of more complex implementations in both clients and servers.
 
-In practice, switching protocols in the middle of the stream has proven to be
-complicated enough that only a small number of clients bothered implementing
-STARTTLS.
+In practice, switching protocols in the middle of the stream has proven to be complicated enough that only a small number of clients bothered implementing STARTTLS.
 
-STS expects that servers offer a port that directly services
-secure connections and it is incompatible with servers that offer secure
-connections only via STARTTLS on a non-secure port.
+STS expects that servers offer a port that directly services secure connections and it is incompatible with servers that offer secure connections only via STARTTLS on a non-secure port.
 
 ### Relationship with the `tls` cap
 
-The `tls` cap is a hint for clients that secure connection support is
-available via STARTTLS.
+The `tls` cap is a hint for clients that secure connection support is available via STARTTLS.
 
 STS is an improved solution and should be considered a replacement for multiple reasons.
 
-* STS is not merely a hint but requires conforming clients to
-switch to a secure connection. This means that a bookmarked server entry in
-conforming clients is upgraded to use secure connections, even if the
-bookmark was originally set up to use non-secure connections.
+* STS is not merely a hint but requires conforming clients to switch to a secure connection. This means that a bookmarked server entry in conforming clients is upgraded to use secure connections, even if the bookmark was originally set up to use non-secure connections.
 
-* STS mandates that clients must only attempt secure connections
-once a policy has been established, reducing the possibility of users being fooled
-into allowing a man-in-the-middle attack by downgrading their secure
-connections to non-secure ones. The `tls` cap has no such provision.
+* STS mandates that clients must only attempt secure connections once a policy has been established, reducing the possibility of users being fooled into allowing a man-in-the-middle attack by downgrading their secure connections to non-secure ones. The `tls` cap has no such provision.
 
-* STS is more flexible, allowing server administrators to
-configure the lifetime of a policy. 
+* STS is more flexible, allowing server administrators to configure the lifetime of a policy. 
 
 ## Examples
 
@@ -334,8 +234,7 @@ A server tells a client connecting non-securely to connect securely on port 6697
     Non-secure Client: CAP LS 302
                Server: CAP * LS :draft/sts=port=6697
 
-After the exchange, the client disconnects and reconnects securely to the same
-hostname on port 6697.
+After the exchange, the client disconnects and reconnects securely to the same hostname on port 6697.
 
 ### Setting an STS persistence policy with a duration
 
@@ -345,6 +244,7 @@ A server tells a secure client to only use secure connections for roughly 6 mont
            Server: CAP * LS :draft/sts=duration=15552000
 
 Until the policy expires:
+
 * The client will continue use the port it is currently connected on connect securely in future.
 * It will not make any non-secure connection attempts to the same hostname.
 
@@ -355,8 +255,7 @@ A server tells a non-secure client to use secure connections for roughly 6 month
     Non-secure Client: CAP LS 302
                Server: CAP * LS :draft/sts=duration=15552000
 
-The client ignores this because it has received an STS persistence policy over a non-secure
-connection and the STS cap doesn't contain an upgrade policy.
+The client ignores this because it has received an STS persistence policy over a non-secure connection and the STS cap doesn't contain an upgrade policy.
 
 ### Handling tokens with unknown keys
 
@@ -365,22 +264,19 @@ A server tells a secure client to use secure connections for roughly a year, but
     Secure Client: CAP LS 302
            Server: CAP * LS :draft/sts=unknown,duration=31536000,foo=bar
 
-The client ignores the keys it does not understand and until the policy
-expires:
-* The client will use the port it is currently connected to in the future to
-connect securely.
+The client ignores the keys it does not understand and until the policy expires:
+
+* The client will use the port it is currently connected to in the future to connect securely.
 * It will not make any non-secure connection attempts to the same host.
 
 ### Handling 0 `duration`
 
-A server tells a client that is already connected securely to remove the STS
-policy immediately.
+A server tells a client that is already connected securely to remove the STS policy immediately.
 
     Secure Client: CAP LS 302
            Server: CAP * LS :draft/sts=duration=0
 
-If the client has an STS policy stored for the host it clears the policy.
-Future attempts to connect non-securely will be allowed.
+If the client has an STS policy stored for the host it clears the policy. Future attempts to connect non-securely will be allowed.
 
 ### Rescheduling expiry on disconnect
 
@@ -389,8 +285,7 @@ A client securely connects to a server, which advertises an STS policy.
     Secure Client: CAP LS 302
            Server: CAP * LS :multi-prefix draft/sts=duration=2592000
 
-The client saves the policy and notes that it will expire in 2592000 seconds
-(roughly one month). It completes registration, then proceeds as usual.
+The client saves the policy and notes that it will expire in 2592000 seconds (roughly one month). It completes registration, then proceeds as usual.
 
 After 48 hours, the client disconnects.
 
@@ -409,8 +304,7 @@ The client will ignore this attempt and only rely on receiving a duration of 0 t
 
 ### Enabling an STS preload policy
 
-A client securely connects to a server, which advertises an STS policy and
-opts in to preload lists.
+A client securely connects to a server, which advertises an STS policy and opts in to preload lists.
 
     Secure Client: CAP LS 302
            Server: CAP * LS :draft/sts=duration=2592000,preload

--- a/extensions/sts.md
+++ b/extensions/sts.md
@@ -1,5 +1,5 @@
 ---
-title: IRCv3.3 Strict Transport Security
+title: IRCv3 Strict Transport Security
 layout: spec
 work-in-progress: true
 copyrights:
@@ -37,7 +37,7 @@ The name of the STS capability is `draft/sts`.
 
 The value of the capability specifies the duration during which the client
 MUST only connect to the server securely (using TLS, aka. SSL), and the port
-number to use for it.
+number to use for secure connections.
 
 Clients MUST use sufficient certificate verification to ensure the connection
 is secure without any errors. This may involve validation against a system root
@@ -60,7 +60,7 @@ In practice, switching protocols in the middle of the stream has proven to be
 complicated enough that only a small number of clients bothered implementing
 STARTTLS.
 
-This specification expects that servers offer a port that directly services
+STS expects that servers offer a port that directly services
 secure connections and it is incompatible with servers that offer secure
 connections only via STARTTLS on a non-secure port.
 
@@ -69,19 +69,20 @@ connections only via STARTTLS on a non-secure port.
 The `tls` cap is a hint for clients that secure connection support is
 available via STARTTLS.
 
-This specification is an improved solution to that and should be considered a
-replacement for it for multiple reasons.
+STS is an improved solution and should be considered a replacement for multiple reasons.
 
-* This specification is not merely a hint but requires conforming clients to
+* STS is not merely a hint but requires conforming clients to
 switch to a secure connection. This means that a bookmarked server entry in
 conforming clients is upgraded to use secure connections, even if the
 bookmark was originally set up to use non-secure connections.
-* This specification mandates that clients must only attempt secure connections
-to a server which has a policy, reducing the possibility of users being fooled
+
+* STS mandates that clients must only attempt secure connections
+once a policy has been established, reducing the possibility of users being fooled
 into allowing a man-in-the-middle attack by downgrading their secure
 connections to non-secure ones. The `tls` cap has no such provision.
-* This specification is more flexible, allowing server administrators to
-configure the lifetime of the policy. 
+
+* STS is more flexible, allowing server administrators to
+configure the lifetime of a policy. 
 
 ## Details
 
@@ -93,20 +94,20 @@ this document MUST only occur at most once.
 
 Clients MUST ignore every token with a key that they don't understand.
 
-An STS capability having at least a `duration` key expresses an STS policy.
+An STS capability having at least a `duration` key expresses an STS policy when advertised on a secure connection.
 
 See [capability negotiation 3.2](capability-negotiation-3.2.html) for more
 information about capabilities with values.
 
 ### Mechanism
 
-When the client sees the STS capability advertised over a non-secure
+When the client sees an STS capability advertised over a non-secure
 connection, it MUST first establish a secure connection and confirm that the
 STS capability is still present.
 
 Once the client has confirmed that the STS capability is indeed offered over
-a secure connection, it then MUST only attempt secure connections to the
-server from now on until the policy expires (see the `duration` key).
+a secure connection with a valid policy, it then MUST only use a secure transport to
+connect to the server in future, until the policy expires (see the `duration` key).
 It MUST refuse to connect if a secure connection cannot be established with the
 server for any reason during the lifetime of the policy.
 
@@ -145,8 +146,7 @@ if the server disables the capability with `CAP DEL`.
 
 ### The `port` key
 
-This key indicates the port number that clients can use when connecting over
-TLS. This key's value MUST be a single port number.
+This key indicates the port number for connecting over TLS. This key's value MUST be a single port number.
 
 If the client is not already connected securely, it MUST close the insecure
 connection and reconnect securely on the stated port.
@@ -157,31 +157,27 @@ ignored.
 
 ### Handling disconnection
 
-IRC connections may be long-lived. Connections lasting for more than a month
+IRC connections can be long-lived. Connections lasting for more than a month
 are not uncommon. When a client has successfully learned the STS policy for a
-server but it does not reconnect for a long period of time it may think
-the policy expired, even if in fact the same policy is still advertised by the
+server but it does not reconnect for a long period of time, it might think
+the policy has expired, even if in fact the same policy is still advertised by the
 server.
 
-The client MUST reschedule the expiration on disconnection.
-The new expiration is calculated from the current policy as last advertised by
-the server and the current time.
+Clients MUST reschedule expiry on disconnection. The new expiry time is calculated by adding the policy duration as last advertised by the server to the time of disconnection.
 
 ## Client implementation considerations
 
 This section is non-normative.
 
 For increased user protection and more advanced management of cached STS policies,
-clients should consider implementing features such as the following:
+clients might consider implementing features such as the following:
 
 ### Rescheduling while connected
 
-The client may choose to periodically reschedule the expiration of the policy
-while connected as well, to protect against sudden power outages, for example.
+A client might choose to periodically reschedule policy expiry
+while connected as well, to protect against sudden power failures, for example.
 
-An appropriate period for rescheduling expiration while connected might
-depend on the length of the policy expiration. For instance, longer expiry
-times might warrant less frequent rescheduling.
+An appropriate period for rescheduling expiry while connected might depend on the policy's duration. For instance, a longer policy duration might warrant less frequent rescheduling.
 
 ### No immediate user recourse
 
@@ -203,10 +199,10 @@ discussed in General security considerations.
 
 ### Pre-loaded STS policies
 
-As further protection against bootstrap MITM vulnerabilities, clients may choose to
+As further protection against bootstrap MITM vulnerabilities, clients might choose to
 include a pre-loaded list of known hosts with STS policies. Such lists should be
 compiled on an opt-in basis, by request of IRC network administrators. Hosts should be
-verified to be correctly advertising an STS policy before inclusion.
+verified to be correctly advertising a secure STS policy before inclusion.
 
 Clients should consider how their release upgrade cycle compares to server policy expiry
 times when compiling pre-loaded lists. Implementations should be able to provide updates
@@ -214,7 +210,7 @@ to user installed pre-load lists within an appropriate time frame of host polici
 
 ### STS policy deletion or rejection
 
-Clients should allow users to delete cached STS policies on a per-host
+Clients should allow users or administrators to delete cached STS policies on a per-host
 basis, in case a server's policy is accidentally or maliciously injected on
 a secure connection.
 
@@ -234,17 +230,16 @@ This section is non-normative.
 
 ### Policy expiry time
 
-IRCd configurations and network administrators should consider whether expiry times
-represent a constant value into the future, or a fixed expiry time.
+Network administrators should consider whether their policy duration represents a constant value into the future, or a fixed expiry time.
 
 Constant values into the future can be achieved by a configured number of seconds being
 sent in the `duration` key on each connection attempt.
 
-Servers implementors should be aware that fixed expiry times may not be precisely
-guaranteed in the case where clients reschedule policy expiry on disconnect.
-
 Fixed expiry times will involve a dynamic `duration` value being calculated on each
 connection attempt.
+
+Server implementors should be aware that fixed expiry times may not be precisely
+guaranteed in the case where clients reschedule policy expiry on disconnect.
 
 Which approach to take will depend on a number of considerations. For example, a server
 may wish their STS Policy to expire at the same time as their domain certificate.
@@ -257,23 +252,23 @@ according to their specific needs rather than an arbitrary generic value.
 ### Offering multiple IRC servers at alternate ports on the same domain
 
 The STS policy is imposed for an entire domain name. This means that mixing
-STS-utilizing and non-secure IRC servers on the same domain name or running
-multiple STS-utilizing IRC servers on the same domain name may result in some
+STS-enabled and non-secure IRC servers on the same domain name or running
+multiple STS-enabled IRC servers on the same domain name may result in some
 clients only being able to connect to a single IRC server on that domain name,
 depending on which IRC server they connected to first.
 
-For example, a single server may run a production IRC server which advertises
+For example, a single server might run a production IRC server which advertises
 an STS policy and another, unrelated IRC server on a different port for
 testing purposes which does not offer secure connections.
 
 In this case, to allow clients to connect to both IRC servers the non-secure IRC
-server may be offered at a different domain name, for example a subdomain.
+server can be offered at a different domain name, for example a subdomain.
 
 ## General Security considerations
 
 ### STS policy stripping
 
-It's possible for an attacker to strip the STS `port` value from an initial connection
+It's possible for an attacker to remove the STS `port` value from an initial connection
 established via an insecure connection, before the policy has been cached by the client.
 This represents a Bootstrap MITM (man-in-the-middle) vulnerability.
 
@@ -283,14 +278,13 @@ section.
 
 ### Policy expiry
 
-It is possible that a client successfully receives the STS policy from a server
+It is possible that a client successfully receives an STS policy from a server
 but later on attackers begin to block all secure connection attempts from the
-client to the server until the policy expires. At that time, the client will
+client to the server until the policy expires. At that time, the client might
 revert back to a non-secure connection. Servers SHOULD advertise a long enough
 duration which makes this scenario less likely to happen.
 
-Servers should choose an appropriate `duration` value according with reference to
-the "Server implementation considerations" section to avoid inadvertent expiry issues.
+Servers should choose an appropriate `duration` value with reference to the "Server implementation considerations" section to avoid inadvertent expiry issues.
 
 ### Denial of Service
 
@@ -299,7 +293,7 @@ Some non-exhaustive examples include:
 
 * An attacker could inject an STS policy into an insecure connection that causes clients
 to reconnect on a secure port under the attacker's control. If this secure connection
-suceeds, an unwanted policy will be set for the host and persist in clients even after
+suceeds, an unwanted policy could be set for the host and persist in clients even after
 an administrator has regained control of their server. This can be mitigated in clients
 by allowing for STS policy rejection as described in the "Client implementation
 considerations" section.
@@ -312,30 +306,29 @@ even without STS, but users may be relying on it for non-secure access.
 
 * A server administrator may configure an STS policy for a server whose secure capabilities
 are later disabled. For example, their host certificate is allowed to expire without being
-renewed, or is deemed insecure by newly exposed weak hash algorithms. Care must be taken when
+renewed, or is deemed insecure by newly exposed weak cipher suites. Care must be taken when
 choosing policy expiry times, as discussed in "Server implementation considerations", in
 particular when hosts are included in client pre-load policy lists. The ability to set a
 `duration=0` value at any time to revoke an STS policy is also a useful protection against
 such errors.
 
-These issues are not vulnerabilities with STS as such, but rather compound configuration
-errors, or issues involving vulnerable systems exploited by other means.
+These issues are not vulnerabilities with STS itself, but rather are compounding issues for configuration errors, or issues involving vulnerable systems exploited by other means.
 
 ## Examples
 
-### Redirection to a secure port
+### Redirecting to a secure port
 
-Server tells a client connecting non-securely to connect securely on port 6697.
+A server tells a client connecting non-securely to connect securely on port 6697.
 
     Client: CAP LS 302
     Server: CAP * LS :draft/sts=port=6697
 
 After the exchange, the client disconnects and reconnects securely to the same
-server on port 6697 and proceeds as it normally would.
+server on port 6697.
 
-### Setting STS policy
+### Setting an STS policy
 
-Server tells a client that is already connected securely that the client must
+A server tells a client that is already connected securely that the client must
 only use secure connections for roughly 6 months.
 
     Client: CAP LS 302
@@ -346,9 +339,9 @@ Until the policy expires:
 connect securely.
 * It will not make any non-secure connection attempts to the same server.
 
-### Ignoring invalid request
+### Ignoring an invalid request
 
-Server tells a client that is connected non-securely that the client must
+A server tells a client that is connected non-securely that the client must
 use secure connections for roughly 6 months. There is no port advertised.
 
     Client: CAP LS 302
@@ -359,7 +352,7 @@ connection and the STS cap contains no token with key `port`.
 
 ### Handling tokens with unknown keys
 
-Server tells a client that is already connected securely that the client must
+A server tells a client that is already connected securely that the client must
 use secure connections for roughly a year, but the value of the STS capability
 also contains some tokens whose keys the client does not understand.
 
@@ -374,30 +367,36 @@ connect securely.
 
 ### Handling 0 `duration`
 
-Server tells a client that is already connected securely to remove the STS
-policy now.
+A server tells a client that is already connected securely to remove the STS
+policy immediately.
 
     Client: CAP LS 302
     Server: CAP * LS :draft/sts=duration=0
 
-If the client has any STS policy stored for the server it clears the policy.
+If the client has an STS policy stored for the server it clears the policy.
 Future connections should use whatever settings (port, secure/non-secure) the
 client used before it received the STS policy.
 
-### Rescheduling on disconnection
+### Rescheduling on disconnect
 
 A client securely connects to a server, which advertises an STS policy.
 
     Client: CAP LS 302
     Server: CAP * LS :multi-prefix draft/sts=duration=2592000
 
-The client saves the policy and notes that it will become expired in 2592000 seconds
+The client saves the policy and notes that it will expire in 2592000 seconds
 (roughly one month). It completes registration, then proceeds as usual.
 
 After 48 hours, the client disconnects.
 
     Client: QUIT :Bye
 
-According to the client's last information at the time of disconnection the
-policy is still valid, so it reschedules the expiration to occur in 2592000
-seconds from the time of disconnection.
+The policy is still valid, so the client reschedules expiry for 2592000 seconds from the time of disconnection.
+
+### Receiving CAP DEL
+
+A server makes an invalid attempt to remove an sts policy by disabling the CAP.
+
+    Server: CAP * DEL :draft/sts
+
+The client will ignore this attempt and only rely on receiving a duration of 0 to disable STS policies.

--- a/extensions/sts.md
+++ b/extensions/sts.md
@@ -25,9 +25,9 @@ The final version of the specification will use an unprefixed capability name.
 
 ## Description
 
-Strict Transport Security (STS) is a mechanism which allows servers to communicate that complying clients should only connect to them over a secure connection.
+Strict Transport Security (STS) is a mechanism which allows servers to advertise a policy that clients should only connect to them over a secure connection.
 
-The policy is communicated to the client via the STS capability and should be processed by the client at capability negotiation time.
+The policy is communicated to clients via the STS capability and should be processed by the client at capability negotiation time.
 
 The name of the STS capability is `draft/sts`.
 
@@ -35,43 +35,34 @@ The value of the capability specifies the duration during which the client MUST 
 
 Clients MUST use sufficient certificate verification to ensure the connection is secure without any errors. This might involve validation against a system root certificate bundle or a user-specified trust root.
 
-In compliant server software, this capability MUST be made available as an optional configuration setting. Server administrators might have valid reasons not to enable it.
+In server software, this capability MUST be made available as an optional configuration setting. Server administrators might have valid reasons not to enable it.
 
 ## Details
 
-When enabled, the capability has a REQUIRED value: a comma (`,`) separated list of tokens. Each token consists of a key which might have a value attached. If there is a value attached, the value is separated from the key by a `=`. That is, `<key>[=<value>][,<key2>[=<value2>][,<keyN>[=<valueN>]]]`. Keys specified in this document MUST only occur at most once.
+When enabled, the capability has a REQUIRED value: a comma (`,`) (0x2C) separated list of tokens. Each token consists of a key which might have a value attached. If there is a value attached, the value is separated from the key by an equals sign (`=`) (0x3D). That is, `<key>[=<value>][,<key2>[=<value2>][,<keyN>[=<valueN>]]]`. Keys specified in this document MUST only occur at most once.
 
 Clients MUST ignore every token with a key that they don't understand.
 
-An STS capability advertised on a secure connection with at least a `duration` key present expresses an **STS persistence policy** for the server at the requested hostname.
+An STS policy has several parts:
 
-An STS capability advertised on an insecure connection with at least a `port` key present expresses an **STS upgrade policy** for the server at the requested hostname.
+* An **upgrade policy**, expressed via the [`port` key](#the-port-key) over an insecure connection. *REQUIRED*
+* A **persistence policy**, expressed via the [`duration` key](#the-duration-key) over a secure connection. *REQUIRED*
+* A **preload policy**, expressed via the [`preload` key](#the-preload-key) over a secure connection. *OPTIONAL*
 
-See [capability negotiation 3.2](capability-negotiation-3.2.html) for more information about capabilities with values.
+
+See [capability negotiation 3.2](../core/capability-negotiation-3.2.html) for more information about capabilities with values.
 
 ### Mechanism
 
-When a client sees an STS upgrade policy over a non-secure connection, it MUST first establish a secure connection (see the `port` key) and confirm that the STS persistence policy is present.
+When a client sees an STS upgrade policy over a insecure connection, it MUST first establish a secure connection (see the [`port` key](#the-port-key)) and confirm that the STS persistence policy is present.
 
-Once a client has connected securely, and it has verified that an STS persistence policy is in place, it then MUST only use a secure transport to connect to the server at the requested hostname in future, until the policy expires (see the `duration` key). Once an STS persistence policy has been verified, clients MUST refuse to connect if a secure connection cannot be established to the server for any reason during the lifetime of the policy.
+Once a client has connected securely, and it has verified that an STS persistence policy is in place, it then MUST only use a secure transport to connect to the server at the requested hostname in future, until the policy expires (see the [`duration` key](#the-duration-key)). Once an STS persistence policy has been verified, clients MUST refuse to connect if a secure connection cannot be established to the server for any reason during the lifetime of the policy.
 
-If the secure connection succeeds but the STS persistence policy is not present, the client SHOULD continue using the secure connection for that session. This allows servers to upgrade client connections without committing to a more permanent STS policy.
+If the secure connection succeeds but an STS persistence policy is not present, the client SHOULD continue using the secure connection for that session. This allows servers to upgrade client connections without committing to a more permanent STS policy.
 
-Clients MUST NOT request this capability (`CAP REQ`). Servers MAY reply with a `CAP NAK` message if a client requests this capability.
+Clients MUST NOT request this capability with `CAP REQ`. Servers MAY reply with a `CAP NAK` message if a client requests this capability.
 
 Servers MUST NOT send `CAP DEL` to disable this capability, and clients MUST ignore any attempts to do so. The mechanism for disabling an STS persistence policy is described in the `duration` key section.
-
-### The `duration` key
-
-This key is used on secure connections to indicate how long clients MUST continue to use secure connections when connecting to the server at the requested hostname. The value of this key MUST be given as a single integer which represents the number of seconds until the persistence policy expires.
-
-To enforce an STS persistence policy, servers MUST send this key to securely connected clients. Servers MAY send this key to all clients, but non-securely connected clients MUST ignore it.
-
-Clients MUST reset the STS policy expiry time for a requested hostname every time a valid persistence policy with a `duration` key is received from a server.
-
-A duration value of 0 indicates a disabled STS persistence policy with an immediate expiry. This value MAY be used by servers to remove a previously set policy.
-
-When an STS persistence policy expires, clients MAY continue to connect securely to the server at the requested hostname, but they are no longer required to pre-emptively upgrade non-secure connections. Clients MUST still respect any STS upgrade policies encountered when a persistence policy is expired or disabled.
 
 ### The `port` key
 
@@ -79,17 +70,29 @@ This key indicates the port number for making a secure connection. This key's va
 
 If the client is not already connected securely to the server at the requested hostname, it MUST close the insecure connection and reconnect securely on the stated port.
 
-To enforce an STS upgrade policy, servers MUST send this key to non-securely connected clients. Servers MAY send this key to securely connected clients, but it will be ignored.
+To enforce an STS upgrade policy, servers MUST send this key to insecurely connected clients. Servers MAY send this key to securely connected clients, but it will be ignored.
+
+### The `duration` key
+
+This key is used on secure connections to indicate how long clients MUST continue to use secure connections when connecting to the server at the requested hostname. The value of this key MUST be given as a single integer which represents the number of seconds until the persistence policy expires.
+
+To enforce an STS persistence policy, servers MUST send this key to securely connected clients. Servers MAY send this key to all clients, but insecurely connected clients MUST ignore it.
+
+Clients MUST reset the STS policy expiry time for a requested hostname every time a valid persistence policy with a `duration` key is received on a secure connection.
+
+A `duration=0` value indicates a disabled STS persistence policy with an immediate expiry. This value MAY be used by servers to remove a previously set policy.
+
+When an STS persistence policy expires, clients MAY continue to connect securely to the server at the requested hostname, but they are no longer required to pre-emptively upgrade insecure connections. Clients MUST still respect any STS upgrade policies encountered when a persistence policy is expired or disabled.
 
 ### The `preload` key
 
-This OPTIONAL key, if present, indicates that the server agrees to be included in STS preload lists. If it has a value, the value MUST be ignored.
+This OPTIONAL key, if present on a secure connection, indicates that the server agrees to be included in STS preload lists. If it has a value, the value MUST be ignored.
 
-Clients not looking to confirm whether the server agrees to be included in STS preload lists MAY ignore the presence of this key.
+Servers MAY send this key to all clients, but insecurely connected clients MUST ignore it.
 
-If a client receives a `preload` key on a non-secure connection, it is invalid and MUST be ignored.
+Preload list providers MUST only consider hosts for inclusion after validating their connection security and ensuring a valid STS policy with a `preload` key is in place. This allows IRC network administrators to opt-in for inclusion in preload lists.
 
-See the [Pre-loaded STS policies section](#pre-loaded-sts-policies) for more information on preload lists.
+Servers SHOULD consider the duration of their persistence policies when enabling a preload policy and clients SHOULD consider their release cycles when using preload lists. Implementations SHOULD be able to provide updates to installed preload lists within an appropriate time frame of host policies expiring to avoid [denial of service issues](#denial-of-service).
 
 ### Server Name Indication
 
@@ -99,9 +102,9 @@ If no hostname has been provided for the connection, an STS policy SHOULD NOT be
 
 This allows server administrators to retain control over which hostnames are STS-enabled in case the server is accessible on multiple hostnames. It is possible that a server uses a wildcard certificate or a certificate with Subject Alternative Names but its administrators only wish to advertise STS on a subset of its hostnames.
 
-For example a server presents a wildcard certificate for `*.example.net`. `irc.example.net`, `example.net`, `www.example.net` and `test.example.net` all point to the IP address of the server. The administrators may not wish to have STS enabled for `test.example.net` or `www.example.net`.
+Take for example a server presenting a wildcard certificate for `*.example.net`. The hostnames `irc.example.net`, `example.net`, `www.example.net` and `test.example.net` all point to the same IP address. The server administrators may only wish to have STS enabled for `irc.example.net`, but no other hostname.
 
-IRCd software SHOULD allow for each part of the STS policy to be configured per hostname. This allows server administrators to, for example enable STS persistence on all hostnames, but only enable a preload policy for a subset.
+IRCd software SHOULD allow for each part of the STS policy to be configured per hostname. This allows server administrators to, for example, enable STS persistence on all hostnames, but only enable a preload policy for a subset of them.
 
 ### Rescheduling expiry on disconnect
 
@@ -117,27 +120,23 @@ This section is non-normative.
 
 It's possible for an attacker to remove the STS `port` value from an initial connection established via an insecure connection, before the policy has been cached by the client. This represents a bootstrap MITM (man-in-the-middle) vulnerability.
 
-Clients might choose to mitigate this risk by implementing features such as user-declared and pre-loaded STS policies, as described in the "Client implementation considerations" section.
-
-### Policy expiry
-
-It is possible that a client successfully receives an STS policy from a server but later on attackers begin to block all secure connection attempts from the client to the server until the policy expires. At that time, the client might revert back to a non-secure connection. Servers should advertise a long enough duration which makes this scenario less likely to happen.
-
-Servers should choose an appropriate `duration` value with reference to the "Server implementation considerations" section to avoid inadvertent expiry issues.
+Clients might choose to mitigate this risk by implementing features such as [user-declared](#user-declared-sts-policy) and [preloaded](#the-preload-key) STS policies.
 
 ### Denial of Service
 
-STS could result in a Denial of Service (DoS) on IRC servers in a number of ways. Some non-exhaustive examples include:
+STS could result in a Denial of Service (DoS) on IRC servers in a number of ways. A non-exhaustive list of examples might include:
 
-* An attacker could inject an STS policy into an insecure connection that causes clients to reconnect on a secure port under the attacker's control. If this secure connection succeeds, an unwanted policy could be set for the host and persist in clients even after an administrator has regained control of their server. This can be mitigated in clients by allowing for STS policy rejection as described in the "Client implementation considerations" section.
+* An attacker could inject an STS policy into an insecure connection that causes clients to reconnect on a secure port under the attacker's control. If this secure connection succeeds, an unwanted policy could be set for the host and persist in clients even after an administrator has regained control of their server.
 
-* A 3rd party host with DNS pointing to an STS-enabled host, where the 3rd party isn't listed on the server's certificate. This configuration would fail certificate validation even without STS, but users might be relying on it for non-secure access.
+* A 3rd party sets up a hostname with DNS pointing to a server they don't control, and the hostname isn't covered by the server's certificate. This configuration already fails certificate validation, but users might be relying on it for insecure access. If the server administrators enable STS on the server, users would no longer be able to connect with that hostname.
 
-* An attacker could trick a user into declaring a manual STS policy in their client.
+* An attacker could trick a user into declaring a manual STS policy in their client for an insecure hostname.
 
-* A server administrator might configure an STS policy for a server whose secure capabilities are later disabled. For example, their host certificate is allowed to expire without being renewed, or is deemed insecure by newly exposed weak cipher suites. Care must be taken when choosing policy expiry times, as discussed in "Server implementation considerations", in particular when hosts are included in client pre-load policy lists. The ability to set a `duration=0` value at any time to revoke an STS policy is also a useful protection against such errors.
+* A server administrator might configure an STS policy for a server whose secure capabilities are later disabled. For example, their host certificate is allowed to expire without being renewed, or is deemed insecure by newly exposed weak cipher suites.
 
 These issues are not vulnerabilities with STS itself, but rather are compounding issues for configuration errors, or issues involving vulnerable systems exploited by other means.
+
+Clients and servers can mitigate many of these issues by adopting mechanisms such as preload lists described in the following implementation consideration sections 
 
 ## Client implementation considerations
 
@@ -147,25 +146,19 @@ For increased user protection and more advanced management of cached STS policie
 
 ### Rescheduling while connected
 
-A client might choose to periodically reschedule policy expiry while connected as well, to protect against sudden power failures, for example.
+In addition to [rescheduling expiry on disconnect](#rescheduling-expiry-on-disconnect), clients might choose to periodically reschedule policy expiry while connected as well. This could provide extra protection in the case of a sudden power failure, for example.
 
 An appropriate period for rescheduling expiry while connected might depend on the policy's duration. For instance, a longer policy duration might warrant less frequent rescheduling.
 
 ### No immediate user recourse
 
-If a client fails to establish a secure connection for any reason to a hostname with an active STS policy, there should be no immediate user recourse to bypass the failure. For example the user should not be presented with a dialog that allows them to proceed with the connection. A failure to establish a secure connection should be treated similarly to a server error that the user is unable to do anything about except retrying at a later time.
+If a client fails to establish a secure connection to a hostname with an active STS policy, there should be no immediate user recourse to bypass the failure. Clients should treat a failure to establish a secure connection to an STS-enabled host as a critical error, and shouldn't offer a prominent way to retry it insecurely. For example, the user should not be presented with a dialog that allows them to proceed with the connection with a click. Users should instead be required to retry the connection manually at a later time.
 
-This is to ensure that it is not possible to fool users into allowing a man-in-the-middle attack.
+This advice is intended to avoid teaching users that strict security errors can be ignored, and to offer an extra layer of protection from man-in-the-middle attacks.
 
 ### User-declared STS policy
 
-Clients might consider allowing users to explicitly define an STS policy for a given host, before any interaction with the host. This could help prevent a bootstrap MITM vulnerability as discussed in General security considerations.
-
-### Pre-loaded STS policies
-
-As further protection against bootstrap MITM vulnerabilities, clients might choose to include a pre-loaded list of known hosts with STS policies. Such lists should only include hosts with valid certificates and STS policies, and their [preload policy](#the-preload-key) should be in place. This allows IRC network administrators to opt-in to inclusion in preload lists.
-
-Clients should consider how their release upgrade cycle compares to server policy expiry times when compiling pre-loaded lists. Implementations should be able to provide updates to user installed pre-load lists within an appropriate time frame of host policies expiring.
+Clients might consider allowing users to explicitly define an STS policy for a given host, before any interaction with the host. This could help prevent a bootstrap MITM vulnerability as discussed in the (STS policy stripping)[#sts-policy-stripping] section.
 
 ### STS policy deletion or rejection
 
@@ -173,7 +166,7 @@ Clients should consider allowing users or administrators to delete cached STS po
 
 Clients might additionally provide the ability to reject STS policies on a per-host basis as an additional mitigation.
 
-These features should be made available very carefully in both the user interface and security senses. Deleting or rejecting a cache entry for a known STS host should be a very deliberate and well-considered act -- it shouldn't be something that users get used to doing as a matter of course: e.g., just "clicking through" in order to get work done. In other words, these features should not violate the "no immediate user recourse" section.
+These features should be made available very carefully in both user interface and security senses. Deleting or rejecting a cache entry for a known STS host should be a very deliberate and well-considered act -- it shouldn't be something that users get used to doing as a matter of course: e.g., just "clicking through" in order to get work done. In other words, these features should not violate the [no immediate user recourse](#no-immediate-user-recourse) section.
 
 ## Server implementation considerations
 
@@ -187,19 +180,21 @@ Constant values into the future can be achieved by a configured number of second
 
 Fixed expiry times will involve a dynamic `duration` value being calculated on each connection attempt.
 
-Server implementers should be aware that fixed expiry times might not be precisely guaranteed in the case where clients reschedule policy expiry on disconnect.
+Server implementers should be aware that fixed expiry times might not be precisely guaranteed in the case where clients reschedule policy expiry on disconnect, or periodically while connected.
 
 Which approach to take will depend on a number of considerations. For example, a server might wish their STS Policy to expire at the same time as their hostname certificate. Alternatively, a server might wish their STS policy to last for as long as possible.
 
-Server implementations should consider using a value of `duration=0` in their example configurations. This will require server administrators to deliberately set an expiry according to their specific needs rather than an arbitrary generic value.
+Server administrators should be aware of the ability to set a `duration=0` value at any time to revoke an STS policy if secure connections are no longer enabled for their servers.
+
+Server implementations should consider using a default value of `duration=0` in their example configurations. This will require server administrators to deliberately choose an expiry according to their specific needs rather than (perhaps unknowingly) rely on an arbitrary generic value.
 
 ### Offering multiple IRC servers at alternate ports on the same hostname
 
-The STS policy is imposed for all connections to a hostname. This means that mixing STS-enabled and non-secure IRC servers, or running multiple STS-enabled IRC servers on the same hostname on different ports will result in some clients only being able to connect to a single IRC server on that host, depending on which IRC server they connected to first.
+An STS policy is imposed for all connections to a hostname. This can create issues when attempting to run multiple IRC servers that share a hostname but use different ports.
 
-For example, a single host might run a production IRC server which advertises an STS policy and another, unrelated IRC server on a different port for testing purposes which does not offer secure connections.
+For example, a single host might run a production IRC server which advertises an STS policy and another, insecure IRC server on a different port for testing purposes. STS capable clients will lose the ability to connect to the testing server once an STS policy is established for the production server.
 
-In this case, to allow clients to connect to both IRC servers the non-secure IRC server can be offered at a different hostname, for example a subdomain.
+To avoid these issues, servers can be offered on separate hostnames, perhaps using subdomains.
 
 ## Relationship with other specifications
 
@@ -207,31 +202,31 @@ This section is non-normative.
 
 ### Relationship with STARTTLS
 
-STARTTLS is a mechanism for upgrading a connection which has started out as a non-secure connection to a secure connection without reconnecting to a different port. This means a server can offer both non-secure and secure connections on the same port for compatible clients at the cost of more complex implementations in both clients and servers.
+STARTTLS is a mechanism for upgrading a connection which has started out as a insecure connection to a secure connection without reconnecting to a different port. This means a server can offer both insecure and secure connections on the same port for compatible clients at the cost of more complex implementations in both clients and servers.
 
 In practice, switching protocols in the middle of the stream has proven to be complicated enough that only a small number of clients bothered implementing STARTTLS.
 
-STS expects that servers offer a port that directly services secure connections and it is incompatible with servers that offer secure connections only via STARTTLS on a non-secure port.
+STS expects that servers instead offer a port that directly services secure connections and it is incompatible with servers that offer secure connections only via STARTTLS on a insecure port.
 
-### Relationship with the `tls` cap
+### Relationship with the `tls` capability
 
-The `tls` cap is a hint for clients that secure connection support is available via STARTTLS.
+The `tls` capability is a hint for clients that secure connection support is available via STARTTLS.
 
 STS is an improved solution and should be considered a replacement for multiple reasons.
 
-* STS is not merely a hint but requires conforming clients to switch to a secure connection. This means that a bookmarked server entry in conforming clients is upgraded to use secure connections, even if the bookmark was originally set up to use non-secure connections.
+* STS is not merely a hint but requires conforming clients to switch to a secure connection. This means that bookmarked servers are upgraded to use secure connections, even if the bookmark was originally set up to use insecure connections.
 
-* STS mandates that clients must only attempt secure connections once a policy has been established, reducing the possibility of users being fooled into allowing a man-in-the-middle attack by downgrading their secure connections to non-secure ones. The `tls` cap has no such provision.
+* STS mandates that clients only attempt secure connections once a policy has been established, reducing the possibility of users being fooled into allowing a man-in-the-middle attack by downgrading their secure connections to insecure ones. The `tls` capability has no such provision.
 
-* STS is more flexible, allowing server administrators to configure the lifetime of a policy. 
+* STS is more flexible, as server administrators can configure the lifetime of a policy. 
 
 ## Examples
 
 ### Redirecting to a secure port with an upgrade policy
 
-A server tells a client connecting non-securely to connect securely on port 6697.
+A server tells a client connecting insecurely to connect securely on port 6697.
 
-    Non-secure Client: CAP LS 302
+      Insecure Client: CAP LS 302
                Server: CAP * LS :draft/sts=port=6697
 
 After the exchange, the client disconnects and reconnects securely to the same hostname on port 6697.
@@ -246,16 +241,16 @@ A server tells a secure client to only use secure connections for roughly 6 mont
 Until the policy expires:
 
 * The client will continue use the port it is currently connected on connect securely in future.
-* It will not make any non-secure connection attempts to the same hostname.
+* It will not make any insecure connection attempts to the same hostname.
 
 ### Ignoring an invalid request
 
-A server tells a non-secure client to use secure connections for roughly 6 months. There is no port advertised.
+A server tells a insecure client to use secure connections for roughly 6 months. There is no port advertised.
 
-    Non-secure Client: CAP LS 302
+      Insecure Client: CAP LS 302
                Server: CAP * LS :draft/sts=duration=15552000
 
-The client ignores this because it has received an STS persistence policy over a non-secure connection and the STS cap doesn't contain an upgrade policy.
+The client ignores this because it has received an STS persistence policy over a insecure connection and the STS cap doesn't contain an upgrade policy.
 
 ### Handling tokens with unknown keys
 
@@ -267,7 +262,7 @@ A server tells a secure client to use secure connections for roughly a year, but
 The client ignores the keys it does not understand and until the policy expires:
 
 * The client will use the port it is currently connected to in the future to connect securely.
-* It will not make any non-secure connection attempts to the same host.
+* It will not make any insecure connection attempts to the same host.
 
 ### Handling 0 `duration`
 
@@ -276,7 +271,7 @@ A server tells a client that is already connected securely to remove the STS pol
     Secure Client: CAP LS 302
            Server: CAP * LS :draft/sts=duration=0
 
-If the client has an STS policy stored for the host it clears the policy. Future attempts to connect non-securely will be allowed.
+If the client has an STS policy stored for the host it clears the policy. Future attempts to connect insecurely will be allowed.
 
 ### Rescheduling expiry on disconnect
 

--- a/extensions/sts.md
+++ b/extensions/sts.md
@@ -48,44 +48,6 @@ certificate bundle or a user-specified trust root.
 In compliant server software, this capability MUST be made available as an optional
 configuration setting. Server administrators may have valid reasons not to enable it.
 
-## Relationship with other specifications
-
-### Relationship with STARTTLS
-
-STARTTLS is a mechanism for upgrading a connection which has started out as a
-non-secure connection to a secure connection without reconnecting to a
-different port. This means a server can offer both non-secure and secure
-connections on the same port for compatible clients at the cost of more
-complex implementations in both clients and servers.
-
-In practice, switching protocols in the middle of the stream has proven to be
-complicated enough that only a small number of clients bothered implementing
-STARTTLS.
-
-STS expects that servers offer a port that directly services
-secure connections and it is incompatible with servers that offer secure
-connections only via STARTTLS on a non-secure port.
-
-### Relationship with the `tls` cap
-
-The `tls` cap is a hint for clients that secure connection support is
-available via STARTTLS.
-
-STS is an improved solution and should be considered a replacement for multiple reasons.
-
-* STS is not merely a hint but requires conforming clients to
-switch to a secure connection. This means that a bookmarked server entry in
-conforming clients is upgraded to use secure connections, even if the
-bookmark was originally set up to use non-secure connections.
-
-* STS mandates that clients must only attempt secure connections
-once a policy has been established, reducing the possibility of users being fooled
-into allowing a man-in-the-middle attack by downgrading their secure
-connections to non-secure ones. The `tls` cap has no such provision.
-
-* STS is more flexible, allowing server administrators to
-configure the lifetime of a policy. 
-
 ## Details
 
 When enabled, the capability has a REQUIRED value: a comma (`,`) separated
@@ -315,6 +277,44 @@ particular when hosts are included in client pre-load policy lists. The ability 
 such errors.
 
 These issues are not vulnerabilities with STS itself, but rather are compounding issues for configuration errors, or issues involving vulnerable systems exploited by other means.
+
+## Relationship with other specifications
+
+### Relationship with STARTTLS
+
+STARTTLS is a mechanism for upgrading a connection which has started out as a
+non-secure connection to a secure connection without reconnecting to a
+different port. This means a server can offer both non-secure and secure
+connections on the same port for compatible clients at the cost of more
+complex implementations in both clients and servers.
+
+In practice, switching protocols in the middle of the stream has proven to be
+complicated enough that only a small number of clients bothered implementing
+STARTTLS.
+
+STS expects that servers offer a port that directly services
+secure connections and it is incompatible with servers that offer secure
+connections only via STARTTLS on a non-secure port.
+
+### Relationship with the `tls` cap
+
+The `tls` cap is a hint for clients that secure connection support is
+available via STARTTLS.
+
+STS is an improved solution and should be considered a replacement for multiple reasons.
+
+* STS is not merely a hint but requires conforming clients to
+switch to a secure connection. This means that a bookmarked server entry in
+conforming clients is upgraded to use secure connections, even if the
+bookmark was originally set up to use non-secure connections.
+
+* STS mandates that clients must only attempt secure connections
+once a policy has been established, reducing the possibility of users being fooled
+into allowing a man-in-the-middle attack by downgrading their secure
+connections to non-secure ones. The `tls` cap has no such provision.
+
+* STS is more flexible, allowing server administrators to
+configure the lifetime of a policy. 
 
 ## Examples
 

--- a/extensions/sts.md
+++ b/extensions/sts.md
@@ -179,27 +179,27 @@ Server implementers should be aware that fixed expiry times may not be precisely
 guaranteed in the case where clients reschedule policy expiry on disconnect.
 
 Which approach to take will depend on a number of considerations. For example, a server
-may wish their STS Policy to expire at the same time as their domain certificate.
+may wish their STS Policy to expire at the same time as their hostname certificate.
 Alternatively, a server may wish their STS policy to last for as long as possible.
 
 Server implementations should consider using a value of `duration=0` in their example
 configurations. This will require server administrators to deliberately set an expiry
 according to their specific needs rather than an arbitrary generic value.
 
-### Offering multiple IRC servers at alternate ports on the same domain
+### Offering multiple IRC servers at alternate ports on the same hostname
 
-The STS policy is imposed for an entire domain name. This means that mixing
-STS-enabled and non-secure IRC servers on the same domain name or running
-multiple STS-enabled IRC servers on the same domain name may result in some
-clients only being able to connect to a single IRC server on that domain name,
-depending on which IRC server they connected to first.
+The STS policy is imposed for all connections to a hostname. This means that mixing
+STS-enabled and non-secure IRC servers, or running multiple STS-enabled IRC servers
+on the same hostname may on different ports will result in some clients only being
+able to connect to a single IRC server on that host, depending on which IRC
+server they connected to first.
 
-For example, a single server might run a production IRC server which advertises
+For example, a single host might run a production IRC server which advertises
 an STS policy and another, unrelated IRC server on a different port for
 testing purposes which does not offer secure connections.
 
 In this case, to allow clients to connect to both IRC servers the non-secure IRC
-server can be offered at a different domain name, for example a subdomain.
+server can be offered at a different hostname, for example a subdomain.
 
 ## General Security considerations
 

--- a/extensions/sts.md
+++ b/extensions/sts.md
@@ -2,6 +2,8 @@
 title: IRCv3 Strict Transport Security
 layout: spec
 work-in-progress: true
+redirect_from:
+  - /specs/core/sts-3.3.html
 copyrights:
   -
     name: "Attila Molnar"

--- a/extensions/sts.md
+++ b/extensions/sts.md
@@ -119,8 +119,7 @@ An appropriate period for rescheduling expiry while connected might depend on th
 
 ### No immediate user recourse
 
-If a client fails to establish a secure connection for any reason to a server with which
-an STS policy has been stored, there should be no immediate user recourse. For example
+If a client fails to establish a secure connection for any reason to a hostname with an active STS policy, there should be no immediate user recourse to bypass the failure. For example
 the user should not be presented with a dialog that allows them to proceed with
 the connection. A failure to establish a secure connection should be treated similarly
 to a server error that the user is unable to do anything about except retrying at a
@@ -296,39 +295,38 @@ configure the lifetime of a policy.
 
 ## Examples
 
-### Redirecting to a secure port
+### Redirecting to a secure port with an upgrade policy
 
 A server tells a client connecting non-securely to connect securely on port 6697.
 
-    Client: CAP LS 302
-    Server: CAP * LS :draft/sts=port=6697
+    Non-secure Client: CAP LS 302
+               Server: CAP * LS :draft/sts=port=6697
 
 After the exchange, the client disconnects and reconnects securely to the same
-server on port 6697.
+hostname on port 6697.
 
-### Setting an STS policy
+### Setting an STS persistence policy with a duration
 
 A server tells a client that is already connected securely that the client must
 only use secure connections for roughly 6 months.
 
-    Client: CAP LS 302
-    Server: CAP * LS :draft/sts=duration=15552000
+    Secure Client: CAP LS 302
+           Server: CAP * LS :draft/sts=duration=15552000
 
 Until the policy expires:
-* The client will use the port it is currently connected to in the future to
-connect securely.
-* It will not make any non-secure connection attempts to the same server.
+* The client will continue use the port it is currently connected on connect securely in future.
+* It will not make any non-secure connection attempts to the same hostname.
 
 ### Ignoring an invalid request
 
 A server tells a client that is connected non-securely that the client must
 use secure connections for roughly 6 months. There is no port advertised.
 
-    Client: CAP LS 302
-    Server: CAP * LS :draft/sts=duration=15552000
+    Non-secure Client: CAP LS 302
+               Server: CAP * LS :draft/sts=duration=15552000
 
-The client ignores this because it received the STS policy over a non-secure
-connection and the STS cap contains no token with key `port`.
+The client ignores this because it has received an STS persistence policy over a non-secure
+connection and the STS cap doesn't contain an upgrade policy.
 
 ### Handling tokens with unknown keys
 
@@ -336,39 +334,39 @@ A server tells a client that is already connected securely that the client must
 use secure connections for roughly a year, but the value of the STS capability
 also contains some tokens whose keys the client does not understand.
 
-    Client: CAP LS 302
-    Server: CAP * LS :draft/sts=unknown,duration=31536000,foo=bar
+    Secure Client: CAP LS 302
+           Server: CAP * LS :draft/sts=unknown,duration=31536000,foo=bar
 
 The client ignores the keys it does not understand and until the policy
 expires:
 * The client will use the port it is currently connected to in the future to
 connect securely.
-* It will not make any non-secure connection attempts to the same server.
+* It will not make any non-secure connection attempts to the same host.
 
 ### Handling 0 `duration`
 
 A server tells a client that is already connected securely to remove the STS
 policy immediately.
 
-    Client: CAP LS 302
-    Server: CAP * LS :draft/sts=duration=0
+    Secure Client: CAP LS 302
+           Server: CAP * LS :draft/sts=duration=0
 
-If the client has an STS policy stored for the server it clears the policy.
-Future attempts to connect non-securely will be allowed
+If the client has an STS policy stored for the host it clears the policy.
+Future attempts to connect non-securely will be allowed.
 
 ### Rescheduling expiry on disconnect
 
 A client securely connects to a server, which advertises an STS policy.
 
-    Client: CAP LS 302
-    Server: CAP * LS :multi-prefix draft/sts=duration=2592000
+    Secure Client: CAP LS 302
+           Server: CAP * LS :multi-prefix draft/sts=duration=2592000
 
 The client saves the policy and notes that it will expire in 2592000 seconds
 (roughly one month). It completes registration, then proceeds as usual.
 
 After 48 hours, the client disconnects.
 
-    Client: QUIT :Bye
+    Secure Client: QUIT :Bye
 
 The policy is still valid, so the client reschedules expiry for 2592000 seconds from the time of disconnection.
 


### PR DESCRIPTION
This is a WIP PR

* [x] Copy edits
* [x] Drops 3.3
* [x] Moves from core to extensions
* [x] Adds an example of clients ignoring CAP DEL
* [x] Add redirect-from yaml to avoid breaking old links
* [x] Make sure all non-normative sections are marked appropriately
* [x] The spec mostly talks about servers, maybe it should refer to hostnames, since that's what policies are tied to.
* [x] Sort out what to do on policy expiry/removal. The spec currently implies that clients need to revert to the previously insecure settings that were chosen by the user prior to upgrade, but I think it makes more sense to keep the upgraded port but just no longer enforce upgrades for new connections. This saves having to remember the original connection details, and just treat port=6697 upgrades as stateless.
* [x] Note that an sts port but no duration can be used as a soft temporary upgrade, if a server doesn't want to commit to a full policy.
* [x] Add a stronger recommendation for SNI. Done in #295
* [x] Try not to use "must", "should", "may" in non-normative sections
* [x] Merge in changes from #295
* [x] Reorder "General Security considerations" above "Client implementation considerations"
* [x] Use CAP NEW to update/disable an STS policy for active connections.

Leaving this out of scope for now:

* [x] Possibly out of scope, but maybe discuss what clients should do when a cert error is seen on a secure connection *without* an sts policy. At least initially, I'll be using the presence of sts to enforce cert validation, but still allow self-signed, unrecognised CAs on non-sts connections (though possibly with a more visible error). Given the number of non-secure certs still out there, I think that's reasonable. I'll also allow treat sts=duration=0 upgraded connections the same way, i.e. not hard fail, so it may be in scope after all.