### PR TITLE
[WIP] Merged metadata rewrite

### DIFF
--- a/core/metadata-3.2.md
+++ b/core/metadata-3.2.md
@@ -15,6 +15,18 @@ copyrights:
     period: "2018"
     email: "james@irccloud.com"
 ---
+
+## Notes for implementing work-in-progress version
+
+This is a work-in-progress specification.
+
+Software implementing this work-in-progress specification MUST NOT use the
+unprefixed `metadata` capability name. Instead, implementations SHOULD
+use the `draft/metadata` capability name to be interoperable with other
+software implementing a compatible work-in-progress version.
+
+The final version of the specification will use an unprefixed capability name.
+
 ## Introduction
 
 It is generally useful to associate metadata with one's IRC presence, e.g. to
@@ -31,8 +43,7 @@ this purpose.
 
 All metadata subcommands will flow through the outgoing `METADATA` verb.
 
-This specification adds the `metadata-notify` capability for notifications.
-Please see the 'Metadata Notifications' section for more information.
+This specification adds the `metadata` capability.
 
 For the purposes of this specification, 'targets' are entities for which
 metadata may be set. Such entities MUST be a valid nickname or channel. As a
@@ -47,6 +58,16 @@ attempts with `ERR_KEYNOPERMISSION`.
 Implementations MAY provide a mechanism for limiting visibility of certain
 metadata to certain users. Such mechanism is implementation-defined;
 for instance, it may depend on some permission level or a flag.
+
+### Capability value
+
+The value of the `metadata` capability introduced in this document MUST
+have the following format:
+
+    [<anything>,]maxsub=<N>[,<anything>]`
+
+`<N>` is an integer indicating the maximum number of keys a client is allowed
+to be subscribed to.
 
 ### METADATA GET
 
@@ -134,6 +155,83 @@ using `ERR_KEYNOPERMISSION` with an asterisk (`*`) in the `<Key>` field.
 
 *Errors*: `ERR_KEYNOPERMISSION`
 
+### METADATA SUB
+
+This subcommand is used to subscribe to metadata keys.
+
+Syntax:
+
+    METADATA * SUB <key1> [<key2> ...]
+
+The server MUST reply with zero or more numerics of the following types in any
+order: `RPL_METADATASUBOK`, `ERR_KEYINVALID`, `ERR_KEYNOPERMISSION` and zero or
+one `ERR_METADATATOOMANYSUBS` numeric.
+The server MUST end the reply with one `RPL_METADATAEND` numeric.
+
+The server MUST process the keys in the given order. This is critical when
+determining which keys the client gets subscribed to in case the server limits
+the number of keys the client can subscribe to.
+
+If the client is subscribed to too many keys then the server MUST include a
+`ERR_METADATATOOMANYSUBS` numeric in its reply and not process any further keys
+in the command.
+
+If the client successfully subscribes to a key it is not subscribed to then the
+key MUST appear in a `RPL_METADATASUBOK` reply numeric.
+
+If the client tries to subscribe to a key it is already subscribed to then the
+client remains subscribed to the key. In case such a key is processed in a
+request the key MUST appear at least once in a `RPL_METADATASUBOK` numeric in
+the reply.
+
+Servers MUST respond to requests to subscribe to a key whose name is invalid
+with a `ERR_KEYINVALID` numeric.
+
+Servers MAY additionally respond to requests to subscribe to a key that the
+client has no privilege to access with a `ERR_KEYNOPERMISSION` numeric.
+Even if a server does that, the subscription MUST still be successful.
+This is because in this case the `ERR_KEYNOPERMISSION` numeric only serves as a
+warning, indicating that the client will not receive METADATA events about this
+key unless it acquires the necessary (implementation defined) privileges later.
+
+### METADATA UNSUB
+
+This subcommand is used to unsubscribe from metadata keys.
+
+Syntax:
+
+    METADATA * UNSUB <key1> [<key2> ...]
+
+The reply of the server MUST be zero or more numerics of the following types
+in any order: `RPL_METADATAUNSUBOK`, `ERR_KEYINVALID`.
+Then the server MUST end the reply with one `RPL_METADATAEND` numeric.
+
+If a client successfully unsubscribes from a key it is subscribed to then the
+key MUST appear in a `RPL_METADATAUNSUBOK` reply numeric.
+
+If a client tries to unsubscribe from a key that it is not subscribed to then
+the client remains not subscribed to the key and the key MUST appear at least
+once in a `RPL_METADATAUNSUBOK` numeric in the reply.
+
+Servers MUST respond to requests to subscribe to a key whose name is invalid
+with a `ERR_KEYINVALID` numeric.
+
+### METADATA SUBS
+
+This subcommand can be used to get a list of keys which the client is
+subscribed to.
+
+Syntax:
+
+    METADATA * SUBS
+
+The server MUST reply with zero or more `RPL_METADATASUBS` numerics and then
+one `RPL_METADATAEND` numeric.
+
+The replied `RPL_METADATASUBS` numerics, collectively, MUST contain all keys
+the client is subscribed to exactly once and MUST NOT contain keys the client
+is not subscribed to.
+
 ### METADATA SYNC
 
 This subcommand requests the full synchronization of metadata associated with
@@ -149,6 +247,50 @@ performed at this time.
 
 For details, please see the Postponed synchronization subsection of the
 Metadata notifications section.
+
+### RPL_METADATASUBS
+
+The order of the keys is undefined.
+
+### ERR_METADATATOOMANYSUBS
+
+The `<key>` parameter of this numeric is the first key that the client was not
+subscribed to.
+
+## Notification Mechanics (TODO merge with Metadata Notifications)
+
+A client can either be subscribed to a key, or not subscribed to it.
+
+The server MUST allow a client to subscribe to any valid keys, even to
+privileged keys when the client has no privilege to access that key at
+the time of subscription.
+
+If a client is subscribed to a metadata key and has adequate privileges to get
+notifications about that key then it gets METADATA events about the key as
+described [here](http://ircv3.net/specs/core/metadata-3.2.html#metadata-notifications).
+
+If a client is not subscribed to a metadata key then it will not get METADATA
+events about it, however the client can use `METADATA GET`, `METADATA LIST` or
+other means available to obtain the value of the key.
+
+By default, the client is not subscribed to any keys.
+
+Managing subscriptions are possible with the protocol described below.
+
+## Compatibility with `metadata-notify`
+
+It is pointless to use the new metadata notify cap described in this document
+and `metadata-notify` (as described in the [metadata v3.2 specification](http://ircv3.net/specs/core/metadata-3.2.html))
+together.
+
+This is because `metadata-notify` implicitly subscribes the client to all keys,
+while metadata notify v2 requires the client to tell the keys it wants to
+subscribe to.
+
+Servers and clients MAY support both of the mentioned extensions, but MUST NOT
+negotiate both of them at the same time in the same connection.
+
+If both are available, the new metadata notify cap SHOULD be used.
 
 ## Metadata Notifications
 
@@ -192,7 +334,7 @@ Metadata propagates to clients automatically under certain conditions:
 It can happen that a server needs to send a large number of `METADATA` events
 to a client due to the client subscribing to many targets at once.
 For example, this can happen if the client joins a large channel or when the
-client is already on some channels and turns on the `metadata-notify`
+client is already on some channels and turns on the `metadata`
 capability. In this case the server MAY choose to not propagate the metadata
 of the newly subscribed targets to the client when the join or when the
 `CAP REQ` happens, but send a `ERR_METADATASYNCLATER` numeric instead.
@@ -240,23 +382,26 @@ keys per-user; the format in that case MUST be `METADATA=<integer>`, where
 
 ## Numerics
 
-The numerics 760 through 769 and 774 and 775 MUST be reserved for metadata, carrying the
+The numerics 760 through 775 MUST be reserved for metadata, carrying the
 following labels and formats:
 
-| No. | Label                   | Format                                   |
-| --- | ----------------------- | ---------------------------------------- |
-| 760 | `RPL_WHOISKEYVALUE`     | `<Target> <Key> <Visibility> :<Value>`   |
-| 761 | `RPL_KEYVALUE`          | `<Target> <Key> <Visibility>[ :<Value>]` |
-| 762 | `RPL_METADATAEND`       | `:end of metadata`                       |
-| 764 | `ERR_METADATALIMIT`     | `<Target> :metadata limit reached`       |
-| 765 | `ERR_TARGETINVALID`     | `<Target> :invalid metadata target`      |
-| 766 | `ERR_NOMATCHINGKEY`     | `<Target> <Key> :no matching key`        |
-| 767 | `ERR_KEYINVALID`        | `<Key> :invalid metadata key`            |
-| 768 | `ERR_KEYNOTSET`         | `<Target> <Key> :key not set`            |
-| 769 | `ERR_KEYNOPERMISSION`   | `<Target> <Key> :permission denied`      |
-
-| 774 | `ERR_METADATASYNCLATER` | `<Target> [<RetryAfter>]`                |
-| 775 | `ERR_METADATARATELIMIT` | `<Target> <Key> <RetryAfter> :<Value>`   |
+| No. | Label                     | Format                                   |
+| --- | ------------------------- | ---------------------------------------- |
+| 760 | `RPL_WHOISKEYVALUE`       | `<Target> <Key> <Visibility> :<Value>`   |
+| 761 | `RPL_KEYVALUE`            | `<Target> <Key> <Visibility>[ :<Value>]` |
+| 762 | `RPL_METADATAEND`         | `:end of metadata`                       |
+| 764 | `ERR_METADATALIMIT`       | `<Target> :metadata limit reached`       |
+| 765 | `ERR_TARGETINVALID`       | `<Target> :invalid metadata target`      |
+| 766 | `ERR_NOMATCHINGKEY`       | `<Target> <Key> :no matching key`        |
+| 767 | `ERR_KEYINVALID`          | `:<InvalidKey>`                          |
+| 768 | `ERR_KEYNOTSET`           | `<Target> <Key> :key not set`            |
+| 769 | `ERR_KEYNOPERMISSION`     | `<Target> <Key> :permission denied`      |
+| 770 | `RPL_METADATASUBOK`       | `:<Key1> [<Key2> ...]`                   |
+| 771 | `RPL_METADATAUNSUBOK`     | `:<Key1> [<Key2> ...]`                   |
+| 772 | `RPL_METADATASUBS`        | `:<Key1> [<Key2> ...]`                   |
+| 773 | `ERR_METADATATOOMANYSUBS` | `<Key>`                                  |
+| 774 | `ERR_METADATASYNCLATER`   | `<Target> [<RetryAfter>]`                |
+| 775 | `ERR_METADATARATELIMIT`   | `<Target> <Key> <RetryAfter> :<Value>`   |
 
 The `<Visibility>` field for numerics follows the same rules and requirements
 as specified for notifications' visibility.
@@ -360,6 +505,254 @@ Client joins a channel, gets `ERR_METADATASYNCLATER` and requests a sync later
     S: :irc.example.com METADATA user152 bar * :dolor sit amet
 
     ...and many more metadata messages   
+
+
+## More Examples (TODO merge with previous)
+
+These examples show the labels of the numerics (e.g. `RPL_METADATASUBOK`)
+instead of their number (e.g. `775`) in order to aid understanding.
+In a real implementation, the messages always contain the number of numerics,
+not a label.
+
+All examples begin with the client not being subscribed to any keys.
+
+### Basic subscriping and unsubscribing
+
+    C: METADATA * SUB avatar website foo bar
+    S: :irc.example.com RPL_METADATASUBOK modernclient :avatar website foo bar
+    S: :irc.example.com RPL_METADATAEND modernclient :end of metadata
+    C: METADATA * UNSUB foo bar
+    S: :irc.example.com RPL_METADATAUNSUBOK modernclient :bar foo
+    S: :irc.example.com RPL_METADATAEND modernclient :end of metadata
+
+### Multiple `RPL_METADATASUBOK` numerics in reply to `METADATA SUB`
+
+    C: METADATA * SUB avatar website foo bar baz
+    S: :irc.example.com RPL_METADATASUBOK modernclient :avatar website
+    S: :irc.example.com RPL_METADATASUBOK modernclient :foo
+    S: :irc.example.com RPL_METADATASUBOK modernclient :bar baz
+    S: :irc.example.com RPL_METADATAEND modernclient :end of metadata
+
+### Invalid key name in reply to subscription
+
+    C: METADATA * SUB foo $url bar
+    S: :irc.example.com RPL_METADATASUBOK modernclient :foo bar
+    S: :irc.example.com ERR_KEYINVALID modernclient $url :invalid metadata key
+    S: :irc.example.com RPL_METADATAEND modernclient :end of metadata
+
+### "Subscribed to too many keys" error in reply to subscription 1
+
+The client first successfully subscribes to some keys and later it tries to
+subscribe to some more keys, unsuccessfully.
+
+    C: METADATA * SUB website avatar foo bar baz
+    S: :irc.example.com RPL_METADATASUBOK modernclient :website avatar foo bar baz
+    S: :irc.example.com RPL_METADATAEND modernclient :end of metadata
+    C: METADATA * SUB email city
+    S: :irc.example.com ERR_METADATATOOMANYSUBS modernclient email
+    S: :irc.example.com RPL_METADATAEND modernclient :end of metadata
+    C: METADATA * SUBS
+    S: :irc.example.com RPL_METADATASUBS modernclient :website avatar foo bar baz
+    S: :irc.example.com RPL_METADATAEND modernclient :end of metadata
+
+### "Subscribed to too many keys" error in reply to subscription 2
+
+This is like the previous case, except when the second METADATA SUB happens
+the server accepts the first 2 keys (`email`, `city`) but not the rest
+(`country`, `bar`, `baz`).
+
+    C: METADATA * SUB website avatar foo
+    S: :irc.example.com RPL_METADATASUBOK modernclient :website avatar foo
+    S: :irc.example.com RPL_METADATAEND modernclient :end of metadata
+    C: METADATA * SUB email city country bar baz
+    S: :irc.example.com ERR_METADATATOOMANYSUBS modernclient country
+    S: :irc.example.com RPL_METADATASUBOK modernclient :email city
+    S: :irc.example.com RPL_METADATAEND modernclient :end of metadata
+    C: METADATA * SUBS
+    S: :irc.example.com RPL_METADATASUBS modernclient :website avatar city foo email
+    S: :irc.example.com RPL_METADATAEND modernclient :end of metadata
+
+### "Subscribed to too many keys" error in reply to subscription 3
+
+In this case, the client is trying to subscribe to a key that it is already
+subscribed to (`website`), but the key is not processed because the limit
+imposed by the server on the number of subscribed keys is reached before the
+`website` key is processed by the server. The client, however, successfully
+subscribes to the `foo` key which was also in the second request, but it
+appeared before the `website` key.
+
+    C: METADATA * SUB avatar website
+    S: :irc.example.com RPL_METADATASUBOK modernclient :avatar website
+    S: :irc.example.com RPL_METADATAEND modernclient :end of metadata
+    C: METADATA * SUB foo website avatar
+    S: :irc.example.com ERR_METADATATOOMANYSUBS modernclient website
+    S: :irc.example.com RPL_METADATASUBOK modernclient :foo
+    S: :irc.example.com RPL_METADATAEND modernclient :end of metadata
+    C: METADATA * SUBS
+    S: :irc.example.com RPL_METADATASUBS modernclient :avatar foo website
+    S: :irc.example.com RPL_METADATAEND modernclient :end of metadata
+
+### Querying the list of subscribed keys 1
+
+The server replies with a single `RPL_METADATASUBS` numeric.
+
+    C: METADATA * SUB website avatar foo bar baz
+    S: :irc.example.com RPL_METADATASUBOK modernclient :website avatar foo bar baz
+    S: :irc.example.com RPL_METADATAEND modernclient :end of metadata
+    C: METADATA * SUBS
+    S: :irc.example.com RPL_METADATASUBS modernclient :avatar bar baz foo website
+    S: :irc.example.com RPL_METADATAEND modernclient :end of metadata
+
+### Querying the list of subscribed keys 2
+
+The server replies with multiple `RPL_METADATASUBS` numerics.
+
+    C: METADATA * SUB website avatar foo bar baz
+    S: :irc.example.com RPL_METADATASUBOK modernclient :website avatar foo bar baz
+    S: :irc.example.com RPL_METADATAEND modernclient :end of metadata
+    C: METADATA * SUBS
+    S: :irc.example.com RPL_METADATASUBS modernclient :avatar
+    S: :irc.example.com RPL_METADATASUBS modernclient :bar baz
+    S: :irc.example.com RPL_METADATASUBS modernclient :foo website
+    S: :irc.example.com RPL_METADATAEND modernclient :end of metadata
+
+### Empty list of subscribed keys
+
+In this case, there are no `RPL_METADATASUB` numerics sent.
+
+    C: METADATA * SUBS
+    S: :irc.example.com RPL_METADATAEND modernclient :end of metadata
+
+### Unsubscribing
+
+    C: METADATA * SUB website avatar foo bar baz
+    S: :irc.example.com RPL_METADATASUBOK modernclient :website avatar foo bar baz
+    S: :irc.example.com RPL_METADATAEND modernclient :end of metadata
+    C: METADATA * SUBS
+    S: :irc.example.com RPL_METADATASUBS modernclient :avatar bar baz foo website
+    S: :irc.example.com RPL_METADATAEND modernclient :end of metadata
+    C: METADATA * UNSUB bar foo baz
+    S: :irc.example.com RPL_METADATAUNSUBOK modernclient :baz foo bar
+    S: :irc.example.com RPL_METADATAEND modernclient :end of metadata
+    C: METADATA * SUBS
+    S: :irc.example.com RPL_METADATASUBS modernclient :avatar website
+    S: :irc.example.com RPL_METADATAEND modernclient :end of metadata
+
+### Subscribing to the same key multiple times 1
+
+    C: METADATA * SUB website avatar foo bar baz
+    S: :irc.example.com RPL_METADATASUBOK modernclient :website avatar foo bar baz
+    S: :irc.example.com RPL_METADATAEND modernclient :end of metadata
+    C: METADATA * SUBS
+    S: :irc.example.com RPL_METADATASUBS modernclient :avatar bar baz foo website
+    S: :irc.example.com RPL_METADATAEND modernclient :end of metadata
+    C: METADATA * SUB avatar website
+    S: :irc.example.com RPL_METADATASUBOK modernclient :avatar website
+    S: :irc.example.com RPL_METADATAEND modernclient :end of metadata
+    C: METADATA * SUBS
+    S: :irc.example.com RPL_METADATASUBS modernclient :avatar bar baz foo website
+    S: :irc.example.com RPL_METADATAEND modernclient :end of metadata
+
+### Subscribing to the same key multiple times 2
+
+The client (erroneously) subscribes to the same key twice in the same command.
+The server is free to include the key being subscribed to in the
+`RPL_METADATASUBOK` numeric once or twice.
+
+In both cases, the key will only appear once in the reply to a following
+`METADATA SUBS` command.
+
+Once:
+
+    C: METADATA * SUB avatar avatar
+    S: :irc.example.com RPL_METADATASUBOK modernclient :avatar
+    S: :irc.example.com RPL_METADATAEND modernclient :end of metadata
+    C: METADATA * SUBS
+    S: :irc.example.com RPL_METADATASUBS modernclient :avatar
+    S: :irc.example.com RPL_METADATAEND modernclient :end of metadata
+
+Twice:
+
+    C: METADATA * SUB avatar avatar
+    S: :irc.example.com RPL_METADATASUBOK modernclient :avatar avatar
+    S: :irc.example.com RPL_METADATAEND modernclient :end of metadata
+    C: METADATA * SUBS
+    S: :irc.example.com RPL_METADATASUBS modernclient :avatar
+    S: :irc.example.com RPL_METADATAEND modernclient :end of metadata
+
+### Unsubscribing from a non-subscribed key 1
+
+    C: METADATA * SUBS
+    S: :irc.example.com RPL_METADATAEND modernclient :end of metadata
+    C: METADATA * UNSUB website
+    S: :irc.example.com RPL_METADATAUNSUBOK modernclient :website
+    S: :irc.example.com RPL_METADATAEND modernclient :end of metadata
+    C: METADATA * SUBS
+    S: :irc.example.com RPL_METADATAEND modernclient :end of metadata
+    C: METADATA * SUB website
+    S: :irc.example.com RPL_METADATASUBOK modernclient :website
+    S: :irc.example.com RPL_METADATAEND modernclient :end of metadata
+    C: METADATA * SUBS
+    S: :irc.example.com RPL_METADATASUBS modernclient :website
+    S: :irc.example.com RPL_METADATAEND modernclient :end of metadata
+
+### Unsubscribing from a non-subscribed key 2
+
+The client (erroneously) unsubscribes from the same key twice in the same
+command. The server is free to include the key being unsubscribed from in the
+`RPL_METADATAUNSUBOK` numeric once or twice.
+
+Once:
+
+    C: METADATA * SUBS
+    S: :irc.example.com RPL_METADATASUBS modernclient :website
+    S: :irc.example.com RPL_METADATAEND modernclient :end of metadata
+    C: METADATA * UNSUB website website
+    S: :irc.example.com RPL_METADATAUNSUBOK modernclient :website
+    S: :irc.example.com RPL_METADATAEND modernclient :end of metadata
+
+Twice:
+
+    C: METADATA * SUBS
+    S: :irc.example.com RPL_METADATASUBS modernclient :website
+    S: :irc.example.com RPL_METADATAEND modernclient :end of metadata
+    C: METADATA * UNSUB website website
+    S: :irc.example.com RPL_METADATAUNSUBOK modernclient :website website
+    S: :irc.example.com RPL_METADATAEND modernclient :end of metadata
+
+### Subscribing to a key which requires privileges but without privileges
+
+    C: METADATA * SUB avatar secretkey website
+    S: :irc.example.com ERR_KEYNOPERMISSION modernclient modernclient secretkey :permission denied
+    S: :irc.example.com RPL_METADATASUBOK modernclient :secretkey website
+    S: :irc.example.com RPL_METADATAEND modernclient :end of metadata
+    C: METADATA * SUBS
+    S: :irc.example.com RPL_METADATASUBS modernclient :secretkey website
+    S: :irc.example.com RPL_METADATAEND modernclient :end of metadata
+
+### Subscribing to invalid keys and a key which requires privileges but without privileges
+
+    C: METADATA * SUB $invalid1 secretkey1 $invalid2 secretkey2 website
+    S: :irc.example.com ERR_KEYNOPERMISSION modernclient modernclient secretkey1 :permission denied
+    S: :irc.example.com ERR_KEYINVALID modernclient $invalid1 :invalid metadata key
+    S: :irc.example.com ERR_KEYNOPERMISSION modernclient modernclient secretkey2 :permission denied
+    S: :irc.example.com ERR_KEYINVALID modernclient $invalid2 :invalid metadata key
+    S: :irc.example.com RPL_METADATASUBOK modernclient :secretkey1 secretkey2 website
+    S: :irc.example.com RPL_METADATAEND modernclient :end of metadata
+    C: METADATA * SUBS
+    S: :irc.example.com RPL_METADATASUBS modernclient :secretkey1 secretkey2 website
+    S: :irc.example.com RPL_METADATAEND modernclient :end of metadata
+
+### Capability value in `CAP LS` 1 
+
+    C: CAP LS 302
+    S: CAP * LS :userhost-in-names draft/metadata=foo,maxsub=50,bar multi-prefix
+
+### Capability value in `CAP LS` 2
+
+    C: CAP LS 302
+    S: CAP * LS :draft/metadata=maxsub=25 multi-prefix invite-notify
+
 
 ### Non-normative
 

--- a/core/metadata-3.2.md
+++ b/core/metadata-3.2.md
@@ -281,6 +281,9 @@ If the client is subscribed to too many keys then the server MUST include a
 `ERR_METADATATOOMANYSUBS` numeric in its reply and not process any further keys
 in the command.
 
+The `<key>` parameter of this numeric is the first key that the client was not
+subscribed to.
+
 If the client successfully subscribes to a key it is not subscribed to then the
 key MUST appear in a `RPL_METADATASUBOK` reply numeric.
 
@@ -337,6 +340,8 @@ The replied `RPL_METADATASUBS` numerics, collectively, MUST contain all keys
 the client is subscribed to exactly once and MUST NOT contain keys the client
 is not subscribed to.
 
+The order of the keys is undefined.
+
 ### METADATA SYNC
 
 This subcommand requests the full synchronization of metadata associated with
@@ -352,15 +357,6 @@ performed at this time.
 
 For details, please see the Postponed synchronization subsection of the
 Metadata notifications section.
-
-### RPL_METADATASUBS
-
-The order of the keys is undefined.
-
-### ERR_METADATATOOMANYSUBS
-
-The `<key>` parameter of this numeric is the first key that the client was not
-subscribed to.
 
 ## Notification Mechanics (TODO merge with Metadata Notifications)
 

--- a/core/metadata-3.2.md
+++ b/core/metadata-3.2.md
@@ -166,7 +166,9 @@ Errors:
 
 ### Keys and values
 
-Keys MUST be restricted to the ranges `A-Z`, `a-z`, `0-9`, and `_.:-` and are case-insensitive. Values are unrestricted, except that they MUST be UTF-8.
+Key names MUST be restricted to the ranges `A-Z`, `a-z`, `0-9`, and `_.:-` and are case-insensitive. Key names MUST not start with a colon (`:`).
+
+Values are unrestricted, except that they MUST be encoded using UTF-8.
 
 The expected client behaviour of individual metadata keys SHOULD be defined in separate specifications and listed in the IRCv3 extension registry.
 

--- a/core/metadata-3.2.md
+++ b/core/metadata-3.2.md
@@ -53,11 +53,13 @@ This document defines the following new protocol features:
 
 The `metadata` capability and value indicates that a server supports metadata, and communicates any configuration value keys that may affect the level of support.
 
-The ABNF format of the `metadata` capability and value is: (TODO verify ABNF)
+The ABNF format of the `metadata` capability and value is:
 
-    capability ::= 'metadata' ['=' value]
-    value      ::= value_item [',' value_item]*
-    value_item ::= ( 'maxsub=' integer ) |  ( 'maxkey=' integer )
+    capability ::= 'metadata' ['=' tokens]
+    tokens     ::= token [',' token]*
+    token      ::= key ['=' value]
+    key        ::= <sequence of a-zA-Z0-9_.:- >
+    value      ::= <utf8>
 
 The value keys are defined as follows:
 

--- a/core/metadata-3.2.md
+++ b/core/metadata-3.2.md
@@ -95,7 +95,7 @@ Servers MUST respond to requests to remove a key that has a valid name but is
 not set with only an `ERR_KEYNOTSET` event and fail the request.
 
 Servers MAY respond to certain keys, considered not settable by the requesting
-user, with `ERR_KEYNOPERMISSION`.
+user, or otherwise disallowed by the server, with `ERR_KEYNOPERMISSION`.
 
 It is an error for users to set keys on targets for which they lack
 authorization from the server, and the server MUST respond with

--- a/core/metadata-3.2.md
+++ b/core/metadata-3.2.md
@@ -293,7 +293,7 @@ Setting metadata for an invalid target:
 Setting metadata with an invalid key:
 
     METADATA user1 SET $url$ :http://www.example.com
-    :irc.example.com 767 $url$ :invalid metadata key
+    :irc.example.com 767 $url$
 
 Listing metadata, with an implementation-defined visibility field:
 

--- a/core/metadata-3.2.md
+++ b/core/metadata-3.2.md
@@ -82,13 +82,13 @@ The format of the `METADATA` server notication is:
 
     METADATA <Target> <Key> <Visibility> <Value>
 
-`Target` MUST be any valid nickname or channel name.
+`Target` MUST be a valid nickname or channel name.
 
 `Key` MUST be a valid key name
 
 `Visibility` MUST be an asterisk (`*`) for keys visible to everyone, or an implementation-defined value which describes the key's visibility status; for instance, it MAY be a permission level or flag. (TODO should we define a prefix like STATUSMSG for this value?)
 
-`Value` MUST be any UTF-8 encoded value.
+`Value` MUST be a UTF-8 encoded value.
 
 ### Client command
 
@@ -96,7 +96,7 @@ The format of the `METADATA` client command is:
 
     METADATA <Target> <Subcommand> [<Param 1> ... [<Param n>]]
 
-`Target` MUST be any valid nickname or channel name. Clients MAY use the asterisk symbol (`*`) when targeting their own nickname.
+`Target` MUST be a valid nickname or channel name. Clients MAY use the asterisk symbol (`*`) when targeting their own nickname.
 
 `Subcommand` MUST be one of the following, described in detail along with any `Param` further in the document:
 

--- a/core/metadata-3.2.md
+++ b/core/metadata-3.2.md
@@ -277,6 +277,9 @@ By default, the client is not subscribed to any keys.
 
 Managing subscriptions are possible with the protocol described below.
 
+Clients MUST handle the case where a metadata notification is sent even if they
+haven't subscribed to any key.
+
 ## Compatibility with `metadata-notify`
 
 It is pointless to use the new metadata notify cap described in this document

--- a/core/metadata-3.2.md
+++ b/core/metadata-3.2.md
@@ -131,7 +131,7 @@ The following numerics 760 through 775 are reserved for metadata, with these lab
 | 774 | `ERR_METADATASYNCLATER`   | `<Target> [<RetryAfter>]`                |
 | 775 | `ERR_METADATARATELIMIT`   | `<Target> <Key> <RetryAfter> :<Value>`   |
 
-Reference table listing which subcommands of `METADATA` or any other commands that produce these numerics:
+Reference table of numerics and the subcommands of `METADATA` or any other commands that produce them:
 
 | Label                     | GET | LIST | SET | CLEAR | SUB | UNSUB | SUBS | SYNC | Other   |
 | ------------------------- | --- | ---- | --- | ----- | --- | ----- | ---- | ---- | ------- |

--- a/core/metadata-3.2.md
+++ b/core/metadata-3.2.md
@@ -212,7 +212,7 @@ the client SHOULD wait before sending the `METADATA SYNC` request for the
 
 ## Metadata Restrictions
 
-Keys MUST be restricted to the ranges `A-Z`, `a-z`, `0-9`, and `_.:`, and are
+Keys MUST be restricted to the ranges `A-Z`, `a-z`, `0-9`, and `_.:-` and are
 case-insensitive. Values are unrestricted, except that they MUST be UTF-8.
 Server and client authors cannot assume that keys will carry specific
 formatting or meaning.


### PR DESCRIPTION
This is a work in progress. Currently representing the changes from #245 and #250. This can probably replace those issues.

This still needs massaging and editing, some things might be in a weird order, BUT this should contain everything you need to implement the updated metadata spec and matches what we've implemented in IRCCloud.

The best way to improve this spec is to try implementing it now, rather than wait for it to be finished. That way we can identify any issues and fix them.

This will eventually exist at a new URL, without 3.2 in it, and probably without errata, but not renaming it for now to allow a degree of diff readability,

Here are the TODO items from #250 (most of which are done)

* [ ] #278 Additional non-normative sections
* [ ] Allow ordered but async processing of requests (database storage, etc)
* [x] Update numerics to match [inspircd implementation](https://github.com/inspircd/inspircd/blob/3d52a33d3c650292b33825ce3458456790149caa/src/modules/m_ircv3_metadata.cpp#L35-L39)
* [x] Rewrite to include the parts of 3.2 that still apply, clarifying if necessary and mention that 3.2 is deprecated (see #279)
* [x] Add a requirement that clients should expect to receive notifications even if they haven't subscribed to any key, e.g. if a server needs to update a client's own metadata, e.g. on oper, or auth, or if an oper sets a key on another user.
* [x] Drop the 3.3 versioning. (see #265)
* [x] Change ERR_KEYINVALID to drop the message reason and include the invalid key as the last arg since it could contain spaces
* [x] Clarify ERR_KEYNOPERMISSION to expand "not settable by the requesting user" with "or otherwise disallowed by the server"
* [x] Allow hyphens in key names
* [x] Rename CAP to just `metadata` (no need for version number, values are about more than notifications)
* [ ] Possibly specify a cap value that advertises a limit of key and/or value names instead of ISUPPORT?
