### PR TITLE
Add `chathistory` to the list of batch types

### DIFF
--- a/extensions/batch-3.2.md
+++ b/extensions/batch-3.2.md
@@ -81,6 +81,7 @@ To submit a new batch type please follow the extension submission procedure
 [found here](/participation.html).
 
  * [IRC Version 3.2: `netsplit` and `netjoin`](batch/netsplit-3.2.html)
+ * [IRC Version 3.3: `chathistory`](batch/chathistory-3.3.html)
 
 ## Examples
 


### PR DESCRIPTION
This is a small fix to add a link to the `chathistory` page onto the `batch` extension page.