### PR TITLE
extensions/sasl-3.1: Fix when to send 904

### DIFF
--- a/extensions/sasl-3.1.md
+++ b/extensions/sasl-3.1.md
@@ -157,6 +157,33 @@ an additional capability.
     S: :jaguar.test 001 jilles :Welcome to the jillestest Internet Relay Chat Network jilles
     (usual welcome messages)
 
+If the client requests a capability that is not supported, the server should
+send both a 908 and a 904 message, allowing the client to reattempt
+authentication with a different method.
+
+    C: CAP LS
+    C: NICK ryan
+    C: user ryan * * :RyanSquared
+    S: NOTICE AUTH :*** Processing connection to irc.test.hashbang.sh
+    S: NOTICE AUTH :*** Looking up your hostname...
+    S: NOTICE AUTH :*** Checking Ident
+    S: NOTICE AUTH :*** No Ident response
+    S: NOTICE AUTH :*** Found your hostname
+    S: :irc.test.hashbang.sh CAP * LS :multi-prefix sasl
+    C: CAP REQ :multi-prefix sasl
+    S: :irc.test.hashbang.sh CAP ryan ACK :multi-prefix sasl
+    C: AUTHENTICATE SCRAM-SHA-1
+    S: :irc.test.hashbang.sh 908 ryan EXTERNAL,PLAIN :are available SASL mechanisms
+    S: :irc.test.hashbang.sh 904 ryan :SASL authentication failed
+    C: AUTHENTICATE PLAIN
+    S: AUTHENTICATE +
+    C: AUTHENTICATE cnlhbnJ5YW5leGFtcGxlCg==
+    S: :irc.test.hashbang.sh 900 ryan ryan!ryan@de1.hashbang.sh lordryan :You are now logged in as lordryan
+    S: :irc.test.hashbang.sh 903 ryan :SASL authentication successful
+    C: CAP END
+    S: :irc.test.hashbang.sh 001 ryan :Welcome to the #! Testing Internet Relay Chat Network ryan
+    (usual welcome messages)
+
 ## Numerics used by this extension
 
 `900` aka `RPL_LOGGEDIN` is sent when the user's account name is set (whether by SASL or otherwise).
@@ -175,7 +202,7 @@ an additional capability.
 
     :server 903 <nick> :SASL authentication successful
 
-`904` aka `ERR_SASLFAIL` is sent when the SASL authentication fails because of invalid credentials or other errors not explicitly mentioned by other numerics.
+`904` aka `ERR_SASLFAIL` is sent when the SASL authentication fails because of invalid credentials or other errors, even if they're additionally sent by other numerics, and must be sent after all additional numerics.
 
     :server 904 <nick> :SASL authentication failed
 


### PR DESCRIPTION
It's been pointed out to me that servers often send an 908 numeric to
the client, but then also send an 904. When looking at this behavior, I
think this is so is because servers are generally built by default with
904 no matter what failed and then later, the 908 functionality is
implemented. In order to keep compatibility with clients that may not
understand the 908 numeric but do understand the 904 numeric as a
generic "retry". However, some clients do understand a 908 and use that
as a way to say "downgrade the mechanism and try again". So, they can
begin reconnecting as of the 908 numeric, but then get sent a 904
numeric, which some clients also take as a "try again" and do not
blindly consume the message.

The fix for the client would be to keep a state of which related
numerics are sent to the server, then begin the next attempt once the
904 numeric is received. This would *still work* with this proposed
change.

This also means that any numerics added in the future are compatible
with this specification, as the numerics will need to be sent before the
904 numeric which the client can use to restart the authentication with
any context sent from the other numerics.

---

I also noticed that there was only example of a "failed" case. I have
manually added one. I will be reattempting it sometime in the future to
get an actual response, I was just being ~~really lazy~~ busy writing
the example. I will also go attempt to get further examples of numerics
that are not currently covered by examples.

I do know the branch is called 804. It is a typo.