### PR TITLE
[message-tags] Describe a JSON encoding format and bump version to 0.3

### DIFF
--- a/core/message-tags-3.3.md
+++ b/core/message-tags-3.3.md
@@ -131,7 +131,7 @@ Fully encoded and escaped JSON tag data is transmitted instead of `<tags>` in th
 
 To detect JSON-encoded tag data, clients and servers MUST check for `'{'` (0x7B) as the first character of tag data, after the leading `'@'` (0x40) character. The JSON data ends on the first space `' '` (0x20) character.
 
-If JSON tag data fails to decode correctly, clients MUST abort message parsing and discard the entire message, as this may be a symptom of incorrectly applied escaping rules, making the remainder of the message vulnerable to command injection. Servers MUST ignore incorrectly encoded JSON data entirely and MAY terminate the client connection as a result.
+If JSON tag data fails to decode correctly, clients and servers MUST treat the message as having no tags.
 
 ### Size limit
 

--- a/core/message-tags-3.3.md
+++ b/core/message-tags-3.3.md
@@ -204,7 +204,7 @@ A message sent by a client with the `+example-client-tag` client-only tag:
 A message with the same tags sent with both the normal and JSON encodings for comparison:
 
     @tag=value;+client-tag=value\swith\sspaces PRIVMSG #channel :Message
-    @{"tag":"value","+client-tag":"value\swith\spaces"} PRIVMSG #channel :Message
+    @{"tag":"value","+client-tag":"value\swith\sspaces"} PRIVMSG #channel :Message
 
 ---
 


### PR DESCRIPTION
> To allow for tag values containing complex typed data such as lists and associative arrays, new encoding rules are required. JSON was chosen as an existing, widely-adopted format with established encoding rules.

This is implemented on IRCCloud team servers. Let me know if you need access to the test team.

This grew out of discussion around various client tag specs (e.g. [this `+draft/emoji` idea](https://github.com/ircv3/ircv3-ideas/issues/14)) relying on per-value JSON encoded data. It was suggested that instead we allow the entire tagset to be encoded with JSON if such features are desired.

Still need to resolve how best to deal with size limits. A few issues:

* Checking that tags being added to a message fall within the limits will get different size values depending on the encoding used. JSON will be larger.
* Having to check limits for server-added and client-provided tagsets separately is a bit more complex, because you have to json encode each tagset individually.
* Combining two json tagsets into one, you drop the adjacent braces and add a comma, rather than just merging with a semicolon. This is probably not an overflow issue because it only means that your max data allowance is smaller by two characters, but we should probably mention this somehow.

One solution might be to just always check the limit based on the json encoding, even if you send tags with the standard encoding.