### PR TITLE
Add `brb` extension

### DIFF
--- a/extensions/brb.md
+++ b/extensions/brb.md
@@ -50,11 +50,13 @@ closes - in which case it will be used for a `QUIT` reason from the client.
 
 #### Success
 
-    BRB SUCCESS
+    BRB SUCCESS <time>
 
-Used to tell the client that their `BRB` command was successful.
+`<time>` is a positive integer, representing the window of time the client has
+to reconnect.
 
-This is to be immediately followed by the server terminating the TCP connection.
+Used to tell the client that their `BRB` command was successful. This is to be
+immediately followed by the server terminating the TCP connection.
 
 #### Failure
 

--- a/extensions/brb.md
+++ b/extensions/brb.md
@@ -22,7 +22,7 @@ The final version of the specification will use an unprefixed capability name.
 
 ## Introduction
 
-Occasionally, clients will need to restart in order to update servers and, at 
+Occasionally, clients will need to restart in order to update software and, at
 the moment, this will cause a `QUIT` to be sent out for the user on all their 
 networks (unless the client supports in-place upgrading e.g. weechat.)
 

--- a/extensions/brb.md
+++ b/extensions/brb.md
@@ -1,0 +1,86 @@
+---
+title: IRCv3 `brb` Extension
+layout: spec
+extends: resume
+copyrights:
+  -
+    name: "Jess"
+    period: "2019"
+    email: "jess@jesopo.uk"
+---
+
+## Notes for implementing work-in-progress version
+
+This is a work-in-progress specification.
+
+Software implementing this work-in-progress specification MUST NOT use the
+unprefixed `brb` capability name. Instead, implementations SHOULD
+use the `draft/brb` capability name to be interoperable with other
+software implementing a compatible work-in-progress version.
+
+The final version of the specification will use an unprefixed capability name.
+
+## Introduction
+
+Occasionally, clients will need to restart in order to update servers and, at 
+the moment, this will cause a `QUIT` to be sent out for the user on all their 
+networks (unless the client supports in-place upgrading e.g. weechat.)
+
+With the introduction of the `resume` spec, we have an opportunity to leverage 
+the ability to resume an old session to achieve this but we need a way to 
+client-initiate a clean disconnect that holds a session open (`resume` is 
+designed solely for ping timeouts.)
+
+## Architecture
+
+### Commands
+
+#### `BRB` Command
+
+This command MAY ONLY be sent by a client that has previously negotiated the 
+`resume` capability.
+
+    BRB <reason>
+
+`<reason>` is a trailing argument that will be used as an `AWAY` message for the 
+client until either they resume the session or the window of time for resumption 
+closes - in which case it will be used for a `QUIT` reason from the client.
+
+### Messages
+
+#### Success
+
+    BRB SUCCESS
+
+Used to tell the client that their request for a disconnection that keeps their 
+session open was successful. This message MUST be immediately followed by the 
+server terminating the TCP connection with the client.
+
+#### Failure
+
+    FAIL BRB CANNOT_BRB :<reason>
+
+Used when, for any reason, the server could not accept the `BRB` request.
+
+## Examples
+
+#### Successful request
+
+    C: BRB :software updates!
+    S: BRB SUCCESS 
+    ... TCP connection is immediately terminated by the server ...
+
+    ... client reconnects and does draft/resume-0.3 handshake ...
+
+#### Failed request
+
+    C: BRB :software updates!
+    S: FAIL BRB CANNOT_BRB :BRB is unavailable at this time
+    ... IRC connection continues as it was ...
+
+#### Failed request with `QUIT` fallback
+
+    C: BRB :software updates!
+    S: FAIL BRB CANNOT_BRB :BRB is unavailable at this time
+    C: QUIT :software updates!
+

--- a/extensions/brb.md
+++ b/extensions/brb.md
@@ -24,7 +24,7 @@ The final version of the specification will use an unprefixed capability name.
 
 Occasionally, clients will need to restart in order to update software and, at
 the moment, this will cause a `QUIT` to be sent out for the user on all their 
-networks (unless the client supports in-place upgrading e.g. weechat.)
+networks (unless the client supports upgrading in-place)
 
 With the introduction of the `resume` spec, we have an opportunity to leverage 
 the ability to resume an old session to achieve this but we need a way to 

--- a/extensions/brb.md
+++ b/extensions/brb.md
@@ -52,9 +52,9 @@ closes - in which case it will be used for a `QUIT` reason from the client.
 
     BRB SUCCESS
 
-Used to tell the client that their request for a disconnection that keeps their 
-session open was successful. This message MUST be immediately followed by the 
-server terminating the TCP connection with the client.
+Used to tell the client that their `BRB` command was successful.
+
+This is to be immediately followed by the server terminating the TCP connection.
 
 #### Failure
 

--- a/extensions/brb.md
+++ b/extensions/brb.md
@@ -43,7 +43,7 @@ capability and the `FAIL` message.
 #### `BRB` Command
 
 This command MAY ONLY be sent by a client that has previously negotiated the 
-`resume` capability.
+`resume` capability, and has received and stored their resume token.
 
     BRB <reason>
 

--- a/extensions/brb.md
+++ b/extensions/brb.md
@@ -33,7 +33,7 @@ designed solely for ping timeouts.)
 
 ## Dependencies
 
-Clients wishing to use this capability must also support the `draft/resume-0.3`
+Clients wishing to use this capability MUST also support the `draft/resume-0.3`
 capability and the `FAIL` message.
 
 ## Architecture

--- a/extensions/brb.md
+++ b/extensions/brb.md
@@ -24,12 +24,14 @@ The final version of the specification will use an unprefixed capability name.
 
 Occasionally, clients will need to restart in order to update software and, at
 the moment, this will cause a `QUIT` to be sent out for the user on all their 
-networks (unless the client supports upgrading in-place)
+networks (unless the client supports upgrading in-place.) This specification
+provides a feature to allow clients to do these upgrades in an effectively
+silent manner, using the `draft/resume` capability.
 
-With the introduction of the `resume` spec, we have an opportunity to leverage 
-the ability to resume an old session to achieve this but we need a way to 
-client-initiate a clean disconnect that holds a session open (`resume` is 
-designed solely for ping timeouts.)
+With the introduction of the `draft/resume` capability, half of this goal is
+achieved (resuming a previous session) but we still need a way to agree on a clean
+close of the client<->server TCP connection such that it can be resumed after a
+software upgrade; that's where `BRB` comes in.
 
 ## Dependencies
 

--- a/extensions/brb.md
+++ b/extensions/brb.md
@@ -76,7 +76,7 @@ Used when, for any reason, the server could not accept the `BRB` request.
 #### Successful request
 
     C: BRB :software updates!
-    S: BRB SUCCESS 
+    S: BRB SUCCESS 30
     ... TCP connection is immediately terminated by the server ...
 
     ... client reconnects and does draft/resume-0.3 handshake ...

--- a/extensions/brb.md
+++ b/extensions/brb.md
@@ -53,7 +53,7 @@ closes - in which case it will be used for a `QUIT` reason from the client.
     BRB SUCCESS <time>
 
 `<time>` is a positive integer, representing the window of time the client has
-to reconnect.
+to reconnect in seconds.
 
 Used to tell the client that their `BRB` command was successful. This is to be
 immediately followed by the server terminating the TCP connection.

--- a/extensions/brb.md
+++ b/extensions/brb.md
@@ -31,6 +31,11 @@ the ability to resume an old session to achieve this but we need a way to
 client-initiate a clean disconnect that holds a session open (`resume` is 
 designed solely for ping timeouts.)
 
+## Dependencies
+
+Clients wishing to use this capability must also support the `draft/resume-0.3`
+capability and the `FAIL` message.
+
 ## Architecture
 
 ### Commands


### PR DESCRIPTION
Born out of the need to restart BitBot during rapid development - this spec allows clients to use a `BRB` command that piggybacks off `resume` to instantly close a connection while the server holds the session available to `RESUME`.