### PR TITLE
Clarify chghost

### DIFF
--- a/extensions/chghost-3.2.md
+++ b/extensions/chghost-3.2.md
@@ -26,11 +26,23 @@ message to clients who have enabled the `chghost` capability and either share
 the same channel as the target client or have the client on a `MONITOR` list.
 Servers SHOULD additionally send the `CHGHOST` message to the client whose
 user and/or host has changed if the client supports the `chghost` capability.
+The server MUST defer sending CHGHOST messages to the client about successfully
+changing it's own user or host (for example, if using SASL and a virtual host
+is set) until both a successful `NICK` command and a successful `USER` command
+have been received.
 
-When the capability is not enabled for clients who share the same channel,
-servers should fall back to having the client `QUIT` the server, rejoin all
-channels, and re-establish the channel and user modes the client had before, as
-though the client had reconnected.
+When the capability is not enabled for other clients who share channels with or
+monitor the changed client, servers SHOULD send messages to simulate the client
+reconnecting. This allows clients to keep their user state up to date. For
+shared channels, the simulated events SHOULD include appropriate QUIT, JOIN and
+MODE commands, to restore membership and user channel modes. For monitored
+clients, the events SHOULD include appropriate RPL_MONOFFLINE and RPL_MONONLINE
+numerics.
+
+The server MUST send a `CHGHOST` message to a client, but MUST defer doing so
+until both a successful `NICK` command a successful `USER` command are received
+by the server. The server CAN choose to defer it until after registration is
+completed.
 
 ## The `CHGHOST` message
 
@@ -67,6 +79,9 @@ their hostname changed to `backyard`:
 * Previous versions of this specification did not include any examples, which made
 it unclear as to whether the de-facto `~` prefix should be included on CHGHOST
 messages. The new examples make clear that it should be included.
+* Previous versions of this specification did not specify that the `CHGHOST`
+command should be sent after both a valid NICK and a valid USER command have
+been received.
 * Previous versions of this specification used confusing descriptions and have
 since been rewritten to include a simpler description and example.
 * Previous versions of this specification did not specify whether or not the

--- a/extensions/chghost-3.2.md
+++ b/extensions/chghost-3.2.md
@@ -15,39 +15,39 @@ copyrights:
 ## Introduction
 
 The `chghost` client capability allows servers to directly inform clients about
-clients changing their host and/or user without having to simulate the client
-disconnecting. This is useful for servers implementing virtual hosts or masks
-and helps with reducing the amount of information spent on a client's UI.
+clients changing their host or user without having to simulate the client
+reconnecting. This is useful for servers implementing virtual hosts or masks
+and helps reduce clutter on the client's UI.
 
 ## The `chghost` capability
 
-When a client changes their user and/or host, servers MUST send the `CHGHOST`
+When a client changes their user or host, servers MUST send the `CHGHOST`
 message to clients who have enabled the `chghost` capability and either share
 the same channel as the target client or have the client on a `MONITOR` list.
 Servers SHOULD additionally send the `CHGHOST` message to the client whose
-user and/or host has changed if the client supports the `chghost` capability.
+user or host has changed if the client supports the `chghost` capability.
 
 When the capability is not enabled for other clients who share channels with or
 monitor the changed client, servers SHOULD send messages to simulate the client
 reconnecting. This allows clients to keep their user state up to date. For
-shared channels, the simulated events SHOULD include appropriate QUIT, JOIN and
-MODE commands, to restore membership and user channel modes. For monitored
-clients, the events SHOULD include appropriate RPL_MONOFFLINE and RPL_MONONLINE
-numerics.
+shared channels, the simulated events SHOULD include appropriate `QUIT`, `JOIN`
+and MODE commands, to restore membership and user channel modes. For monitored
+clients, the events SHOULD include appropriate `RPL_MONOFFLINE` and
+`RPL_MONONLINE` numerics.
 
-The server MUST send a `CHGHOST` message to a client, but MUST defer doing so
-until both a successful `NICK` command and a successful `USER` command have
-been received by the server. The server CAN choose to defer it until after
-registration is completed, for example if a valid SASL authentication during
-client registration triggers an assignment of a virtual host. If the server
-does not defer it until registration is completed, and either the user or the
-host of the client changes, the server MUST send down a new `CHGHOST` message.
+The server MUST send a `CHGHOST` message to a client, but defer doing so until
+both successful `NICK` and `USER` commands have been received by the server.
+The server MAY choose to defer it until after registration is completed, for
+example if a valid SASL authentication during client registration triggers an
+assignment of a virtual host. If the server does not defer it until
+registration is completed, and either the user or the host of the client
+changes, the server MUST send a new `CHGHOST` message.
 
 ## The `CHGHOST` message
 
 The `CHGHOST` message is as follows:
 
-    :nick!user@old_host.local CHGHOST new-user new_host.local
+    :nick!old-user@old_host.local CHGHOST new-user new_host.local
 
 The `new-user` parameter represents the user's "username" or "ident" which may
 or may not have changed in the CHGHOST process.

--- a/extensions/chghost-3.2.md
+++ b/extensions/chghost-3.2.md
@@ -14,26 +14,11 @@ copyrights:
 
 ## Introduction
 
-The `chghost` client capability allows servers to directly inform clients about
-clients changing their host or user without having to simulate the client
-reconnecting. This is useful for servers implementing virtual hosts or masks
-and helps reduce clutter on the client's UI.
+The `chghost` capability allows servers to send a notification when clients change their username or host. This mechanism avoids simulating a reconnect of the client. This is useful for servers that implement virtual hosts or cloaks, and helps to reduce clutter in client UI.
 
 ## The `chghost` capability
 
-When a client changes their user or host, servers MUST send the `CHGHOST`
-message to clients who have enabled the `chghost` capability and either share
-the same channel as the target client.
-Servers SHOULD additionally send the `CHGHOST` message to the client whose
-user or host has changed if the client supports the `chghost` capability.
-
-When the server sends a `CHGHOST` message to a client, it MUST defer doing so
-until both successful `NICK` and `USER` commands have been received by the
-server.  The server MAY choose to defer it until after registration is
-completed, for example if a valid SASL authentication during client
-registration triggers an assignment of a virtual host. If the server does not
-defer it until registration is completed, and either the user or the host of
-the client changes, the server MUST send a new `CHGHOST` message.
+When a client username or host is changed, servers MUST send the `CHGHOST` message to other clients who share channels with the target client and who have enabled the `chghost` capability. Servers SHOULD also send the `CHGHOST` message to the client whose own username or host changed, if that client also supports the `chghost` capability.
 
 ## The `CHGHOST` message
 
@@ -41,11 +26,11 @@ The `CHGHOST` message is as follows:
 
     :nick!old_user@old_host.local CHGHOST new_user new_host.local
 
-The `new_user` parameter represents the user's "username" or "ident" which may
-or may not have changed in the CHGHOST process.
+The `new_user` parameter represents the user's username.
 
-The `new_host.local` parameter represents the new hostname for the user which
-may or may not have changed in the CHGHOST process.
+The `new_host.local` parameter represents the user's hostname.
+
+One or both of the username and hostname can change during the CHGHOST process.
 
 Servers that implement ident checking might choose to prefix a username with a tilde `~` character to indicate missing confirmation from an ident server. This MUST be considered part of the username and included in any CHGHOST messages where relevant.
 
@@ -53,10 +38,7 @@ Servers that implement ident checking might choose to prefix a username with a t
 
 ## Fallback when the `chghost` capability has not been negotiated
 
-When the capability is not enabled for other clients who share channels with the changed client, servers SHOULD send fallback messages to simulate the client
-reconnecting. This allows clients to keep their user state up to date. For
-shared channels, the simulated events SHOULD include appropriate `QUIT`, `JOIN`
-and `MODE` commands, to restore membership and user channel modes.
+When the capability is not enabled for other clients who share channels with the changed client, servers SHOULD send fallback messages to simulate the client reconnecting. This allows clients to keep their user state up to date. For shared channels, the simulated events SHOULD include appropriate `QUIT`, `JOIN` and `MODE` commands, to restore membership and user channel modes.
 
     :nick!old_user@old_host.local QUIT :Changing hostname
     :nick!new_user@new_host.local JOIN #ircv3
@@ -64,25 +46,15 @@ and `MODE` commands, to restore membership and user channel modes.
 
 ## Examples
 
-In this example, `tim!~toolshed@backyard` gets their username changed to `~b` and
-their hostname changed to `ckyard`. Their new user mask is `tim!~b@ckyard`:
+In this example, `tim!~toolshed@backyard` gets their username changed to `~b` and their hostname changed to `ckyard`. Their new user mask is `tim!~b@ckyard`:
 
     :tim!~toolshed@backyard CHGHOST ~b ckyard
 
-In this example, `tim!b@ckyard` gets their username changed to `toolshed` and
-their hostname changed to `backyard`. Their new user mask is `tim!toolshed@backyard`:
+In this example, `tim!b@ckyard` gets their username changed to `toolshed` and their hostname changed to `backyard`. Their new user mask is `tim!toolshed@backyard`:
 
     :tim!b@ckyard CHGHOST toolshed backyard
 
 ## Errata
 
-* Previous versions of this specification did not include any examples, which made
-it unclear as to whether the de-facto `~` prefix should be included on CHGHOST
-messages. The new examples make clear that it should be included.
-* Previous versions of this specification did not specify that the `CHGHOST`
-command should be sent after both a valid NICK and a valid USER command have
-been received.
-* Previous versions of this specification used confusing descriptions and have
-since been rewritten to include a simpler description and example.
-* Previous versions of this specification did not specify whether or not the
-client whose user or host changed should receive the message.
+* Previous versions of this specification did not include any examples, which made it unclear as to whether the de-facto `~` prefix should be included on CHGHOST messages. The new examples make clear that it should be included.
+* Previous versions of this specification did not specify whether or not the client whose own user or host changed should receive the message.

--- a/extensions/chghost-3.2.md
+++ b/extensions/chghost-3.2.md
@@ -27,14 +27,6 @@ the same channel as the target client or have the client on a `MONITOR` list.
 Servers SHOULD additionally send the `CHGHOST` message to the client whose
 user or host has changed if the client supports the `chghost` capability.
 
-When the capability is not enabled for other clients who share channels with or
-monitor the changed client, servers SHOULD send messages to simulate the client
-reconnecting. This allows clients to keep their user state up to date. For
-shared channels, the simulated events SHOULD include appropriate `QUIT`, `JOIN`
-and MODE commands, to restore membership and user channel modes. For monitored
-clients, the events SHOULD include appropriate `RPL_MONOFFLINE` and
-`RPL_MONONLINE` numerics.
-
 When the server sends a `CHGHOST` message to a client, it MUST defer doing so
 until both successful `NICK` and `USER` commands have been received by the
 server.  The server MAY choose to defer it until after registration is
@@ -59,7 +51,15 @@ Servers that implement ident checking might choose to prefix a username with a t
 
     :nick!~old_user@old_host.local CHGHOST ~new_user new_host.local
 
-## Fallback for not supporting the `chghost` capability
+## Fallback when the `chghost` capability has not been negotiated
+
+When the capability is not enabled for other clients who share channels with or
+monitor the changed client, servers SHOULD send fallback messages to simulate the client
+reconnecting. This allows clients to keep their user state up to date. For
+shared channels, the simulated events SHOULD include appropriate `QUIT`, `JOIN`
+and MODE commands, to restore membership and user channel modes. For monitored
+clients, the events SHOULD include appropriate `RPL_MONOFFLINE` and
+`RPL_MONONLINE` numerics.
 
     :nick!old_user@old_host.local QUIT :Changing hostname
     :nick!new_user@new_host.local JOIN #ircv3

--- a/extensions/chghost-3.2.md
+++ b/extensions/chghost-3.2.md
@@ -57,7 +57,7 @@ When the capability is not enabled for other clients who share channels with or
 monitor the changed client, servers SHOULD send fallback messages to simulate the client
 reconnecting. This allows clients to keep their user state up to date. For
 shared channels, the simulated events SHOULD include appropriate `QUIT`, `JOIN`
-and MODE commands, to restore membership and user channel modes. For monitored
+and `MODE` commands, to restore membership and user channel modes. For monitored
 clients, the events SHOULD include appropriate `RPL_MONOFFLINE` and
 `RPL_MONONLINE` numerics.
 

--- a/extensions/chghost-3.2.md
+++ b/extensions/chghost-3.2.md
@@ -16,18 +16,33 @@ The chghost client capability allows servers to directly inform clients about a
 host or user change without having to send fake quits or joins. This capability
 MUST be referred to as `chghost` at capability negotiation time.
 
-When enabled, clients will get the `CHGHOST` message to designate the host of a
-user changing for clients on common channels with them.
+When the capability is enabled, servers MUST send the `CHGHOST` message to
+clients sharing the same channel as the target client, informing those clients
+that the user or host of the target client has changed.
+
+Servers SHOULD also send the `CHGHOST` command to the client who changed their
+host, as well as the previously-unspecified `396` numeric, whose exact value
+count changes per implementation (from two to three arguments), but always
+places the client's new host in the second-to-last position.
 
 The `CHGHOST` message is as follows:
 
-    :nick!user@host CHGHOST new-user new.host.goes.here
+    :nick!user@old_host.local CHGHOST new-user new_host.local
 
-The field represented by `new-user` represents the user's "username" or "ident"
-which may or may not have changed in the CHGHOST process.
+The `new-user` parameter represents the user's "username" or "ident" which may
+or may not have changed in the CHGHOST process.
 
-The field represented by `new.host.goes.here` represents the new hostname for
-the user which may or may not have changed in the CHGHOST process.
+The `new_host.local` parameter represents the new hostname for the user which
+may or may not have changed in the CHGHOST process.
+
+When the capability is not enabled for clients who share the same channel,
+servers should fall back to having the client `QUIT` the server, rejoin all
+channels, and re-establish the channel and user modes the client had before, as
+though the client had reconnected.
+
+    :nick!user@old_host.local QUIT :Changing hostname
+    :nick!new-user@new_host.local JOIN #ircv3
+    :ircd.local MODE #ircv3 +v :nick
 
 ## Examples
 
@@ -48,3 +63,5 @@ it unclear as to whether the de-facto `~` prefix should be included on CHGHOST
 messages. The new examples make clear that it should be included.
 * Previous versions of this specification used confusing descriptions and have
 since been rewritten to include a simpler description and example.
+* Previous versions of this specification did not specify whether or not the
+client whose user or host changed should receive the message.

--- a/extensions/chghost-3.2.md
+++ b/extensions/chghost-3.2.md
@@ -20,11 +20,6 @@ When the capability is enabled, servers MUST send the `CHGHOST` message to
 clients sharing the same channel as the target client, informing those clients
 that the user or host of the target client has changed.
 
-Servers SHOULD also send the `CHGHOST` command to the client who changed their
-host, as well as the previously-unspecified `396` numeric, whose exact value
-count changes per implementation (from two to three arguments), but always
-places the client's new host in the second-to-last position.
-
 The `CHGHOST` message is as follows:
 
     :nick!user@old_host.local CHGHOST new-user new_host.local

--- a/extensions/chghost-3.2.md
+++ b/extensions/chghost-3.2.md
@@ -12,13 +12,27 @@ copyrights:
     email: "ryan@hashbang.sh"
 ---
 
-The chghost client capability allows servers to directly inform clients about a
-host or user change without having to send fake quits or joins. This capability
-MUST be referred to as `chghost` at capability negotiation time.
+## Introduction
 
-When the capability is enabled, servers MUST send the `CHGHOST` message to
-clients sharing the same channel as the target client, informing those clients
-that the user or host of the target client has changed.
+The `chghost` client capability allows servers to directly inform clients about
+clients changing their host and/or user without having to simulate the client
+disconnecting. This is useful for servers implementing virtual hosts or masks
+and helps with reducing the amount of information spent on a client's UI.
+
+## The `chghost` capability
+
+When a client changes their user and/or host, servers MUST send the `CHGHOST`
+message to clients who have enabled the `chghost` capability and either share
+the same channel as the target client or have the client on a `MONITOR` list.
+Servers SHOULD additionally send the `CHGHOST` message to the client whose
+user and/or host has changed if the client supports the `chghost` capability.
+
+When the capability is not enabled for clients who share the same channel,
+servers should fall back to having the client `QUIT` the server, rejoin all
+channels, and re-establish the channel and user modes the client had before, as
+though the client had reconnected.
+
+## The `CHGHOST` message
 
 The `CHGHOST` message is as follows:
 
@@ -30,10 +44,7 @@ or may not have changed in the CHGHOST process.
 The `new_host.local` parameter represents the new hostname for the user which
 may or may not have changed in the CHGHOST process.
 
-When the capability is not enabled for clients who share the same channel,
-servers should fall back to having the client `QUIT` the server, rejoin all
-channels, and re-establish the channel and user modes the client had before, as
-though the client had reconnected.
+## Fallback for not supporting the `chghost` capability
 
     :nick!user@old_host.local QUIT :Changing hostname
     :nick!new-user@new_host.local JOIN #ircv3

--- a/extensions/chghost-3.2.md
+++ b/extensions/chghost-3.2.md
@@ -55,11 +55,9 @@ or may not have changed in the CHGHOST process.
 The `new_host.local` parameter represents the new hostname for the user which
 may or may not have changed in the CHGHOST process.
 
-If the server chooses to do so, the server can prepend the user with a tilde
-(such as denoting that the user was not sent by an ident daemon). When doing
-so, the command might look like:
+Servers that implement ident checking might choose to prefix a username with a tilde `~` character to indicate missing confirmation from an ident server. This MUST be considered part of the username and included in any CHGHOST messages where relevant.
 
-    :nick!old_user@old_host.local CHGHOST ~new_user new_host.local
+    :nick!~old_user@old_host.local CHGHOST ~new_user new_host.local
 
 ## Fallback for not supporting the `chghost` capability
 
@@ -67,24 +65,17 @@ so, the command might look like:
     :nick!new_user@new_host.local JOIN #ircv3
     :ircd.local MODE #ircv3 +v :nick
 
-Like above, if the server chooses to do so, the server can prepend the user
-with a tilde:
-
-    :nick!old_user@old_host.local QUIT :Changing hostname
-    :nick!~new_user@new_host.local JOIN #ircv3
-    :ircd.local MODE #ircv3 +v :nick
-
 ## Examples
 
-In this example, `tim!~toolshed@backyard` gets their username changed to `b` and
+In this example, `tim!~toolshed@backyard` gets their username changed to `~b` and
 their hostname changed to `ckyard`:
 
-    :tim!~toolshed@backyard CHGHOST b ckyard
+    :tim!~toolshed@backyard CHGHOST ~b ckyard
 
-In this example, `tim!b@ckyard` gets their username changed to `~toolshed` and
+In this example, `tim!b@ckyard` gets their username changed to `toolshed` and
 their hostname changed to `backyard`:
 
-    :tim!b@ckyard CHGHOST ~toolshed backyard
+    :tim!b@ckyard CHGHOST toolshed backyard
 
 ## Errata
 

--- a/extensions/chghost-3.2.md
+++ b/extensions/chghost-3.2.md
@@ -35,19 +35,19 @@ and MODE commands, to restore membership and user channel modes. For monitored
 clients, the events SHOULD include appropriate `RPL_MONOFFLINE` and
 `RPL_MONONLINE` numerics.
 
-The server MUST send a `CHGHOST` message to a client, but defer doing so until
-both successful `NICK` and `USER` commands have been received by the server.
-The server MAY choose to defer it until after registration is completed, for
-example if a valid SASL authentication during client registration triggers an
-assignment of a virtual host. If the server does not defer it until
-registration is completed, and either the user or the host of the client
-changes, the server MUST send a new `CHGHOST` message.
+When the server sends a `CHGHOST` message to a client, it MUST defer doing so
+until both successful `NICK` and `USER` commands have been received by the
+server.  The server MAY choose to defer it until after registration is
+completed, for example if a valid SASL authentication during client
+registration triggers an assignment of a virtual host. If the server does not
+defer it until registration is completed, and either the user or the host of
+the client changes, the server MUST send a new `CHGHOST` message.
 
 ## The `CHGHOST` message
 
 The `CHGHOST` message is as follows:
 
-    :nick!old-user@old_host.local CHGHOST new-user new_host.local
+    :nick!old_user@old_host.local CHGHOST new_user new_host.local
 
 The `new-user` parameter represents the user's "username" or "ident" which may
 or may not have changed in the CHGHOST process.
@@ -55,10 +55,23 @@ or may not have changed in the CHGHOST process.
 The `new_host.local` parameter represents the new hostname for the user which
 may or may not have changed in the CHGHOST process.
 
+If the server chooses to do so, the server can prepend the user with a tilde
+(such as denoting that the user was not sent by an ident daemon). When doing
+so, the command might look like:
+
+    :nick!old_user@old_host.local CHGHOST ~new_user new_host.local
+
 ## Fallback for not supporting the `chghost` capability
 
-    :nick!user@old_host.local QUIT :Changing hostname
-    :nick!new-user@new_host.local JOIN #ircv3
+    :nick!old_user@old_host.local QUIT :Changing hostname
+    :nick!new_user@new_host.local JOIN #ircv3
+    :ircd.local MODE #ircv3 +v :nick
+
+Like above, if the server chooses to do so, the server can prepend the user
+with a tilde:
+
+    :nick!old_user@old_host.local QUIT :Changing hostname
+    :nick!~new_user@new_host.local JOIN #ircv3
     :ircd.local MODE #ircv3 +v :nick
 
 ## Examples

--- a/extensions/chghost-3.2.md
+++ b/extensions/chghost-3.2.md
@@ -40,9 +40,9 @@ clients, the events SHOULD include appropriate RPL_MONOFFLINE and RPL_MONONLINE
 numerics.
 
 The server MUST send a `CHGHOST` message to a client, but MUST defer doing so
-until both a successful `NICK` command a successful `USER` command are received
-by the server. The server CAN choose to defer it until after registration is
-completed.
+until both a successful `NICK` command and a successful `USER` command have
+been received by the server. The server CAN choose to defer it until after
+registration is completed.
 
 ## The `CHGHOST` message
 

--- a/extensions/chghost-3.2.md
+++ b/extensions/chghost-3.2.md
@@ -5,7 +5,7 @@ copyrights:
   -
     name: "Christine Dodrill"
     period: "2013"
-    email: "xena@yolo-swag.com"
+    email: "me@christine.website"
   -
     name: "Ryan"
     period: "2016"

--- a/extensions/chghost-3.2.md
+++ b/extensions/chghost-3.2.md
@@ -10,6 +10,10 @@ copyrights:
     name: "Ryan"
     period: "2016"
     email: "ryan@hashbang.sh"
+  -
+    name: "James Wheare"
+    period: "2020"
+    email: "james@irccloud.com"
 ---
 
 ## Introduction

--- a/extensions/chghost-3.2.md
+++ b/extensions/chghost-3.2.md
@@ -6,43 +6,28 @@ copyrights:
     name: "Christine Dodrill"
     period: "2013"
     email: "xena@yolo-swag.com"
+  -
+    name: "Ryan"
+    period: "2016"
+    email: "ryan@hashbang.sh"
 ---
-The chghost client capability allows a server to directly inform clients about a
-host or user change without having to send a fake quit and join. This capability
+
+The chghost client capability allows servers to directly inform clients about a
+host or user change without having to send fake quits or joins. This capability
 MUST be referred to as `chghost` at capability negotiation time.
 
-When enabled, clients will get the CHGHOST message to designate the host of a
+When enabled, clients will get the `CHGHOST` message to designate the host of a
 user changing for clients on common channels with them.
 
-The CHGHOST message is one of the following:
+The `CHGHOST` message is as follows:
 
-    :nick!user@host CHGHOST user new.host.goes.here
+    :nick!user@host CHGHOST new-user new.host.goes.here
 
-This message represents that the user identified by nick!user@host has changed
-host to another value. The first parameter is the user of the client. The
-second parameter is the new host the client is using.
+The field represented by `new-user` represents the user's "username" or "ident"
+which may or may not have changed in the CHGHOST process.
 
-On irc daemons with support for changing the user portion of a client, the
-second form may appear:
-
-    :nick!user@host CHGHOST newuser host
-
-If specified, a client may also have their user and host changed at the same
-time:
-
-    :nick!user@host CHGHOST newuser new.host.goes.here
-
-This second and third form should only be seen on IRC daemons that support
-changing the user field of a user.
-
-In order to take full advantage of the CHGHOST message, clients must be modified
-to support it. The proper way to do so is this:
-
-1) Enable the chghost capability at capability negotiation time during the
-   login handshake.
-
-2) Update the user and host portions of data structures and process channel
-   users as appropriate.
+The field represented by `new.host.goes.here` represents the new hostname for
+the user which may or may not have changed in the CHGHOST process.
 
 ## Examples
 
@@ -58,6 +43,8 @@ their hostname changed to `backyard`:
 
 ## Errata
 
-A previous version of this specification did not include any examples, which made
+* Previous versions of this specification did not include any examples, which made
 it unclear as to whether the de-facto `~` prefix should be included on CHGHOST
 messages. The new examples make clear that it should be included.
+* Previous versions of this specification used confusing descriptions and have
+since been rewritten to include a simpler description and example.

--- a/extensions/chghost-3.2.md
+++ b/extensions/chghost-3.2.md
@@ -26,10 +26,6 @@ message to clients who have enabled the `chghost` capability and either share
 the same channel as the target client or have the client on a `MONITOR` list.
 Servers SHOULD additionally send the `CHGHOST` message to the client whose
 user and/or host has changed if the client supports the `chghost` capability.
-The server MUST defer sending CHGHOST messages to the client about successfully
-changing it's own user or host (for example, if using SASL and a virtual host
-is set) until both a successful `NICK` command and a successful `USER` command
-have been received.
 
 When the capability is not enabled for other clients who share channels with or
 monitor the changed client, servers SHOULD send messages to simulate the client
@@ -42,7 +38,10 @@ numerics.
 The server MUST send a `CHGHOST` message to a client, but MUST defer doing so
 until both a successful `NICK` command and a successful `USER` command have
 been received by the server. The server CAN choose to defer it until after
-registration is completed.
+registration is completed, for example if a valid SASL authentication during
+client registration triggers an assignment of a virtual host. If the server
+does not defer it until registration is completed, and either the user or the
+host of the client changes, the server MUST send down a new `CHGHOST` message.
 
 ## The `CHGHOST` message
 

--- a/extensions/chghost-3.2.md
+++ b/extensions/chghost-3.2.md
@@ -68,12 +68,12 @@ clients, the events SHOULD include appropriate `RPL_MONOFFLINE` and
 ## Examples
 
 In this example, `tim!~toolshed@backyard` gets their username changed to `~b` and
-their hostname changed to `ckyard`:
+their hostname changed to `ckyard`. Their new user mask is `tim!~b@ckyard`:
 
     :tim!~toolshed@backyard CHGHOST ~b ckyard
 
 In this example, `tim!b@ckyard` gets their username changed to `toolshed` and
-their hostname changed to `backyard`:
+their hostname changed to `backyard`. Their new user mask is `tim!toolshed@backyard`:
 
     :tim!b@ckyard CHGHOST toolshed backyard
 

--- a/extensions/chghost-3.2.md
+++ b/extensions/chghost-3.2.md
@@ -23,7 +23,7 @@ and helps reduce clutter on the client's UI.
 
 When a client changes their user or host, servers MUST send the `CHGHOST`
 message to clients who have enabled the `chghost` capability and either share
-the same channel as the target client or have the client on a `MONITOR` list.
+the same channel as the target client.
 Servers SHOULD additionally send the `CHGHOST` message to the client whose
 user or host has changed if the client supports the `chghost` capability.
 
@@ -53,13 +53,10 @@ Servers that implement ident checking might choose to prefix a username with a t
 
 ## Fallback when the `chghost` capability has not been negotiated
 
-When the capability is not enabled for other clients who share channels with or
-monitor the changed client, servers SHOULD send fallback messages to simulate the client
+When the capability is not enabled for other clients who share channels with the changed client, servers SHOULD send fallback messages to simulate the client
 reconnecting. This allows clients to keep their user state up to date. For
 shared channels, the simulated events SHOULD include appropriate `QUIT`, `JOIN`
-and `MODE` commands, to restore membership and user channel modes. For monitored
-clients, the events SHOULD include appropriate `RPL_MONOFFLINE` and
-`RPL_MONONLINE` numerics.
+and `MODE` commands, to restore membership and user channel modes.
 
     :nick!old_user@old_host.local QUIT :Changing hostname
     :nick!new_user@new_host.local JOIN #ircv3

--- a/extensions/chghost-3.2.md
+++ b/extensions/chghost-3.2.md
@@ -41,7 +41,7 @@ The `CHGHOST` message is as follows:
 
     :nick!old_user@old_host.local CHGHOST new_user new_host.local
 
-The `new-user` parameter represents the user's "username" or "ident" which may
+The `new_user` parameter represents the user's "username" or "ident" which may
 or may not have changed in the CHGHOST process.
 
 The `new_host.local` parameter represents the new hostname for the user which


### PR DESCRIPTION
This PR replaces and builds on #364, incorporating the latest suggestions around showing unidented tildes, and also moving the fallback description to its own subheading.