### PR TITLE
[multi-prefix] Add WHOIS to commands which replies contain all prefixes

### DIFF
--- a/extensions/multi-prefix.md
+++ b/extensions/multi-prefix.md
@@ -13,7 +13,7 @@ copyrights:
 ## Description
 
 When requested, the multi-prefix client capability will cause the IRC server to send
-all possible prefixes which apply to a user in NAMES and WHO output.
+all possible prefixes which apply to a user in NAMES, WHO and WHOIS output.
 
 These prefixes MUST be in order of 'rank', from highest to lowest.
 
@@ -27,3 +27,12 @@ Example:
     :kenny.chatspike.net 352 guest #test grawity broken.symlink *.chatspike.net grawity H@%+ :0 Mantas M.
     :kenny.chatspike.net 315 guest #test :End of /WHO list
 
+    --> WHOIS barmand
+    :irc.chat 311 guest barmand barmand cosani.jp * :Armand
+    :irc.chat 319 guest barmand :~&@%+#falco @+#raynor
+    :irc.chat 312 guest barmand irc.chat :Antibes
+    :irc.chat 318 guest barmand :End of /WHOIS list
+
+## Errata
+
+Previous versions of this spec did not specify that all possible prefixes which apply to users be also sent in WHOIS output. This was added for consistency with other replies that contain user prefixes.


### PR DESCRIPTION
This is a small errata to address an inconsistency in the `multi-prefix` specification. There are 3 commands which replies contain user prefixes: NAMES, WHO, WHOIS. WHOIS is currently not listed in the specification, which means that compliant servers should currently not send multiple user prefixes in reply to WHOIS in their RPL_WHOISCHANNELS.

I think that this is simply an oversight in the original spec, and that it makes sense that WHOIS replies should also have all the user prefixes.

Here's a table compiled from the [list of servers supporting multi-prefix](https://ircv3.net/software/servers), that shows whether they send a multi-prefix for WHOIS replies (currently *not* spec-compliant) or they don't (compliant, but not consistent with NAMES and WHO).

| IRCd | Sends multi-prefix for WHOIS? |
| -- | -- |
| Bitlbee | Irrelevant ([does not send RPL_WHOISCHANNELS](https://github.com/bitlbee/bitlbee/blob/0b1448f070917daf4966097a06b47fc4b2ce0c92/irc_send.c#L290)) |
| Charybdis | Yes (always sent!) ([1](https://github.com/charybdis-ircd/charybdis/blob/b9da417b4e5c56fe63fd7cefccc0cd9b2fa4b4b8/modules/m_whois.c#L293) [2](https://github.com/charybdis-ircd/charybdis/blob/2c11ccb99eb8fcdd32eddfa56ca228f4246270aa/ircd/channel.c#L193)) |
| ChatIRCd | Yes (always sent!) ([1](https://github.com/ChatLounge/ChatIRCd/blob/f8e3830745d167adf65948b9ce054b4b3810cb76/modules/m_whois.c#L307) [2](https://github.com/ChatLounge/ChatIRCd/blob/f8e3830745d167adf65948b9ce054b4b3810cb76/src/channel.c#L204)) |
| IRCCloud | [No](https://github.com/ircv3/ircv3-specifications/pull/419#issuecomment-640570136) |
| ircd-hybrid | Yes (always sent!) ([1](https://github.com/ircd-hybrid/ircd-hybrid/blob/38fd39c93e5063451259cda1b6b3dc638b35a570/modules/m_whois.c#L104) [2](https://github.com/ircd-hybrid/ircd-hybrid/blob/3ef409bfdd960e49bf36021354decc655d2b32d1/src/channel.c#L505)) |
| InspIRCd | [Yes](https://github.com/ircv3/ircv3-specifications/pull/419#issuecomment-798178383) |
| Nefarious IRCu | [No](https://github.com/evilnet/nefarious2/blob/310b8d98eb46c649ec7580cd513062891934d499/ircd/m_whois.c#L213) |
| Oragono | [Yes](https://github.com/oragono/oragono/blob/e508237fc66873bdf24f7dd81eaa1818526cad83/irc/server.go#L372) |
| txircd | Yes ([1](https://github.com/ElementalAlchemist/txircd/blob/1f4066da06e74c67e545a631b31b7ee4e1495215/txircd/modules/rfc/cmd_whois.py#L44)) ([2](https://github.com/ElementalAlchemist/txircd/blob/1f4066da06e74c67e545a631b31b7ee4e1495215/txircd/modules/ircv3/multiprefix.py#L11)) |
| UnrealIRCd | [Yes](https://github.com/unrealircd/unrealircd/blob/d25f6f6759943d95feba87064eec91b339824594/src/modules/whois.c#L235) |

(Most bouncers pass RPL_WHOISCHANNELS replies as is.)

It seems from this that returning all user prefixes in RPL_WHOISCHANNELS is the general consensus. The two IRCd that use the current spec behaviour are InspIRCd and Nefarious IRCu (the latter is not widely used [AFAIK](https://ircv3.net/support/networks).

Since this change is relatively easy to add to IRCd and is probably safe with regard to client parsing, I think it's OK to add it as an errata.