### PR TITLE
message-tags-3.2: Clarify how to handle lone backslashes

### DIFF
--- a/core/message-tags-3.2.md
+++ b/core/message-tags-3.2.md
@@ -67,6 +67,9 @@ The mapping between characters in tag values and their representation in `<escap
 Reason: more common URL-escaping eats more space, while IRC message's length is very limited.
 Also having semicolon as `\:` makes it easy to split the `<tags>` string by `;` first.
 
+If a lone `\` exists at the end of an escaped value (with no escape character following it), then there
+SHOULD be no output character. For example, the escaped value `"test\"` should unescape to `"test"`.
+
 ## Rules for naming message tags
 
 The full tag name MUST be treated as an opaque identifier.
@@ -115,6 +118,9 @@ Message with 3 tags:
 
 Previous versions of this spec did not specify that the full tag name MUST be parsed as
 an opaque identifier. This was added to improve client resiliency.
+
+Previous versions of this spec did not specify how to handle trailing backslashes with
+no escape character. This was added to help consistency across specifications.
 
 
 [rfc1459]: http://tools.ietf.org/html/rfc1459#section-2.3.1

--- a/core/message-tags-3.2.md
+++ b/core/message-tags-3.2.md
@@ -120,7 +120,7 @@ Previous versions of this spec did not specify that the full tag name MUST be pa
 an opaque identifier. This was added to improve client resiliency.
 
 Previous versions of this spec did not specify how to handle trailing backslashes with
-no escape character. This was added to help consistency across specifications.
+no escape character. This was added to help consistency across implementations.
 
 
 [rfc1459]: http://tools.ietf.org/html/rfc1459#section-2.3.1

--- a/core/message-tags-3.2.md
+++ b/core/message-tags-3.2.md
@@ -68,7 +68,7 @@ Reason: more common URL-escaping eats more space, while IRC message's length is 
 Also having semicolon as `\:` makes it easy to split the `<tags>` string by `;` first.
 
 If a lone `\` exists at the end of an escaped value (with no escape character following it), then there
-SHOULD be no output character. For example, the escaped value `"test\"` should unescape to `"test"`.
+SHOULD be no output character. For example, the escaped value `test\` should unescape to `test`.
 
 ## Rules for naming message tags
 


### PR DESCRIPTION
How to handle this was a question raised to me in email. I think this is the most appropriate way to handle this sort of case (since here, there's no actual `"Character"` as specified by the table, so nothing to output when it's unescaped).

It's an edge case, but it should help make implementations just a bit more compatible knowing how they should handle this specifically.