### PR TITLE
Fix links to message-tags spec

### DIFF
--- a/client-tags/typing.md
+++ b/client-tags/typing.md
@@ -54,5 +54,5 @@ This specification is primarily intended for instances where all users are famil
 ## Privacy Considerations
 Typing status indicators introduce additional privacy concerns for users who may not wish to inform others of when they are creating or replying to a message. Clients are encouraged to provide appropriate privacy controls when enabling this feature. Standard implementation guidelines on [message tag moderation considerations][tags] also apply to servers.
 
-[batch]: http://ircv3.net/specs/extensions/batch-3.2.html
-[tags]: http://ircv3.net/specs/core/message-tags-3.3.html
+[batch]: ../extensions/batch-3.2.html
+[tags]: ../extensions/message-tags.html

--- a/extensions/labeled-response.md
+++ b/extensions/labeled-response.md
@@ -40,7 +40,7 @@ Additionally, labeled responses allow bouncers with multiple connected clients t
 
 ### Dependencies
 
-This specification uses the [message tags framework](/specs/core/message-tags-3.2.html) and the [`batch`](/specs/extensions/batch-3.2.html) capability which SHOULD be negotiated at the same time.
+This specification uses the [message tags framework](../extensions/message-tags.html) and the [`batch`](../extensions/batch-3.2.html) capability which SHOULD be negotiated at the same time.
 
 ### Capabilities
 

--- a/extensions/server-time-3.2.md
+++ b/extensions/server-time-3.2.md
@@ -52,7 +52,7 @@ John joined #chan during the leap second of June 2012 (notice the :60)
 
 
 [cap]: ../core/capability-negotiation.html
-[message tag]: ../core/message-tags-3.2.html
+[message tag]: ../extensions/message-tags.html
 
 
 ## Errata

--- a/extensions/webirc.md
+++ b/extensions/webirc.md
@@ -34,7 +34,7 @@ Note: Previous implementations referred to the `gateway` field as `user`. This c
 ### Options
 The `options` parameter is a space-separated set of additional arguments, each argument having the form `<name>[=<value>]`.
 
-The option values are escaped using the same escaping method as [message tags values](https://ircv3.net/specs/core/message-tags-3.2.html#escaping-values). It is acknowledged that some of the escaping rules are not strictly required, but the same escaping method is used for consistency.
+The option values are escaped using the same escaping method as [message tags values](../extensions/message-tags.html#escaping-values). It is acknowledged that some of the escaping rules are not strictly required, but the same escaping method is used for consistency.
 
 These options are defined and may be sent by clients while connecting:
 


### PR DESCRIPTION
Make sure all dependent specs link to the canonical merged relative URL for message tags.