### PR TITLE
Add meta status keys to header yaml

### DIFF
--- a/core/capability-negotiation-3.1.md
+++ b/core/capability-negotiation-3.1.md
@@ -1,6 +1,9 @@
 ---
 title: IRCv3.1 Client Capability Negotiation
 layout: spec
+updated-by:
+  "CAP Negotiation 3.2": core/capability-negotiation-3.2.html
+  "cap-notify Extension": extensions/cap-notify-3.2.html
 copyrights:
   -
     name: "Kevin L. Mitchell"

--- a/core/capability-negotiation-3.1.md
+++ b/core/capability-negotiation-3.1.md
@@ -2,8 +2,8 @@
 title: IRCv3.1 Client Capability Negotiation
 layout: spec
 updated-by:
-  "CAP Negotiation 3.2": core/capability-negotiation-3.2.html
-  "cap-notify Extension": extensions/cap-notify-3.2.html
+  - cap-3.2
+  - cap-notify
 copyrights:
   -
     name: "Kevin L. Mitchell"

--- a/core/capability-negotiation-3.2.md
+++ b/core/capability-negotiation-3.2.md
@@ -1,6 +1,10 @@
 ---
 title: IRCv3.2 Client Capability Negotiation
 layout: spec
+updates:
+  "CAP Negotiation 3.1": core/capability-negotiation-3.1.html
+extended-by:
+  "cap-notify Extension": extensions/cap-notify-3.2.html
 copyrights:
   -
     name: "Kevin L. Mitchell"

--- a/core/capability-negotiation-3.2.md
+++ b/core/capability-negotiation-3.2.md
@@ -2,9 +2,9 @@
 title: IRCv3.2 Client Capability Negotiation
 layout: spec
 updates:
-  "CAP Negotiation 3.1": core/capability-negotiation-3.1.html
+  - cap-3.1
 extended-by:
-  "cap-notify Extension": extensions/cap-notify-3.2.html
+  - cap-notify
 copyrights:
   -
     name: "Kevin L. Mitchell"

--- a/core/message-tags-3.2.md
+++ b/core/message-tags-3.2.md
@@ -2,7 +2,7 @@
 title: IRCv3.2 Message Tags
 layout: spec
 updated-by:
-  "Message Tags 3.3": core/message-tags-3.3.html
+  - message-tags-3.3
 copyrights:
   -
     name: "Alexey Sokolov"

--- a/core/message-tags-3.2.md
+++ b/core/message-tags-3.2.md
@@ -1,6 +1,8 @@
 ---
 title: IRCv3.2 Message Tags
 layout: spec
+updated-by:
+  "Message Tags 3.3": core/message-tags-3.3.html
 copyrights:
   -
     name: "Alexey Sokolov"

--- a/core/message-tags-3.3.md
+++ b/core/message-tags-3.3.md
@@ -3,7 +3,7 @@ title: IRCv3.3 Message Tags
 layout: spec
 work-in-progress: true
 updates:
-  "Message Tags 3.2": core/message-tags-3.2.html
+  - message-tags-3.2
 copyrights:
   -
     name: "Kiyoshi Aman"

--- a/core/message-tags-3.3.md
+++ b/core/message-tags-3.3.md
@@ -2,6 +2,8 @@
 title: IRCv3.3 Message Tags
 layout: spec
 work-in-progress: true
+updates:
+  "Message Tags 3.2": core/message-tags-3.2.html
 copyrights:
   -
     name: "Kiyoshi Aman"

--- a/example-spec.md
+++ b/example-spec.md
@@ -31,11 +31,12 @@ These keys can be used in the header to specify this spec's relationship to othe
 Each of these links to other specifications, written as such:
 
     updates:
-        "Message Tags 3.2": core/message-tags-3.2.html
-        "Message Tags 3.3": core/message-tags-3.3.html
+        - message-tags-3.2
+        - message-tags-3.3
     obsoletes:
-        "Metadata 3.2": core/metadata-3.2.html
+        - metadata-3.2
 
+The spec names to use here are those specified in the site [speification registry file](https://github.com/ircv3/ircv3.github.io/blob/master/_data/specs.yml).
 
 ---
 

--- a/example-spec.md
+++ b/example-spec.md
@@ -17,9 +17,25 @@ keep in mind that the sections here are not set in stone.
 Also take a look at other specifications and the CONTRIBUTING.md file for further
 suggestions and information to keep in mind while writing a proposal.
 
-Some notes:
+New capability and tag names should be listed in the _"Notes for implementing work-in-progress version"_ section, with the appropriate disclaimer and `draft/` prefix, until it's ratified.
 
-- New capability and tag names should be listed in the _"Notes for implementing work-in-progress version"_ section, with the appropriate disclaimer and `draft/` prefix, until it's ratified.
+These keys can be used in the header to specify this spec's relationship to other IRCv3 specifications:
+
+- `updates`: To follow this specification, read the linked spec(s) and then this one.
+- `updated-by`: After reading this specification, read the linked spec(s) to get the latest version.
+- `extends`: This specification is an optional extension of the linked spec(s).
+- `extended-by`: The linked spec(s) are optional extensions to this specification.
+- `obsoletes`: Ignore the linked specification(s), as this one replaces them entirely.
+- `obsoleted-by`: Ignore this specification, as the linked one(s) replace it entirely.
+
+Each of these links to other specifications, written as such:
+
+    updates:
+        "Message Tags 3.2": core/message-tags-3.2.html
+        "Message Tags 3.3": core/message-tags-3.3.html
+    obsoletes:
+        "Metadata 3.2": core/metadata-3.2.html
+
 
 ---
 

--- a/extensions/cap-notify-3.2.md
+++ b/extensions/cap-notify-3.2.md
@@ -1,6 +1,8 @@
 ---
 title: IRCv3.2 `cap-notify` Extension
 layout: spec
+extends:
+  "IRCv3.2 Client Capability Negotiation": core/capability-negotiation-3.2.html
 copyrights:
   -
     name: "Attila Molnar"

--- a/extensions/cap-notify-3.2.md
+++ b/extensions/cap-notify-3.2.md
@@ -2,7 +2,8 @@
 title: IRCv3.2 `cap-notify` Extension
 layout: spec
 extends:
-  "IRCv3.2 Client Capability Negotiation": core/capability-negotiation-3.2.html
+  - cap-3.2
+  - cap-3.3
 copyrights:
   -
     name: "Attila Molnar"

--- a/extensions/sasl-3.1.md
+++ b/extensions/sasl-3.1.md
@@ -1,6 +1,8 @@
 ---
 title: IRCv3.1 SASL Authentication
 layout: spec
+updated-by:
+  "SASL Authentication 3.2": extensions/sasl-3.2.html
 copyrights:
   -
     name: "Jilles Tjoelker"

--- a/extensions/sasl-3.1.md
+++ b/extensions/sasl-3.1.md
@@ -2,7 +2,7 @@
 title: IRCv3.1 SASL Authentication
 layout: spec
 updated-by:
-  "SASL Authentication 3.2": extensions/sasl-3.2.html
+  - sasl-3.2
 copyrights:
   -
     name: "Jilles Tjoelker"

--- a/extensions/sasl-3.2.md
+++ b/extensions/sasl-3.2.md
@@ -1,6 +1,8 @@
 ---
 title: IRCv3.2 SASL Authentication
 layout: spec
+updates:
+  "SASL Authentication 3.1": extensions/sasl-3.1.html
 copyrights:
   -
     name: "Attila Molnar"

--- a/extensions/sasl-3.2.md
+++ b/extensions/sasl-3.2.md
@@ -2,7 +2,7 @@
 title: IRCv3.2 SASL Authentication
 layout: spec
 updates:
-  "SASL Authentication 3.1": extensions/sasl-3.1.html
+  - sasl-3.1
 copyrights:
   -
     name: "Attila Molnar"


### PR DESCRIPTION
This lets us, in the website, link between specifications where appropriate and makes the discoverability of things like new versions and extensions to existing capabilities much easier to see.