### PR TITLE
STS if-host-match and port-if-match keys

### DIFF
--- a/extensions/sts.md
+++ b/extensions/sts.md
@@ -88,18 +88,18 @@ Servers SHOULD be prepared to offer secure connections for the long term when en
 
 Preload list providers SHOULD consider STS persistence policy durations and MAY set minimum duration requirements prior to inclusion. Clients using preload lists SHOULD consider how their release cycle compares to any duration requirements imposed by list providers.
 
-### Project Aliases and Matching
+### The `if-host-match` and `port-if-match` keys
 
 Sometimes, third-parties create domain aliases that point towards IRC networks (for example, setting `irc.ircv3.net` as a `CNAME` of `irc.example.com`). Unfortunately, this means that TLS certificate validation does not work on the alias, and the network will not be able to use STS without breaking clients that do connect using the alias (e.g. if a user connects via `irc.ircv3.net`, they will not be able to validate the TLS certificate as the cert is valid for `irc.example.com`).
 
-Networks that require this sort of control over incoming connections can advertise these two keys, and not advertise the `port` key described above:
+Networks that require this sort of control over connection upgrades can advertise these two keys. Servers that advertise these two keys MUST NOT advertise the regular `port` key:
 
 - `if-host-match`: Space-separated list of hostnames and hostname patterns to match against. This uses regular IRC 'glob' syntax, where `?` matches any single character and `*` matches zero or more characters.
 - `port-if-match`: This is the port to connect to.
 
-If the hostname that the client connected to is matched by the `if-host-match` list, then the client follows the regular STS process using the `port-if-match` key as the TLS port to connect to.
+If the hostname that the client connected to is matched by the `if-host-match` list, the client MUST follow the regular STS process using the `port-if-match` key as the TLS port to connect to.
 
-Using these two keys and not advertising the `port` key means that only clients who understand how to process the `if-host-match` key will follow the STS policy.
+Advertising these two keys and not advertising the `port` key means that only clients who understand how to process the `if-host-match` key will follow the STS policy.
 
 Example 1: `irc.ircv3.net` is an alias of the canonical server `irc.example.com`. Alice connects to `irc.ircv3.net` and sees the capability: `"sts=duration=1,if-host-match=*.example.com,port-if-match=6697"`. Because Alice connected to `irc.ircv3.net` and does not see a pattern matching that, Alice does not perform an STS upgrade.
 


### PR DESCRIPTION
This adds the `if-host-match` and `port-if-match` keys, allowing a network like freenode (which has third-party domain aliases pointing towards their servers) to advertise STS. I've kept this basically along the lines of the conversation we've had, and think it's pretty simple. I opted to use a space `\s` to separate patterns, as we're sure that character isn't allowed in hosts and it should already be escaped properly by the key escaping.