### PR TITLE
README.md: fix link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,6 @@
 
 This repository contains the IRCv3 specifications, and can contain specs that are still in draft stage and may be missing vital formatting.
 
-**Please view current IRCv3 specifications on our site here:** http://ircv3.net/irc/
+**Please view current IRCv3 specifications on our site here:** [https://ircv3.net/irc/](https://ircv3.net/irc/)
 
 Feel free to talk to us at [#ircv3 on freenode](https://kiwiirc.com/client/irc.freenode.net:+6697/#ircv3), and to read more about why IRCv3 exists and how it operates, see [our charter](http://ircv3.net/charter.html).


### PR DESCRIPTION
It's not clickable at https://ircv3.net/specs/