### PR TITLE
Message tags updates

### DIFF
--- a/client-tags/react.md
+++ b/client-tags/react.md
@@ -32,7 +32,7 @@ This tag provides a means of communicating with context-sensitive, potentially n
 
 ### Dependencies
 
-Clients wishing to use this tag MUST negotiate the [`draft/message-tags`](../core/message-tags-3.3.html) capability with the server. Additionally, this tag MUST be used in conjunction with the [`+draft/reply`](./reply.html) client tag.
+Clients wishing to use this tag MUST negotiate the [`message-tags`](../extensions/message-tags.html) capability with the server. Additionally, this tag MUST be used in conjunction with the [`+draft/reply`](./reply.html) client tag.
 
 ### Format
 

--- a/client-tags/reply.md
+++ b/client-tags/reply.md
@@ -28,7 +28,7 @@ This specification defines a client-only message tag to indicate replies to othe
 
 ### Dependencies
 
-Clients wishing to use this tag MUST negotiate the [`draft/message-tags`](../core/message-tags-3.3.html) capability with the server. Additionally, this tag relies on messages being sent with the [`draft/msgid`](../extensions/message-ids.html) tag. Clients SHOULD negotiate the [`echo-message`](../extensions/echo-message-3.2.html) capability in order to receive message IDs for their own messages, and therefore understand any replies.
+Clients wishing to use this tag MUST negotiate the [`message-tags`](../extensions/message-tags.html) capability with the server. Additionally, this tag relies on messages being sent with the [`draft/msgid`](../extensions/message-ids.html) tag. Clients SHOULD negotiate the [`echo-message`](../extensions/echo-message-3.2.html) capability in order to receive message IDs for their own messages, and therefore understand any replies.
 
 ### Format
 

--- a/extensions/echo-message-3.2.md
+++ b/extensions/echo-message-3.2.md
@@ -28,6 +28,9 @@ message to the target. Clients may choose to disable local echoing
 of sent `PRIVMSG` and `NOTICE` messages altogether, or present them
 in pending state.
 
+When the [`message-tags`](../extensions/message-tags.html) capability
+has been enabled, the same rules apply to `TAGMSG` messages.
+
 ## Use cases
 
 The capability is useful for clients to get an acknowledgement that a

--- a/extensions/message-ids.md
+++ b/extensions/message-ids.md
@@ -34,7 +34,7 @@ The message ID tag is a way for servers to enable these enhancements.
 
 ### Dependencies
 
-This specification doesn't define any capabilities of its own, but the `draft/message-tags` capability MUST be negotiated for servers wishing to use this tag.
+This specification doesn't define any capabilities of its own, but the [`message-tags`](../extensions/message-tags.html) capability MUST be negotiated for servers wishing to use this tag.
 
 ### Tags
 
@@ -119,12 +119,12 @@ Two channel `PRIVMSG` messages sent by the server, with possible non-standard ex
     S: @draft/msgid=msgid1;example/split :nick!user@host PRIVMSG #channel :Hello
     S: @draft/msgid=msgid2;example/concat=msgid1 :nick!user@host PRIVMSG #channel : World
 
-A client negotiating the `draft/message-tags` capability to enable and disable messages tagged with IDs.
+A client negotiating the `message-tags` capability to enable and disable messages tagged with IDs.
 
     S: :nick!user@host PRIVMSG #channel :Hello
-    C: CAP REQ draft/message-tags
-    S: :irc.example.com CAP me ACK :draft/message-tags
+    C: CAP REQ message-tags
+    S: :irc.example.com CAP me ACK :message-tags
     S: @draft/msgid=msgid-a :nick!user@host PRIVMSG #channel :Hello again
-    C: CAP REQ -draft/message-tags
-    S: :irc.example.com CAP me ACK :-draft/message-tags
+    C: CAP REQ -message-tags
+    S: :irc.example.com CAP me ACK :-message-tags
     S: :nick!user@host PRIVMSG #channel :Another hello

--- a/extensions/message-tags.md
+++ b/extensions/message-tags.md
@@ -107,7 +107,7 @@ with a plus sign (`+`). Servers MAY send client-only tags that weren't provided 
 The client-only tag prefix allows servers to safely relay untrusted client tags,
 keeping them distinct from unprefixed tags that carry verified meaning.
 
-Client-only tags MUST be relayed on `PRIVMSG` and `NOTICE` messages, and MAY be relayed on other messages.
+Client-only tags MUST be relayed on `PRIVMSG`, `NOTICE` and `TAGMSG` messages, and MAY be relayed on other messages.
 
 Any server-sent tags attached to messages MUST be included before client-only
 tags to prevent them from being pushed outside of the byte limit.

--- a/extensions/message-tags.md
+++ b/extensions/message-tags.md
@@ -190,6 +190,8 @@ Servers MUST reply with the `ERR_INPUTTOOLONG` (`417`) error numeric if a client
     417    ERR_INPUTTOOLONG
           ":Input line was too long"
 
+If a server sends a message with more tag data than the allowed limit, clients MAY ignore the message.
+
 ## Security considerations
 
 Client-only tags should be treated as untrusted data. They can contain any value

--- a/extensions/message-tags.md
+++ b/extensions/message-tags.md
@@ -50,9 +50,7 @@ The message pseudo-BNF, as defined in [RFC 1459, section 2.3.1][rfc1459] is exte
 
 The ordering of tags is not meaningful.
 
-Individual tag keys MUST only be used a maximum of once per message. Clients
-receiving messages with more than one occurrence of a tag key SHOULD discard all
-but the final occurrence.
+Individual tag keys MUST only be used a maximum of once per message. Implementations receiving messages with more than one occurrence of a tag key name SHOULD disregard all but the final occurrence.
 
 Implementations MUST interpret empty tag values (e.g. `foo=`) as equivalent to missing tag values (e.g. `foo`). Specifications MUST NOT differentiate meaning between tags with empty and missing values. Implementations MAY normalise tag values by converting the empty form to the missing form, but MUST NOT convert values from missing to empty, to prevent size limit issues.
 

--- a/extensions/message-tags.md
+++ b/extensions/message-tags.md
@@ -54,6 +54,8 @@ Individual tag keys MUST only be used a maximum of once per message. Clients
 receiving messages with more than one occurrence of a tag key SHOULD discard all
 but the final occurrence.
 
+Implementations MUST interpret empty tag values (e.g. `foo=`) as equivalent to missing tag values (e.g. `foo`). Specifications MUST NOT differentiate meaning between tags with empty and missing values. Implementations MAY normalise tag values by converting the empty form to the missing form, but MUST NOT convert values from missing to empty, to prevent size limit issues.
+
 ## Escaping values
 
 The mapping between characters in tag values and their representation in `<escaped value>` is defined as follows:
@@ -327,6 +329,9 @@ no escape character. This was added to help consistency across implementations.
 
 Previous versions of this spec did not specify how to handle invalid escapes. This was
 clarified to help consistency across implementations.
+
+Previous versions of this spec did not specify the difference between empty and missing
+tag values.
 
 [rfc1459]: http://tools.ietf.org/html/rfc1459#section-2.3.1
 [privmsg]: https://tools.ietf.org/html/rfc2812#section-3.3.1

--- a/extensions/message-tags.md
+++ b/extensions/message-tags.md
@@ -44,8 +44,8 @@ The message pseudo-BNF, as defined in [RFC 1459, section 2.3.1][rfc1459] is exte
     <tag>           ::= <key> ['=' <escaped_value>]
     <key>           ::= [ <client_prefix> ] [ <vendor> '/' ] <key_name>
     <client_prefix> ::= '+'
-    <key_name>      ::= <sequence of letters, digits, hyphens ('-')>
-    <escaped_value> ::= <sequence of any characters except NUL, CR, LF, semicolon (`;`) and SPACE>
+    <key_name>      ::= <non-empty sequence of ascii letters, digits, hyphens ('-')>
+    <escaped_value> ::= <sequence of zero or more bytes except NUL, CR, LF, semicolon (`;`) and SPACE>
     <vendor>        ::= <host>
 
 The ordering of tags is not meaningful.

--- a/extensions/message-tags.md
+++ b/extensions/message-tags.md
@@ -121,6 +121,8 @@ This means client-only tags that aren't specified in the IRCv3 extension registr
 use a vendor prefix and SHOULD be submitted to the IRCv3 working group for consideration
 if they are appropriate for more widespread adoption. See [Rules for naming message tags](#rules-for-naming-message-tags).
 
+Client-only tags are intended to replace the use of future [CTCP commands][ctcp].
+
 ### The `TAGMSG` tag-only message
 
        Command: TAGMSG
@@ -328,3 +330,4 @@ clarified to help consistency across implementations.
 [privmsg]: https://tools.ietf.org/html/rfc2812#section-3.3.1
 [statusmsg]: https://tools.ietf.org/html/draft-hardy-irc-isupport-00#section-4.18
 [registry]: https://ircv3.net/registry.html#tags
+[ctcp]: https://tools.ietf.org/html/draft-oakley-irc-ctcp-02

--- a/extensions/message-tags.md
+++ b/extensions/message-tags.md
@@ -52,6 +52,8 @@ The ordering of tags is not meaningful.
 
 Individual tag keys MUST only be used a maximum of once per message. Implementations receiving messages with more than one occurrence of a tag key name SHOULD disregard all but the final occurrence.
 
+Implementations MUST treat tag key names as opaque identifiers and MUST NOT perform any validation that would reject the message if an invalid tag key name is used. This allows future modifications to the tag key name format.
+
 Implementations MUST interpret empty tag values (e.g. `foo=`) as equivalent to missing tag values (e.g. `foo`). Specifications MUST NOT differentiate meaning between tags with empty and missing values. Implementations MAY normalise tag values by converting the empty form to the missing form, but MUST NOT convert values from missing to empty, to prevent size limit issues.
 
 ## Escaping values

--- a/extensions/message-tags.md
+++ b/extensions/message-tags.md
@@ -70,7 +70,9 @@ The mapping between characters in tag values and their representation in `<escap
 This escape format is space efficient, and ensures that message parts can easily be split on spaces and semi-colons before further parsing.
 
 If a lone `\` exists at the end of an escaped value (with no escape character following it), then there
-SHOULD be no output character. For example, the escaped value `test\` should unescape to `test`.
+SHOULD be no output character. For example, the escaped value `test\` should unescape to `test`. If a
+`\` exists with no valid escape character (for example, `\b`), then the invalid backslash SHOULD be
+dropped. For example, `\b` should unescape to just `b`.
 
 ## Capabilities
 
@@ -318,6 +320,9 @@ an opaque identifier. This was added to improve client resiliency.
 
 Previous versions of this spec did not specify how to handle trailing backslashes with
 no escape character. This was added to help consistency across implementations.
+
+Previous versions of this spec did not specify how to handle invalid escapes. This was
+clarified to help consistency across implementations.
 
 [rfc1459]: http://tools.ietf.org/html/rfc1459#section-2.3.1
 [privmsg]: https://tools.ietf.org/html/rfc2812#section-3.3.1

--- a/extensions/message-tags.md
+++ b/extensions/message-tags.md
@@ -307,7 +307,7 @@ A `TAGMSG` sent to a channel with [`labeled-response`](../extensions/labeled-res
 
 ---
 
-A `TAGMSG` sent by a client with tags that exceed the size limit and rejected by the server with an `ERR_INPUTTOOLONG` (`417`) error numeric. `[...]` is used to represent tags omitted for readability.
+A `TAGMSG` sent by a client with tags that exceed the size limit. The message is rejected by the server with an `ERR_INPUTTOOLONG` (`417`) error numeric. `[...]` is used to represent tags omitted for readability.
 
     C: @+tag1;+tag2;+tag[...];+tag5000 TAGMSG #channel
     S: :server.example.com 417 nick :Input line was too long

--- a/extensions/message-tags.md
+++ b/extensions/message-tags.md
@@ -163,6 +163,16 @@ e.g. `xn--e1afmkfd.org/foo`.
 
 Vendor-Specific tags should be submitted to the IRCv3 working group for consideration.
 
+### Drafts
+
+The `draft/` vendor namespace may be used when the working group is considering tag specifications.
+However, vendor names should be preferred.
+
+While tags are in draft status, they may need to be given a new identifier, to prevent
+implementation compatibility issues. When updating a draft tag key name, the
+typical method is to add `-0.x` to the name, where `x` is a version number. For example:
+`draft/foo` would become `draft/foo-0.2`, and so on.
+
 ### Standardized
 
 Reserved names for which a corresponding document exists in the [IRCv3 Extension Registry][registry].


### PR DESCRIPTION
This addresses comments from #297 #334 #335 #367 #370 

I've deliberately only added errata for stuff that would have applied to the 3.2 spec.

Edit: this also covers additional typos and comments raised below:
* Clarification around empty/missing tag values
* Clarification around dupe handling and validation of tag key names
* Draft tags