### PR TITLE
labeled-response=all for more strict guarantees

### DIFF
--- a/extensions/labeled-response.md
+++ b/extensions/labeled-response.md
@@ -39,7 +39,7 @@ Clients requesting this capability indicate that they are capable of handling th
 
 Servers advertising this capability indicate that they are capable of handling the message tag described below from clients, and will use the same tag and value in their response. They will also send the batch type and `ACK` response described below where required.
 
-The value, if present, MUST be a comma (`,`) separated list of flags. The `all` flag indicates the server WILL return a labeled response for every single command (i.e. there are NO cases where the client sends a command and receives no response, even for asynchronous remote commands described non-normatively below).
+The value, if present, MUST be a comma (`,`) separated list of flags. The `all` flag is a guarantee that the server WILL return a labeled response for every single command (i.e. the _"where it's feasible to do so"_ language below doesn't apply – there are NO cases where the client can send a command and receive no response, even for asynchronous remote commands).
 
 ### Batch types
 

--- a/extensions/labeled-response.md
+++ b/extensions/labeled-response.md
@@ -39,6 +39,8 @@ Clients requesting this capability indicate that they are capable of handling th
 
 Servers advertising this capability indicate that they are capable of handling the message tag described below from clients, and will use the same tag and value in their response. They will also send the batch type and `ACK` response described below where required.
 
+The value, if present, MUST be a comma (`,`) separated list of flags. The `all` flag indicates the server WILL return a labeled response for every single command (i.e. there are NO cases where the client sends a command and receives no response, even for asynchronous remote commands described non-normatively below).
+
 ### Batch types
 
 This specification adds the `labeled-response` batch type, described below.


### PR DESCRIPTION
Specifies https://github.com/ircv3/ircv3-ideas/issues/70. Lets clients have a more firm guarantee about relying on labeled-responses for _all_ of their response tracking. Basically, if your server advertises `labeled-response=all` then the _"where it's feasible to do so"_ language doesn't apply to you – you ALWAYS send a labeled response, to all commands. There's been interest in adopting this elsewhere.

The _"comma (`,`) separated list of flags"_ thing is mostly for safety, I'm sure we won't change it in the future but we've said that before and then had to do so later on~