### PR TITLE
[typing] Clarify and ratify typing notifications

### DIFF
--- a/client-tags/typing.md
+++ b/client-tags/typing.md
@@ -1,58 +1,79 @@
 ---
 title: IRCv3 typing client tag
 layout: spec
-work-in-progress: true
 copyrights:
   -
     name: "Evan Magaliff"
     period: "2017"
     email: "evan@muffinmedic.net"
+  -
+    name: "James Wheare"
+    period: "2020"
+    email: "james@irccloud.com"
 ---
-## Notes for implementing work-in-progress version
+## Introduction
 
-This is a work-in-progress specification.
+This specification defines a client-only message tag to indicate the current typing status of users in channels and private messages.
 
-Software implementing this work-in-progress specification MUST NOT use the unprefixed `+typing` tag name. Instead, implementations SHOULD use the `+draft/typing` tag name to be interoperable with other software implementing a compatible work-in-progress version.
+## Motivation
 
-The final version of the specification will use an unprefixed tag name.
+This tag provides a means of communicating further context to a conversation. Knowing that someone is typing can allow users to hold off on sending messages that simply ask for feedback or check that someone has seen their message. Conversations can have an increased sense of immediacy when participants are aware that others are in the process of replying.
 
-## Description
-This specification defines the `typing` client tag, which allows clients to send and receive the current status of when a user is typing a new message prior to sending.
+## Architecture
 
-For the purpose of this specification, a message is defined as a user-generated `PRIVMSG`, `NOTICE`, `TAGMSG`, or [`batch`][batch] end.
+For the purpose of this specification, a message is defined as a `PRIVMSG`, `NOTICE`, `TAGMSG`, or [`batch`][batch] end.
 
-## Format
+### Dependencies
+
+Clients wishing to use this tag MUST negotiate the [`message-tags`](../extensions/message-tags.html) capability with the server.
+
+### Format
+
 A typing notification is represented by a [`TAGMSG`][tags] command sent with a `typing` tag using the client-only prefix `+` and possible values of `active`, `paused`, and `done`.
 
-The typing-active notification SHOULD be sent by clients whenever any update is made to the text-input field and the text is not a "/slash command". If the user begins typing in the text-input field and pauses typing without clearing the text-input field, the client SHOULD send a typing-paused notification until typing is resumed or the text-input field is cleared. If the user clears the text-input field without sending a message, the client SHOULD send a typing-done notification.
+* The `typing=active` notification SHOULD be sent by clients **continuously** while the user is making updates to the text-input field and the text is not a "/slash command".
 
-Input event handlers SHOULD be throttled so that typing notifications are not sent within 3 seconds of each other for a given target.
+* The `typing-paused` notification MAY be sent by clients **once** when the user has paused typing in the text-input field and has not cleared their text.
 
-After receiving a typing notification, clients SHOULD assume the sender is still typing until either a message is received, the sender leaves the channel or quits the server, or a done-notification is received. If at least 30 seconds have elapsed since the last typing-paused notification was received or at least 6 seconds have passed since the last typing-active notification was received and no typing-paused notification was received, clients SHOULD assume the user is no longer typing.
+* The `typing=done` notification MAY be sent by clients **once** when the user clears the text-input field without sending a message.
 
-## Examples
-C1 begins typing
+Input event handlers MUST be throttled so that any `typing` notification is not sent within 3 seconds of another one for a given target.
 
-    [C1] @+draft/typing=active :nick!ident@host TAGMSG target
+After receiving a typing notification, clients SHOULD assume the sender is still typing until any of the following conditions is met:
 
-C1 begins typing and then stops entering new text without clearing the text-input field
-
-    [C1] @+draft/typing=paused :nick!ident@host TAGMSG target
-
-C1 begins typing then clears the text-input field without sending the message
-
-    [C1] @+draft/typing=done :nick!ident@host TAGMSG target
-
-## Use Cases
-This specification is intended for use on servers and/or channels where knowing if another user is typing a message would be useful. Current implementations on similar platforms have proven useful, especially in collaborative team environments.
-
-## Limitations
-Clients must support the [`message-tags`][tags] capability. Specific [Privacy Considerations](#privacy-considerations) are addressed below.
-
-This specification is primarily intended for instances where all users are familiar with each other. In large channels of unknown users, the additional client tags add extra data that must be transmitted over the network with little potentential benefit to the users. This specification may also be beneficial in private messages regardless of network size.
+* A message is received from the sender
+* The sender leaves the channel or quits the server
+* A `typing=done` notification is received from the sender
+* At least 30 seconds have elapsed since the last `typing=paused` notification was received
+* At least 6 seconds have passed since the last `typing=active` notification was received
 
 ## Privacy Considerations
-Typing status indicators introduce additional privacy concerns for users who may not wish to inform others of when they are creating or replying to a message. Clients are encouraged to provide appropriate privacy controls when enabling this feature. Standard implementation guidelines on [message tag moderation considerations][tags] also apply to servers.
+
+This section is non-normative.
+
+Typing status indicators introduce additional privacy concerns for users who may not wish to inform others of when they are creating or replying to a message. Clients are recommended to provide appropriate privacy controls when enabling this feature. Standard implementation guidelines on [message tag moderation considerations][tags] also apply to servers.
+
+## Client implementation considerations
+
+This section is non-normative.
+
+To prevent unnecessary distraction, clients might choose to not display typing notifications for their own nickname, while still sending them to others.
+
+## Examples
+
+This section is non-normative.
+
+Client begins typing
+
+    Client: @+typing=active :nick!ident@host TAGMSG target
+
+Client begins typing and then stops entering new text without clearing the text-input field
+
+    Client: @+typing=paused :nick!ident@host TAGMSG target
+
+Client begins typing then clears the text-input field without sending the message
+
+    Client: @+typing=done :nick!ident@host TAGMSG target
 
 [batch]: ../extensions/batch-3.2.html
 [tags]: ../extensions/message-tags.html


### PR DESCRIPTION
I tidied up the sections to more closely match other specs, pulled various things out into bullet points and removed sections that don't seem relevant.

---

## Known implementations

Unchecked means incomplete or an intent to implement has been expressed. The numbers indicate minimum requirements. Any others?

### Server

Client tags don't require server support for ratification. Specific servers that filter client tags are listed here if they support (or will support) this spec

* [x] UnrealIRCd: (@syzop) https://github.com/unrealircd/unrealircd/commit/57f524cbeddb0a56d4cd1c91457cf391a5eaabdb

### Client (2/2)

* [x] IRCCloud (@jwheare)
* [x] KiwiIRC (@prawnsalad)
* [ ] TheLounge (@xPaw) https://github.com/thelounge/thelounge/issues/2419

### Bots

* [x] Bitbot (@jesopo)
* [x] MoonMoon (@RyanSquared)
