### PR TITLE
[multiline] Clarify blank line and line feed handling

### DIFF
--- a/extensions/multiline.md
+++ b/extensions/multiline.md
@@ -71,9 +71,9 @@ When receiving a well-formed mulitiline message batch, implementations MUST coll
 * Servers: delivering the batch to the intended recipients
 * Clients: displaying the batched message to the user
 
-Messages in a multiline batch MUST be joined with a single line feed (`\n`) byte unless the `draft/multiline-concat` message tag is sent, in which case the message is directly joined with the previous message with no separation.
+The combined message value of a multiline batch is defined as the concatenation of the messages from each individual line within the batch. Line messages are joined by a single line feed (`\n`) byte unless the `draft/multiline-concat` message tag is sent, in which case that line's message is directly joined with the previous line's message with no separation.
 
-The line feed joiner uses one byte from the `max-bytes` limit. No line feed is appended to the final line of a batch.
+Each line feed used to join line messages contributes one byte towards the `max-bytes` limit. No line feed is appended to the final line message of a batch.
 
 Servers MUST NOT reject blank lines.
 

--- a/extensions/multiline.md
+++ b/extensions/multiline.md
@@ -87,6 +87,8 @@ When delivering multiline batches to clients that have not negotiated the multil
 
 Servers MUST NOT send blank lines to clients that have not negotiated the multiline capability.
 
+Servers SHOULD maintain the line composition sent by the client instead of combining to a normalised form before re-splitting. This ensures that steps taken to [split long lines](#splitting-long-lines) appropriately are preserved.
+
 Any tags that would have been added to the batch, e.g. message IDs, account tags etc MUST be included on the first message line to be sent. Tags MAY also be included on subsequent lines where it makes sense to do so.
 
 ### Errors

--- a/extensions/multiline.md
+++ b/extensions/multiline.md
@@ -71,7 +71,13 @@ When receiving a well-formed mulitiline message batch, implementations MUST coll
 * Servers: delivering the batch to the intended recipients
 * Clients: displaying the batched message to the user
 
-Messages in a multiline batch MUST be concatenated with a single line feed (`\n`) byte unless the `draft/multiline-concat` message tag is sent, in which case the message is directly concatenated with the previous message without any separation.
+Messages in a multiline batch MUST be joined with a single line feed (`\n`) byte unless the `draft/multiline-concat` message tag is sent, in which case the message is directly joined with the previous message with no separation.
+
+The line feed joiner uses one byte from the `max-bytes` limit. No line feed is appended to the final line of a batch.
+
+Servers MUST NOT reject blank lines.
+
+Clients MUST NOT send blank lines with the `draft/multiline-concat` tag. Clients MUST NOT send messages consisting entirely of blank lines.
 
 Clients MUST NOT send messages other than PRIVMSG while a multiline batch is open.
 
@@ -79,7 +85,9 @@ Clients MUST NOT send messages other than PRIVMSG while a multiline batch is ope
 
 When delivering multiline batches to clients that have not negotiated the multiline capability, servers MUST deliver the component messages without using a multiline BATCH.
 
-Any tags that would have been added to the batch, e.g. message IDs, account tags etc MUST be included on the first message line. Tags MAY also be included on subsequent lines where it makes sense to do so.
+Servers MUST NOT send blank lines to clients that have not negotiated the multiline capability.
+
+Any tags that would have been added to the batch, e.g. message IDs, account tags etc MUST be included on the first message line to be sent. Tags MAY also be included on subsequent lines where it makes sense to do so.
 
 ### Errors
 


### PR DESCRIPTION
This addresses issues raised in https://github.com/oragono/oragono/issues/1005#issuecomment-628000227

* Clarify line feed joiner takes up one byte
* Servers MUST NOT reject blank lines (they can be used to create extra new lines)
* Clients MUST NOT send concat only blank lines or blank-only messages
* Servers MUST NOT send blank lines in legacy fallback (clients may well handle these but they're normally not allowed. An alternative may be to turn them into lines containing a single space, but not sure about that)

I don't think the suggestion to disallow a leading blank line is correct.