### PR TITLE
Clarify contract for caps that depend on message tags

### DIFF
--- a/extensions/account-tag-3.2.md
+++ b/extensions/account-tag-3.2.md
@@ -7,7 +7,7 @@ copyrights:
     period: "2013-2015"
     email: "grawity@gmail.com"
 ---
-The `account-tag` capability causes the server to add a message-tag containing
+The `account-tag` capability causes the server to add a [message tag][] containing
 the command sender's services account to commands sent to the client that has
 requested this capability. It supersedes the `identify-msg` extension.
 
@@ -46,3 +46,5 @@ This extension supersedes `identify-msg`. This extension does not deprecate
 just the account name. Similarly, this extension does not deprecate
 `account-notify`, as the latter provides real-time notifications while this
 extension does not.
+
+[message tag]: ../extensions/message-tags.html

--- a/extensions/batch-3.2.md
+++ b/extensions/batch-3.2.md
@@ -45,7 +45,7 @@ Reference tag MUST contain only ASCII letters, numbers, and/or hyphen, and MUST 
 The `type` parameter indicates how messages are associated.
 The meaning of the additional parameters (if any) depend on the type.
 
-The batched events MUST use `batch` message tag referring to the batch's reference tag.
+The batched events MUST use `batch` [message tag][] referring to the batch's reference tag.
 Messages before start and after end of a batch (including start and end messages of that batch) MUST NOT refer to that batch.
 
 For every started batch, server MUST end that batch.
@@ -120,6 +120,7 @@ Notice that PRIVMSG line will be processed when batch `outer` ends,
 because end of batch `inner` is tagged by batch `outer`.
 The order in which these two batches start doesn't matter.
 
+[message tag]: ../extensions/message-tags.html
 
 ## Errata
 

--- a/extensions/message-tags.md
+++ b/extensions/message-tags.md
@@ -95,7 +95,7 @@ But there is also a generic capability for negotiating tag usage.
 The `message-tags` capability allows clients to indicate support for
 receiving any well-formed tag, whether or not it is recognised or used. It also frees servers from having to filter individual message tags for each client response.
 
-Capabilities that implicitly depend on the tag format do not guarantee support for all well-formed tags.
+The `message-tags` capability is the only guarantee that an implementation supports the full tag format. Following the robustness principle, implementations that use tags MUST support the full message tag format. However, implementations SHOULD NOT assume support for all tags when an individual tag capability is negotiated.
 
 This capability enables the use of client-only tags and the `TAGMSG` command, described below.
 

--- a/extensions/message-tags.md
+++ b/extensions/message-tags.md
@@ -56,7 +56,7 @@ Implementations MUST treat tag key names as opaque identifiers and MUST NOT perf
 
 Implementations MUST interpret empty tag values (e.g. `foo=`) as equivalent to missing tag values (e.g. `foo`). Specifications MUST NOT differentiate meaning between tags with empty and missing values. Implementations MAY normalise tag values by converting the empty form to the missing form, but MUST NOT convert values from missing to empty, to prevent size limit issues.
 
-## Escaping values
+### Escaping values
 
 The mapping between characters in tag values and their representation in `<escaped value>` is defined as follows:
 
@@ -78,7 +78,7 @@ dropped. For example, `\b` should unescape to just `b`.
 
 ## Capabilities
 
-Tags are enabled via capability negotiation. Clients and servers that negotiate a capability that uses tags MUST support the full tag specification.
+Tags are enabled via capability negotiation. Clients and servers that negotiate a capability that uses tags MUST support the full tag format above.
 
 The following capabilities implicitly depend on the tag format:
 
@@ -94,6 +94,8 @@ But there is also a generic capability for negotiating tag usage.
 
 The `message-tags` capability allows clients to indicate support for
 receiving any well-formed tag, whether or not it is recognised or used. It also frees servers from having to filter individual message tags for each client response.
+
+Capabilities that implicitly depend on the tag format do not guarantee support for all well-formed tags.
 
 This capability enables the use of client-only tags and the `TAGMSG` command, described below.
 


### PR DESCRIPTION
Addresses #387 

It's worth noting that labeled-response will also implicitly depend on the message tag format, but doesn't automatically enable the other behaviour of the message-tags cap. So it's not just "legacy" caps this applies to.