### PR TITLE
SETNAME Spec

### DIFF
--- a/extensions/setname.md
+++ b/extensions/setname.md
@@ -73,3 +73,25 @@ modified to support it. The proper way to do so is this:
 
 2) Update the realname portion of data structures and process channel users as
    appropriate.
+
+## Examples
+
+**Client-to-Server**
+
+Complex realname with spaces
+
+    SETNAME :Bruce Wayne <bruce@wayne.enterprises>
+    
+Simple Realname
+
+    SETNAME Batman
+
+**Server-to-Client**
+
+Complex realname with spaces
+
+    :batman@~batman!bat.cave SETNAME :Bruce Wayne <bruce@wayne.enterprises>
+    
+Simple Realname
+
+    :batman@~batman!bat.cave SETNAME Batman

--- a/extensions/setname.md
+++ b/extensions/setname.md
@@ -44,11 +44,11 @@ negotiation time.
 When enabled, clients are allowed to send a `SETNAME` message to notify servers
 of their intent to update their realname.
 
-This client-to-server `SETNAME` message looks as follows:
+This client-to-server `SETNAME` coammdn looks as follows:
 
     SETNAME :realname goes here
 
-This message represents the intent to change the realname. The only, trailing
+This coammdn represents the intent to change the realname. The only, trailing
 parameter is the new realname. Until the server confirms this change, the
 client MUST assume that no change has happened yet.
 

--- a/extensions/setname.md
+++ b/extensions/setname.md
@@ -22,23 +22,17 @@ The final version of the specification will use an unprefixed capability name.
 
 ## Motivation
 
-Realnames have historically been immutable. This has never been much of an
-issue, as they were rarely used and usually not as present in client UIs.
-Still, multiple IRCds have provided independent, non-standard
-commands to update realnames.
-
-Nowadays, this has changed. Multiple clients show realnames directly in chat
-(e.g. next to the nickname) or use information from the realname to provide
-user-visible enhancements (e.g. using emails in the realname to provide
-gravatar based avatars).
-
-Due to this, the ability to change the realname has become relevant.
+Historically, a user's realname could only be set on the initial connection
+handshake. However, multiple IRC servers have provided independent non-standard
+commands to update the realname without reconnecting. This specification
+describes a standardised behaviour based on these existing implementations.
 
 ## Description
 
 The `draft/setname` client capability allows clients to change their realname
-(GECOS) on an active connection. It also allows servers to directly inform clients about such a change.
-This avoids a client reconnect when updating this value. 
+(GECOS) on an active connection. It also allows servers to directly inform
+clients about such a change.
+This avoids a client reconnect when updating this value.
 
 This capability MUST be referred to as `draft/setname` at capability
 negotiation time.
@@ -66,7 +60,8 @@ change.
 Servers MUST check the realname for validity (taking length limits into
 consideration). If they accept the realname change, they MUST send the
 server-to-client version of the `SETNAME` message to all clients in common
-channels, as well as to the client from which it originated, to confirm the change has occurred.
+channels, as well as to the client from which it originated, to confirm the
+change has occurred.
 
 The `SETNAME` message MUST NOT be sent to clients which do not have the
 `draft/setname` capability negotiated.
@@ -85,21 +80,22 @@ modified to support it. The proper way to do so is this:
 1) Enable the `draft/setname` capability at capability negotiation time during
    the login handshake.
 
-2) On receipt of a server-to-client `SETNAME` message, update the realname portion of data structures and process channel users as
-   appropriate.
+2) On receipt of a server-to-client `SETNAME` message, update the realname
+   portion of data structures and process channel users as appropriate.
 
 ## Errors
 
-The server MUST use the standard replies extension to notify the client of failed `SETNAME`
-commands.
+The server MUST use the standard replies extension to notify the client of
+failed `SETNAME` commands.
 
-If the server rejects the realname as a result of a validation failure, it MUST send a `FAIL`
-message with the `INVALID_REALNAME` code.
+If the server rejects the realname as a result of a validation failure, it MUST
+send a `FAIL` message with the `INVALID_REALNAME` code.
 
     FAIL SETNAME INVALID_REALNAME :Realname is not valid
-    
+
 If the server rejects the change for any other reason, it MUST send a `FAIL`
-message with the `CANNOT_CHANGE_REALNAME` code and an appropriate description of the reason:
+message with the `CANNOT_CHANGE_REALNAME` code and an appropriate description of
+the reason:
 
     FAIL SETNAME CANNOT_CHANGE_REALNAME :Slow down your realname changes
     FAIL SETNAME CANNOT_CHANGE_REALNAME :Cannot change realname while banned from a channel
@@ -109,14 +105,14 @@ message with the `CANNOT_CHANGE_REALNAME` code and an appropriate description of
 Complex realname with spaces
 
     C: SETNAME :Bruce Wayne <bruce@wayne.enterprises>
-    S: :batman@~batman!bat.cave SETNAME :Bruce Wayne <bruce@wayne.enterprises> 
-    
+    S: :batman@~batman!bat.cave SETNAME :Bruce Wayne <bruce@wayne.enterprises>
+
 Simple realname
 
     C: SETNAME Batman
     S: :batman@~batman!bat.cave SETNAME Batman
-    
+
 Example with realname rejected by the server
 
     C: SETNAME :Heute back ich, morgen brau ich, übermorgen hol ich der Königin ihr Kind; ach, wie gut, dass niemand weiß, dass ich Rumpelstilzchen heiß!
-    S: FAIL SETNAME INVALID_REALNAME :Realname is not valid 
+    S: FAIL SETNAME INVALID_REALNAME :Realname is not valid

--- a/extensions/setname.md
+++ b/extensions/setname.md
@@ -85,7 +85,7 @@ modified to support it. The proper way to do so is this:
 1) Enable the `draft/setname` capability at capability negotiation time during
    the login handshake.
 
-2) Update the realname portion of data structures and process channel users as
+2) On receipt of a server-to-client `SETNAME` message, update the realname portion of data structures and process channel users as
    appropriate.
 
 ## Errors

--- a/extensions/setname.md
+++ b/extensions/setname.md
@@ -93,7 +93,7 @@ modified to support it. The proper way to do so is this:
 The server MUST use the standard replies extension to notify the client of failed `SETNAME`
 commands.
 
-If the server rejects the realname due to invalidity, it MUST send a FAIL
+If the server rejects the realname as a result of a validation failure, it MUST send a `FAIL`
 message of the following format:
 
     FAIL SETNAME INVALID_REALNAME :Realname is not valid

--- a/extensions/setname.md
+++ b/extensions/setname.md
@@ -42,9 +42,10 @@ This avoids clients having to actually disconnect and reconnect.
 This capability MUST be referred to as `draft/setname` at capability
 negotiation time.
 
-When enabled, clients are allowed to send a `SETNAME` command to notify servers
-of their intent to update their realname. They SHOULD not send it otherwise, as
-they can not reliably ensure that the server will understand it.
+When advertised by the server, clients are allowed to send a `SETNAME` command
+to notify servers of their intent to update their realname. They SHOULD not
+send it otherwise, as they can not reliably ensure that the server will
+understand it.
 
 If a client sends a `SETNAME` command without having negotiated the capability,
 the server SHOULD handle it silently, as the historic implementations did.

--- a/extensions/setname.md
+++ b/extensions/setname.md
@@ -98,7 +98,7 @@ message of the following format:
 
     FAIL SETNAME INVALID_REALNAME :Realname is not valid
     
-If the server rejects the change for any other reason, it MUST send a FAIL
+If the server rejects the change for any other reason, it MUST send a `FAIL`
 message indicating this:
 
     FAIL SETNAME CANNOT_CHANGE_REALNAME :Slow down your realname changes

--- a/extensions/setname.md
+++ b/extensions/setname.md
@@ -85,7 +85,7 @@ modified to support it. The proper way to do so is this:
 
 ## Errors
 
-The server MUST use the standard replies extension to notify the client of
+The server MUST use the [standard replies extension][1] to notify the client of
 failed `SETNAME` commands.
 
 If the server rejects the realname as a result of a validation failure, it MUST
@@ -116,3 +116,5 @@ Example with realname rejected by the server
 
     C: SETNAME :Heute back ich, morgen brau ich, übermorgen hol ich der Königin ihr Kind; ach, wie gut, dass niemand weiß, dass ich Rumpelstilzchen heiß!
     S: FAIL SETNAME INVALID_REALNAME :Realname is not valid
+
+[1]: https://github.com/ircv3/ircv3-specifications/pull/357

--- a/extensions/setname.md
+++ b/extensions/setname.md
@@ -38,7 +38,7 @@ Due to this, the ability to change the realname has become relevant.
 
 The `draft/setname` client capability allows clients to change their realname
 (GECOS) on an active connection. It also allows servers to directly inform clients about such a change.
-This avoids clients having to actually disconnect and reconnect. 
+This avoids a client reconnect when updating this value. 
 
 This capability MUST be referred to as `draft/setname` at capability
 negotiation time.

--- a/extensions/setname.md
+++ b/extensions/setname.md
@@ -21,22 +21,23 @@ The final version of the specification will use an unprefixed tag name.
 
 ## Motivation
 
-Realnames have historically been immutable for a connection, which has
-historically been accepted, as they were rarely used and usually not as present
-in client UIs. Still, multiple IRCds have provided independent, non-standard
+Realnames have historically been immutable. This has never been much of an
+issue, as they were rarely used and usually not as present in client UIs.
+Still, multiple IRCds have provided independent, non-standard
 commands to update realnames.
 
-Nowadays, multiple clients show realnames directly in chat, next to the nick
-name, or use information from the realname to provide enhancements, such as
-using emails in the realname to provide gravatar based avatars, leading to
-higher demand for this functionality than ever.
+Nowadays, this has changed. Multiple clients show realnames directly in chat
+(e.g. next to the nickname) or use information from the realname to provide
+user-visible enhancements (e.g. using emails in the realname to provide
+gravatar based avatars).
+
+Due to this, the ability to change the realname has become relevant.
 
 ## Description
 
 The `draft/setname` client capability allows clients to change their realname
-(GECOS) as well as allowing servers to directly inform clients about such a
-change without having to send a fake quit and join and without clients having
-to actually disconnect and reconnect. 
+(GECOS). It also allows servers to directly inform clients about such a change.
+This avoids clients having to actually disconnect and reconnect. 
 
 This capability MUST be referred to as `draft/setname` at capability
 negotiation time.
@@ -53,9 +54,12 @@ parameter is the new realname. Until the server confirms this change, the
 client MUST assume that no change has happened yet.
 
 Servers MUST check the realname for validity (taking length limits into
-consideration) and, if they apply the realname change, MUST send the
+consideration). If they accept the realname change, they MUST send the
 server-to-client version of the `SETNAME` message to all clients in common
 channels, as well as to the client from which it originated.
+
+The `SETNAME` message MUST NOT be sent to clients which do not have the
+`draft/setname` capability negotiated.
 
 This server-to-client `SETNAME` message looks as follows:
 
@@ -74,24 +78,35 @@ modified to support it. The proper way to do so is this:
 2) Update the realname portion of data structures and process channel users as
    appropriate.
 
+## Errors
+
+The server MUST use the FAIL spec to notify the client of failed `SETNAME`
+commands.
+
+If the server rejects the realname due to invalidity, it MUST send a FAIL
+message of the following format:
+
+    FAIL SETNAME INVALID_REALNAME :Realname is not valid
+    
+If the server rejects the change for any other reason, it MUST send a FAIL
+message indicating this:
+
+    FAIL SETNAME CANNOT_CHANGE_REALNAME :Slow down your realname changes
+    FAIL SETNAME CANNOT_CHANGE_REALNAME :Cannot change realname while banned from a channel
+
 ## Examples
 
-**Client-to-Server**
-
 Complex realname with spaces
 
-    SETNAME :Bruce Wayne <bruce@wayne.enterprises>
+    C: SETNAME :Bruce Wayne <bruce@wayne.enterprises>
+    S: :batman@~batman!bat.cave SETNAME :Bruce Wayne <bruce@wayne.enterprises> 
     
-Simple Realname
+Simple realname
 
-    SETNAME Batman
-
-**Server-to-Client**
-
-Complex realname with spaces
-
-    :batman@~batman!bat.cave SETNAME :Bruce Wayne <bruce@wayne.enterprises>
+    C: SETNAME Batman
+    S: :batman@~batman!bat.cave SETNAME Batman
     
-Simple Realname
+Example with realname rejected by the server
 
-    :batman@~batman!bat.cave SETNAME Batman
+    C: SETNAME :Heute back ich, morgen brau ich, übermorgen hol ich der Königin ihr Kind; ach, wie gut, dass niemand weiß, dass ich Rumpelstilzchen heiß!
+    S: FAIL SETNAME INVALID_REALNAME :Realname is not valid 

--- a/extensions/setname.md
+++ b/extensions/setname.md
@@ -45,6 +45,9 @@ negotiation time.
 When enabled, clients are allowed to send a `SETNAME` command to notify servers
 of their intent to update their realname.
 
+If a client sends a `SETNAME` command without having negotiated the capability,
+the server SHOULD handle it silently, as the historic implementations did.
+
 This client-to-server `SETNAME` command looks as follows:
 
     SETNAME :realname goes here

--- a/extensions/setname.md
+++ b/extensions/setname.md
@@ -46,6 +46,11 @@ Servers advertising the `draft/setname` capability MUST implement the command
 as specified here, and MUST support usage of the command even while the
 capability is not negotiated.
 
+Servers advertising the capability MUST also provide a `NAMELEN` token in
+`RPL_ISUPPORT` with the maximum allowed length for realnames. They MUST NOT
+apply a different maximum allowed length than the one advertised in
+`RPL_ISUPPORT`.
+
 If a client sends a `SETNAME` command without having negotiated the capability,
 the server SHOULD handle it silently, as the historic implementations did.
 

--- a/extensions/setname.md
+++ b/extensions/setname.md
@@ -41,14 +41,14 @@ to actually disconnect and reconnect.
 This capability MUST be referred to as `draft/setname` at capability
 negotiation time.
 
-When enabled, clients are allowed to send a `SETNAME` message to notify servers
+When enabled, clients are allowed to send a `SETNAME` command to notify servers
 of their intent to update their realname.
 
-This client-to-server `SETNAME` coammdn looks as follows:
+This client-to-server `SETNAME` command looks as follows:
 
     SETNAME :realname goes here
 
-This coammdn represents the intent to change the realname. The only, trailing
+This command represents the intent to change the realname. The only, trailing
 parameter is the new realname. Until the server confirms this change, the
 client MUST assume that no change has happened yet.
 

--- a/extensions/setname.md
+++ b/extensions/setname.md
@@ -43,7 +43,7 @@ This capability MUST be referred to as `draft/setname` at capability
 negotiation time.
 
 When advertised by the server, clients are allowed to send a `SETNAME` command
-to notify servers of their intent to update their realname. They SHOULD not
+to notify servers of their intent to update their realname. They SHOULD NOT
 send it otherwise, as they can not reliably ensure that the server will
 understand it.
 

--- a/extensions/setname.md
+++ b/extensions/setname.md
@@ -42,18 +42,8 @@ This avoids clients having to actually disconnect and reconnect.
 This capability MUST be referred to as `draft/setname` at capability
 negotiation time.
 
-Servers advertising the `draft/setname` capability MUST implement the command
-as specified here, and MUST support usage of the command even while the
-capability is not negotiated.
-
-Servers advertising the capability MUST also provide a `NAMELEN` token in
-`RPL_ISUPPORT` with the maximum allowed length for realnames.
-
-If a client sends a `SETNAME` command without having negotiated the capability,
-the server SHOULD handle it silently, as the historic implementations did.
-
-Absence of this capability MUST NOT cause the client to prevent the user from
-sending this command.
+When enabled, servers MUST provide a `NAMELEN` token in `RPL_ISUPPORT` with the
+maximum allowed length for realnames.
 
 This client-to-server `SETNAME` command looks as follows:
 

--- a/extensions/setname.md
+++ b/extensions/setname.md
@@ -60,7 +60,7 @@ The client-to-server `SETNAME` command looks as follows:
 
 This command represents the intent to change the realname. The only, trailing
 parameter is the new realname. If the capability is negotiated, the client
-MUST assume that no change has happened yet until the server confirms this
+MUST assume that no change has happened until the server confirms this
 change.
 
 Servers MUST check the realname for validity (taking length limits into

--- a/extensions/setname.md
+++ b/extensions/setname.md
@@ -42,13 +42,15 @@ This avoids clients having to actually disconnect and reconnect.
 This capability MUST be referred to as `draft/setname` at capability
 negotiation time.
 
-When advertised by the server, clients are allowed to send a `SETNAME` command
-to notify servers of their intent to update their realname. They SHOULD NOT
-send it otherwise, as they can not reliably ensure that the server will
-understand it.
+Servers advertising the `draft/setname` capability MUST implement the command
+as specified here, and MUST support usage of the command even while the
+capability is not negotiated.
 
 If a client sends a `SETNAME` command without having negotiated the capability,
 the server SHOULD handle it silently, as the historic implementations did.
+
+Absence of this capability MUST NOT cause the client to prevent the user from
+sending this command.
 
 This client-to-server `SETNAME` command looks as follows:
 

--- a/extensions/setname.md
+++ b/extensions/setname.md
@@ -1,5 +1,5 @@
 ---
-title: IRCv3 `setname` Extension
+title: IRCv3 setname Extension
 layout: spec
 copyrights:
   -

--- a/extensions/setname.md
+++ b/extensions/setname.md
@@ -94,7 +94,7 @@ The server MUST use the standard replies extension to notify the client of faile
 commands.
 
 If the server rejects the realname as a result of a validation failure, it MUST send a `FAIL`
-message of the following format:
+message with the `INVALID_REALNAME` code.
 
     FAIL SETNAME INVALID_REALNAME :Realname is not valid
     

--- a/extensions/setname.md
+++ b/extensions/setname.md
@@ -90,7 +90,7 @@ modified to support it. The proper way to do so is this:
 
 ## Errors
 
-The server MUST use the FAIL spec to notify the client of failed `SETNAME`
+The server MUST use the standard replies extension to notify the client of failed `SETNAME`
 commands.
 
 If the server rejects the realname due to invalidity, it MUST send a FAIL

--- a/extensions/setname.md
+++ b/extensions/setname.md
@@ -1,5 +1,5 @@
 ---
-title: IRCv3 setname Extension
+title: IRCv3 `setname` Extension
 layout: spec
 copyrights:
   -

--- a/extensions/setname.md
+++ b/extensions/setname.md
@@ -1,6 +1,7 @@
 ---
 title: IRCv3 `setname` Extension
 layout: spec
+work-in-progress: true
 copyrights:
   -
     name: "Janne Mareike Koschinski"

--- a/extensions/setname.md
+++ b/extensions/setname.md
@@ -42,6 +42,14 @@ This avoids clients having to actually disconnect and reconnect.
 This capability MUST be referred to as `draft/setname` at capability
 negotiation time.
 
+Servers advertising the `draft/setname` capability MUST support usage of the
+command even while the capability is not negotiated. Clients MUST NOT prevent
+users from manually using the command while the capability is not negotiated.
+
+If a client sends a `SETNAME` command without having negotiated the capability,
+the server SHOULD handle it silently (with no response), as historic
+implementations did.
+
 When enabled, servers MUST provide a `NAMELEN` token in `RPL_ISUPPORT` with the
 maximum allowed length for realnames.
 

--- a/extensions/setname.md
+++ b/extensions/setname.md
@@ -43,7 +43,8 @@ This capability MUST be referred to as `draft/setname` at capability
 negotiation time.
 
 When enabled, clients are allowed to send a `SETNAME` command to notify servers
-of their intent to update their realname.
+of their intent to update their realname. They SHOULD not send it otherwise, as
+they can not reliably ensure that the server will understand it.
 
 If a client sends a `SETNAME` command without having negotiated the capability,
 the server SHOULD handle it silently, as the historic implementations did.

--- a/extensions/setname.md
+++ b/extensions/setname.md
@@ -47,9 +47,7 @@ as specified here, and MUST support usage of the command even while the
 capability is not negotiated.
 
 Servers advertising the capability MUST also provide a `NAMELEN` token in
-`RPL_ISUPPORT` with the maximum allowed length for realnames. They MUST NOT
-apply a different maximum allowed length than the one advertised in
-`RPL_ISUPPORT`.
+`RPL_ISUPPORT` with the maximum allowed length for realnames.
 
 If a client sends a `SETNAME` command without having negotiated the capability,
 the server SHOULD handle it silently, as the historic implementations did.

--- a/extensions/setname.md
+++ b/extensions/setname.md
@@ -66,7 +66,7 @@ change.
 Servers MUST check the realname for validity (taking length limits into
 consideration). If they accept the realname change, they MUST send the
 server-to-client version of the `SETNAME` message to all clients in common
-channels, as well as to the client from which it originated.
+channels, as well as to the client from which it originated, to confirm the change has occurred.
 
 The `SETNAME` message MUST NOT be sent to clients which do not have the
 `draft/setname` capability negotiated.

--- a/extensions/setname.md
+++ b/extensions/setname.md
@@ -57,8 +57,9 @@ This client-to-server `SETNAME` command looks as follows:
     SETNAME :realname goes here
 
 This command represents the intent to change the realname. The only, trailing
-parameter is the new realname. Until the server confirms this change, the
-client MUST assume that no change has happened yet.
+parameter is the new realname. If the capability is negotiated, the client
+MUST assume that no change has happened yet until the server confirms this
+change.
 
 Servers MUST check the realname for validity (taking length limits into
 consideration). If they accept the realname change, they MUST send the

--- a/extensions/setname.md
+++ b/extensions/setname.md
@@ -37,7 +37,7 @@ Due to this, the ability to change the realname has become relevant.
 ## Description
 
 The `draft/setname` client capability allows clients to change their realname
-(GECOS). It also allows servers to directly inform clients about such a change.
+(GECOS) on an active connection. It also allows servers to directly inform clients about such a change.
 This avoids clients having to actually disconnect and reconnect. 
 
 This capability MUST be referred to as `draft/setname` at capability

--- a/extensions/setname.md
+++ b/extensions/setname.md
@@ -34,8 +34,8 @@ higher demand for this functionality than ever.
 ## Description
 
 The `draft/setname` client capability allows clients to change their realname
-(GEICOS) as well as allowing servers to directly inform clients about such a
-change  without having to send a fake quit and join and without clients having
+(GECOS) as well as allowing servers to directly inform clients about such a
+change without having to send a fake quit and join and without clients having
 to actually disconnect and reconnect. 
 
 This capability MUST be referred to as `draft/setname` at capability

--- a/extensions/setname.md
+++ b/extensions/setname.md
@@ -13,11 +13,11 @@ copyrights:
 This is a work-in-progress specification.
 
 Software implementing this work-in-progress specification MUST NOT use the
-unprefixed `setname` tag name. Instead, implementations SHOULD use
-the `draft/setname` tag name to be interoperable with other software
+unprefixed `setname` capability name. Instead, implementations SHOULD use
+the `draft/setname` capability name to be interoperable with other software
 implementing a compatible work-in-progress version.
 
-The final version of the specification will use an unprefixed tag name.
+The final version of the specification will use an unprefixed capability name.
 
 ## Motivation
 

--- a/extensions/setname.md
+++ b/extensions/setname.md
@@ -54,7 +54,7 @@ implementations did.
 When enabled, servers MUST provide a `NAMELEN` token in `RPL_ISUPPORT` with the
 maximum allowed length for realnames.
 
-This client-to-server `SETNAME` command looks as follows:
+The client-to-server `SETNAME` command looks as follows:
 
     SETNAME :realname goes here
 

--- a/extensions/setname.md
+++ b/extensions/setname.md
@@ -1,0 +1,75 @@
+---
+title: IRCv3 `setname` Extension
+layout: spec
+copyrights:
+  -
+    name: "Janne Mareike Koschinski"
+    period: "2019"
+    email: "janne@kuschku.de"
+---
+
+## Notes for implementing work-in-progress version
+
+This is a work-in-progress specification.
+
+Software implementing this work-in-progress specification MUST NOT use the
+unprefixed `setname` tag name. Instead, implementations SHOULD use
+the `draft/setname` tag name to be interoperable with other software
+implementing a compatible work-in-progress version.
+
+The final version of the specification will use an unprefixed tag name.
+
+## Motivation
+
+Realnames have historically been immutable for a connection, which has
+historically been accepted, as they were rarely used and usually not as present
+in client UIs. Still, multiple IRCds have provided independent, non-standard
+commands to update realnames.
+
+Nowadays, multiple clients show realnames directly in chat, next to the nick
+name, or use information from the realname to provide enhancements, such as
+using emails in the realname to provide gravatar based avatars, leading to
+higher demand for this functionality than ever.
+
+## Description
+
+The `draft/setname` client capability allows clients to change their realname
+(GEICOS) as well as allowing servers to directly inform clients about such a
+change  without having to send a fake quit and join and without clients having
+to actually disconnect and reconnect. 
+
+This capability MUST be referred to as `draft/setname` at capability
+negotiation time.
+
+When enabled, clients are allowed to send a `SETNAME` message to notify servers
+of their intent to update their realname.
+
+This client-to-server `SETNAME` message looks as follows:
+
+    SETNAME :realname goes here
+
+This message represents the intent to change the realname. The only, trailing
+parameter is the new realname. Until the server confirms this change, the
+client MUST assume that no change has happened yet.
+
+Servers MUST check the realname for validity (taking length limits into
+consideration) and, if they apply the realname change, MUST send the
+server-to-client version of the `SETNAME` message to all clients in common
+channels, as well as to the client from which it originated.
+
+This server-to-client `SETNAME` message looks as follows:
+
+    :nick!user@host SETNAME :realname goes here
+
+This message represents that the user identified by nick!user@host has changed
+their realname to another value. The only, trailing parameter is the new
+realname.
+
+In order to take full advantage of the `SETNAME` message, clients must be
+modified to support it. The proper way to do so is this:
+
+1) Enable the `draft/setname` capability at capability negotiation time during
+   the login handshake.
+
+2) Update the realname portion of data structures and process channel users as
+   appropriate.

--- a/extensions/setname.md
+++ b/extensions/setname.md
@@ -71,7 +71,7 @@ channels, as well as to the client from which it originated.
 The `SETNAME` message MUST NOT be sent to clients which do not have the
 `draft/setname` capability negotiated.
 
-This server-to-client `SETNAME` message looks as follows:
+The server-to-client `SETNAME` message looks as follows:
 
     :nick!user@host SETNAME :realname goes here
 

--- a/extensions/setname.md
+++ b/extensions/setname.md
@@ -99,7 +99,7 @@ message with the `INVALID_REALNAME` code.
     FAIL SETNAME INVALID_REALNAME :Realname is not valid
     
 If the server rejects the change for any other reason, it MUST send a `FAIL`
-message indicating this:
+message with the `CANNOT_CHANGE_REALNAME` code and an appropriate description of the reason:
 
     FAIL SETNAME CANNOT_CHANGE_REALNAME :Slow down your realname changes
     FAIL SETNAME CANNOT_CHANGE_REALNAME :Cannot change realname while banned from a channel


### PR DESCRIPTION
## In Short
* Introduces a new `setname` capability
* Introduces a new bidirectional `SETNAME` command

## Rationale

Realnames have historically been immutable for a connection, which has
historically been accepted, as they were rarely used and usually not as present
in client UIs. Still, multiple IRCds have provided independent, non-standard
commands to update realnames.

Nowadays, multiple clients show realnames directly in chat, next to the nick
name, or use information from the realname to provide enhancements, such as
using emails in the realname to provide gravatar based avatars, leading to
higher demand for this functionality than ever.