### PR TITLE
[message-tags] Specify that tag values are utf8

### DIFF
--- a/extensions/message-tags.md
+++ b/extensions/message-tags.md
@@ -54,6 +54,8 @@ Individual tag keys MUST only be used a maximum of once per message. Implementat
 
 Implementations MUST treat tag key names as opaque identifiers and MUST NOT perform any validation that would reject the message if an invalid tag key name is used. This allows future modifications to the tag key name format.
 
+Tag values MUST be encoded as UTF8. This ensures a shared interoperable baseline for data exchange. If tag values are encountered that cannot be decoded as UTF8, implementations MAY drop the value entirely, or substitute replacement bytes in place of invalid data.
+
 Implementations MUST interpret empty tag values (e.g. `foo=`) as equivalent to missing tag values (e.g. `foo`). Specifications MUST NOT differentiate meaning between tags with empty and missing values. Implementations MAY normalise tag values by converting the empty form to the missing form, but MUST NOT convert values from missing to empty, to prevent size limit issues.
 
 ## Escaping values
@@ -342,6 +344,8 @@ clarified to help consistency across implementations.
 
 Previous versions of this spec did not specify the difference between empty and missing
 tag values.
+
+Previous versions of this spec did not specify the UTF8 encoding for tag values
 
 [rfc1459]: http://tools.ietf.org/html/rfc1459#section-2.3.1
 [privmsg]: https://tools.ietf.org/html/rfc2812#section-3.3.1

--- a/extensions/message-tags.md
+++ b/extensions/message-tags.md
@@ -54,7 +54,7 @@ Individual tag keys MUST only be used a maximum of once per message. Implementat
 
 Implementations MUST treat tag key names as opaque identifiers and MUST NOT perform any validation that would reject the message if an invalid tag key name is used. This allows future modifications to the tag key name format.
 
-Tag values MUST be encoded as UTF8. This ensures a shared interoperable baseline for data exchange. If tag values are encountered that cannot be decoded as UTF8, implementations MAY drop the value entirely, or substitute replacement bytes in place of invalid data.
+Tag values MUST be encoded as UTF8. This ensures a shared interoperable baseline for data exchange. If tag values are encountered that cannot be decoded as UTF8, implementations MAY drop the value entirely but MUST NOT substitute replacement bytes in place of invalid data.
 
 Implementations MUST interpret empty tag values (e.g. `foo=`) as equivalent to missing tag values (e.g. `foo`). Specifications MUST NOT differentiate meaning between tags with empty and missing values. Implementations MAY normalise tag values by converting the empty form to the missing form, but MUST NOT convert values from missing to empty, to prevent size limit issues.
 

--- a/extensions/message-tags.md
+++ b/extensions/message-tags.md
@@ -54,7 +54,7 @@ Individual tag keys MUST only be used a maximum of once per message. Implementat
 
 Implementations MUST treat tag key names as opaque identifiers and MUST NOT perform any validation that would reject the message if an invalid tag key name is used. This allows future modifications to the tag key name format.
 
-Tag values MUST be encoded as UTF8. This ensures a shared interoperable baseline for data exchange. If tag values are encountered that cannot be decoded as UTF8, implementations MAY drop the value entirely but MUST NOT substitute replacement bytes in place of invalid data.
+Tag values MUST be encoded as UTF8. This ensures a shared interoperable baseline for data exchange. If tag values are encountered that cannot be decoded as UTF8, implementations MAY drop the value entirely but SHOULD NOT substitute replacement bytes in place of invalid data, which can result in collisions.
 
 Implementations MUST interpret empty tag values (e.g. `foo=`) as equivalent to missing tag values (e.g. `foo`). Specifications MUST NOT differentiate meaning between tags with empty and missing values. Implementations MAY normalise tag values by converting the empty form to the missing form, but MUST NOT convert values from missing to empty, to prevent size limit issues.
 

--- a/extensions/message-tags.md
+++ b/extensions/message-tags.md
@@ -45,7 +45,7 @@ The message pseudo-BNF, as defined in [RFC 1459, section 2.3.1][rfc1459] is exte
     <key>           ::= [ <client_prefix> ] [ <vendor> '/' ] <key_name>
     <client_prefix> ::= '+'
     <key_name>      ::= <non-empty sequence of ascii letters, digits, hyphens ('-')>
-    <escaped_value> ::= <sequence of zero or more bytes except NUL, CR, LF, semicolon (`;`) and SPACE>
+    <escaped_value> ::= <sequence of zero or more utf8 characters except NUL, CR, LF, semicolon (`;`) and SPACE>
     <vendor>        ::= <host>
 
 The ordering of tags is not meaningful.


### PR DESCRIPTION
This is a one word change but needs some discussion (and possibly needs expanding with a clarifying paragraph)

Following on from discussion in https://github.com/ircv3/ircv3-specifications/pull/373#pullrequestreview-209467284 (click `show resolved` to expand) and ircv3/ircv3-ideas#38 this proposal aims to enforce utf8 in at least one, relatively newly introduced section of the protocol.

This would allow us to assume an interoperable baseline for future tag specs, even if we can't for freeform text that has a long legacy of mixed encodings where the user is on their own to decide.

From an implementation point of view, I don't think this should present a major issue. Tags already need to be parsed separately from the rest of the message. For clients that handle multiple encodings, or do things like attempt to parse as UTF8 with a fallback to latin1, they can simply skip this step for tag parsing. For implementations that only support utf8 already, this would change nothing.

This change would mean that any data stored by a server in a different encoding, would need to be re-encoded for message tags. For a contrived example, a server that allowed non-utf8 account names would need to re-encode them for the `account-tag` spec. I think this possibility is sufficiently unlikely and niche as to not be a significant concern for interoperability. And the benefits of establishing a standard encoding far outweigh it.

You might ask why we can't just enforce utf8 everywhere. I think that would be a far more difficult task, and cause much more significant interop issues with legacy. There might be scope for a separate ISUPPORT/cap to enforce that, but it's tricky because users are the ones that decide on their encoding, and any negotiation between client and server wouldn't be done with user intervention. Besides, servers typically are not encoding-aware (nor do they want to be) so it's effectively a client-to-client decision, in which case, a cap isn't really the right solution.