### PR TITLE
spec for UTF8ONLY

### DIFF
--- a/extensions/utf8-only.md
+++ b/extensions/utf8-only.md
@@ -17,7 +17,7 @@ copyrights:
 IRC predates the Unicode standard. Consequently, although UTF-8 has been widely adopted on IRC, clients cannot assume that all IRC data is UTF-8. This specification defines a way for servers to advertise that they only allow UTF-8 on their network, letting clients change their processing of outgoing and incoming messages accordingly.
 
 ## The `UTF8ONLY` ISUPPORT token
-This specification introduces a new token `UTF8ONLY` that servers can include in their [ISUPPORT](https://modern.ircdocs.horse/#feature-advertisement) (`005`) output. Servers publishing this token MUST NOT relay content (such as `PRIVMSG` or `NOTICE` message data, channel topics, or realnames) containing non-UTF-8 data to clients. Clients implementing this specification MUST NOT send non-UTF-8 data to the server once they have seen this token. Server handling of such messages is implementation-defined, and MAY involve sending the `FAIL` code described below.
+This specification introduces a new token `UTF8ONLY` that servers can include in their [ISUPPORT](https://modern.ircdocs.horse/#feature-advertisement) (`005`) output. Servers publishing this token MUST NOT relay content (such as `PRIVMSG` or `NOTICE` message data, channel topics, or realnames) containing non-UTF-8 data to clients. Clients implementing this specification MUST NOT send non-UTF-8 data to the server once they have seen this token. Server handling of such messages is implementation-defined; for example, they MAY send the `FAIL` code described below, disconnect the client with an `ERROR` message, or respond in some other way.
 
 If a client implementing this specification sees this token, they MUST set their outgoing encoding to UTF-8 without requiring any user intervention. This allows clients to work transparently on networks that only allow UTF-8 traffic.
 
@@ -34,4 +34,10 @@ Server: FAIL PRIVMSG INVALID_UTF8 :Message rejected, your IRC software MUST use 
 ```
 Client: USER u s e :<non-utf8 realname>
 Server: FAIL USER INVALID_UTF8 :Message rejected, your IRC software MUST use UTF-8 encoding on this network
+```
+
+```
+Client: PRIVMSG #ircv3 :<non-utf-8 message>
+Server: ERROR :Your IRC software MUST use UTF-8 encoding on this network
+... server disconnects the client ...
 ```

--- a/extensions/utf8-only.md
+++ b/extensions/utf8-only.md
@@ -17,12 +17,12 @@ copyrights:
 IRC predates the Unicode standard. Consequently, although UTF-8 has been widely adopted on IRC, clients cannot assume that all IRC data is UTF-8. This specification defines a way for servers to advertise that they only allow UTF-8 on their network, letting clients change their processing of outgoing and incoming messages accordingly.
 
 ## The `UTF8ONLY` ISUPPORT token
-This specification introduces a new token `UTF8ONLY` that servers can include in their [ISUPPORT](https://modern.ircdocs.horse/#feature-advertisement) (`005`) output. Servers publishing this token MUST NOT relay content (such as `PRIVMSG` or `NOTICE` message data, channel topics, or realnames) containing non-UTF-8 data to clients. Clients implementing this specification MUST NOT send non-UTF-8 data to the server once they have seen this token. Server handling of such messages is implementation-defined; for example, they MAY send the `FAIL` code described below, disconnect the client with an `ERROR` message, or respond in some other way.
+This specification introduces a new token `UTF8ONLY` that servers can include in their [ISUPPORT](https://modern.ircdocs.horse/#feature-advertisement) (`005`) output. Servers publishing this token MUST NOT relay content (such as `PRIVMSG` or `NOTICE` message data, channel topics, or realnames) containing non-UTF-8 data to clients. Clients implementing this specification MUST NOT send non-UTF-8 data to the server once they have seen this token. Server handling of such messages is implementation-defined; for example, they MAY send the `INVALID_UTF8` code described below, disconnect the client with an `ERROR` message, or respond in some other way.
 
 If a client implementing this specification sees this token, they MUST set their outgoing encoding to UTF-8 without requiring any user intervention. This allows clients to work transparently on networks that only allow UTF-8 traffic.
 
-## The `INVALID_UTF8` `FAIL` code
-This is a code that can be used with the `FAIL` command, as defined by the [standard replies](https://ircv3.net/specs/extensions/standard-replies) specification. This code indicates to the client that their message was dropped or modified because it contained non-UTF-8 bytes.
+## The `INVALID_UTF8` standard replies code
+This is a code that can be used with the [standard replies](https://ircv3.net/specs/extensions/standard-replies) specification. When sent with the `FAIL` command, it indicates that the client's message was rejected because it contained invalid UTF-8 data. When sent with the `WARN` command, it indicates that the message was modified but still accepted.
 
 ## Examples
 
@@ -40,4 +40,9 @@ Server: FAIL USER INVALID_UTF8 :Message rejected, your IRC software MUST use UTF
 Client: PRIVMSG #ircv3 :<non-utf-8 message>
 Server: ERROR :Your IRC software MUST use UTF-8 encoding on this network
 ... server disconnects the client ...
+```
+
+```
+Client: PRIVMSG #ircv3 :<non-utf-8 message>
+Server: WARN PRIVMSG INVALID_UTF8 :Your message was not correctly encoded as UTF-8 and had to be modified
 ```

--- a/extensions/utf8-only.md
+++ b/extensions/utf8-only.md
@@ -46,3 +46,6 @@ Server: ERROR :Your IRC software MUST use UTF-8 encoding on this network
 Client: PRIVMSG #ircv3 :<non-utf-8 message>
 Server: WARN PRIVMSG INVALID_UTF8 :Your message was not correctly encoded as UTF-8 and had to be modified
 ```
+
+## Implementation considerations
+Implementations MUST ensure that if they truncate messages to meet a length limit, they do not do so in the middle of a UTF-8 codepoint.

--- a/extensions/utf8-only.md
+++ b/extensions/utf8-only.md
@@ -1,0 +1,37 @@
+---
+title: UTF8ONLY ISUPPORT token
+layout: spec
+meta-description: An ISUPPORT token that indicates only UTF-8 traffic is allowed.
+copyrights:
+  -
+    name: "Daniel Oaks"
+    period: "2021"
+    email: "daniel@danieloaks.net"
+  -
+    name: "Shivaram Lingamneni"
+    period: "2021"
+    email: "slingamn@cs.stanford.edu"
+---
+
+## Introduction
+IRC predates the Unicode standard. Consequently, although UTF-8 has been widely adopted on IRC, clients cannot assume that all IRC data is UTF-8. This specification defines a way for servers to advertise that they only allow UTF-8 on their network, letting clients change their processing of outgoing and incoming messages accordingly.
+
+## The `UTF8ONLY` ISUPPORT token
+This specification introduces a new token `UTF8ONLY` that servers can include in their [ISUPPORT](https://modern.ircdocs.horse/#feature-advertisement) (`005`) output. Servers publishing this token MUST NOT relay content (such as `PRIVMSG` or `NOTICE` message data, channel topics, or realnames) containing non-UTF-8 data to clients. Clients implementing this specification MUST NOT send non-UTF-8 data to the server once they have seen this token. Server handling of such messages is implementation-defined, and MAY involve sending the `FAIL` code described below.
+
+If a client implementing this specification sees this token, they MUST set their outgoing encoding to UTF-8 without requiring any user intervention. This allows clients to work transparently on networks that only allow UTF-8 traffic.
+
+## The `INVALID_UTF8` `FAIL` code
+This is a code that can be used with the `FAIL` command, as defined by the [standard replies](https://ircv3.net/specs/extensions/standard-replies) specification. This code indicates to the client that their message was dropped or modified because it contained non-UTF-8 bytes.
+
+## Examples
+
+```
+Client: PRIVMSG #ircv3 :<non-utf-8 message>
+Server: FAIL PRIVMSG INVALID_UTF8 :Message rejected, your IRC software MUST use UTF-8 encoding on this network
+```
+
+```
+Client: USER u s e :<non-utf8 realname>
+Server: FAIL USER INVALID_UTF8 :Message rejected, your IRC software MUST use UTF-8 encoding on this network
+```

--- a/extensions/utf8-only.md
+++ b/extensions/utf8-only.md
@@ -48,4 +48,6 @@ Server: WARN PRIVMSG INVALID_UTF8 :Your message was not correctly encoded as UTF
 ```
 
 ## Implementation considerations
-Implementations MUST ensure that if they truncate messages to meet a length limit, they do not do so in the middle of a UTF-8 codepoint.
+This section is non-normative.
+
+Implementations must ensure that if they truncate messages to meet a length limit, they do not do so in the middle of a UTF-8-encoded codepoint.


### PR DESCRIPTION
The ISUPPORT token `UTF8ONLY` indicates "this server only accepts or relays UTF-8 content".

This is implemented (configurable, but a recommended default) in Oragono's master and the new [v2.5.0-rc1](https://github.com/oragono/oragono/releases/tag/v2.5.0-rc1) release candidate.