### PR TITLE
Clarify that all `CAP` command replies can be multi-line

### DIFF
--- a/core/capability-negotiation.md
+++ b/core/capability-negotiation.md
@@ -220,7 +220,7 @@ As an overview, these are the new features introduced with each `CAP LS` version
 | CAP | Name | Description |
 | --- | ---- | ----------- |
 | `302` | Capability values | Additional data with each capability name when advertised in `CAP LS` and `CAP NEW`. |
-| `302` | Multiline replies | `CAP LS` and `CAP LIST` can be split across multiple lines, with a minor syntax change that allows clients to wait for the last message and process them together. |
+| `302` | Multiline replies | All `CAP` command replies can be split across multiple lines, with a minor syntax change that allows clients to wait for the last message and process them together. |
 | `302` | `cap-notify` | This capability is enabled implicitly with `302`, and adds the `CAP NEW` and `CAP DEL` messages which let the client know about added and removed capabilities. |
 
 #### Capability Values


### PR DESCRIPTION
As suggested in the third paragraph here https://github.com/ircv3/ircv3-specifications/blob/f06aa95a/core/capability-negotiation.md#the-cap-ack-subcommand...

> If an ACK reply originating from the server is spread across multiple lines, a client MUST NOT change capabilities until the last ACK of the set is received. Equally, a server MUST NOT change the capabilities of the client until the last ACK of the set has been sent.

`CAP ACK` lines can be split across multiple lines, suggesting it behaves similarly to `CAP LS` and `CAP LIST` which would also mean `CAP NACK` would behave this way and it would make sense that `CAP NEW` would too.