### PR TITLE
Add the bouncer-networks extension specification

### DIFF
--- a/extensions/bouncer-networks.md
+++ b/extensions/bouncer-networks.md
@@ -171,6 +171,10 @@ If a client sends an `ADDNETWORK` subcommand without a mandatory attribute:
 
     FAIL BOUNCER NEED_ATTRIBUTE ADDNETWORK <attribute> :Missing required attribute
 
+If a client sends an unknown subcommand:
+
+    FAIL BOUNCER UNKNOWN_COMMAND <subcommand> :Unknown subcommand
+
 TODO: more errors
 
 ### Standard network attributes

--- a/extensions/bouncer-networks.md
+++ b/extensions/bouncer-networks.md
@@ -139,41 +139,67 @@ Errors are returned using the standard replies syntax. The general syntax is:
 
     FAIL BOUNCER <code> <subcommand> [context...] <description>
 
-If a client sends a `BIND` subcommand before authentication:
+If a client sends an unknown subcommand, the server MUST reply with:
+
+    FAIL BOUNCER UNKNOWN_COMMAND <subcommand> :Unknown subcommand
+
+#### `ACCOUNT_REQUIRED` error
+
+If a client sends a `BIND` subcommand before authentication, the server MAY
+reply with:
 
     FAIL BOUNCER ACCOUNT_REQUIRED BIND :Authentication required
 
-If a client sends a `BIND` subcommand after registration:
+#### `REGISTRATION_IS_COMPLETED` error
+
+If a client sends a `BIND` subcommand after registration, the server MAY reply
+with:
 
     FAIL BOUNCER REGISTRATION_IS_COMPLETED BIND :Cannot bind to a network after registration
 
-If a client sends a `BIND` subcommand with an invalid network ID:
+#### `INVALID_NETID` error
 
-    FAIL BOUNCER INVALID_NETID BIND <netid> :Network not found
+If a client sends a subcommand with an invalid network ID, the server MUST
+reply with:
 
-If a client sends an `ADDNETWORK` subcommand with an invalid attribute:
+    FAIL BOUNCER INVALID_NETID <subcommand> <netid> :Network not found
 
-    FAIL BOUNCER INVALID_ATTRIBUTE ADDNETWORK * <attribute> :Invalid attribute value
+#### `INVALID_ATTRIBUTE` error
 
-If a client sends a `CHANGENETWORK` subcommand with an invalid attribute:
+If a client sends an `ADDNETWORK` or a `CHANGENETWORK` subcommand with an
+invalid attribute, the server MUST reply with:
 
-    FAIL BOUNCER INVALID_ATTRIBUTE CHANGENETWORK <netid> <attribute> :Invalid attribute value
+    FAIL BOUNCER INVALID_ATTRIBUTE <subcommand> <netid> <attribute> :Invalid attribute value
 
-If a client attempts to change a read-only network attribute:
+If the `subcommand` is `ADDNETWORK`, `netid` MUST be set to the special `*`
+value.
 
-    FAIL BOUNCER READ_ONLY_ATTRIBUTE CHANGENETWORK <netid> <attribute> :Read-only attribute
+#### `READ_ONLY_ATTRIBUTE` error
 
-If a client sends an `ADDNETWORK` subcommand with an unknown attribute:
+If a client attempts to change a read-only network attribute using the
+`ADDNETWORK` or `CHANGENETWORK` subcommand, the server MUST reply with:
 
-    FAIL BOUNCER UNKNOWN_ATTRIBUTE ADDNETWORK * <attribute> :Unknown attribute
+    FAIL BOUNCER READ_ONLY_ATTRIBUTE <subcommand> <netid> <attribute> :Read-only attribute
 
-If a client sends an `ADDNETWORK` subcommand without a mandatory attribute:
+If the `subcommand` is `ADDNETWORK`, `netid` MUST be set to the special `*`
+value.
+
+#### `UNKNOWN_ATTRIBUTE` error
+
+If a client sends an `ADDNETWORK` or a `CHANGENETWORK` subcommand with an
+unknown attribute, the server MUST reply with:
+
+    FAIL BOUNCER UNKNOWN_ATTRIBUTE <subcommand> <netid> <attribute> :Unknown attribute
+
+If the `subcommand` is `ADDNETWORK`, `netid` MUST be set to the special `*`
+value.
+
+#### `NEED_ATTRIBUTE` error
+
+If a client sends an `ADDNETWORK` subcommand without a mandatory attribute, the
+server MUST reply with:
 
     FAIL BOUNCER NEED_ATTRIBUTE ADDNETWORK <attribute> :Missing required attribute
-
-If a client sends an unknown subcommand:
-
-    FAIL BOUNCER UNKNOWN_COMMAND <subcommand> :Unknown subcommand
 
 TODO: more errors
 

--- a/extensions/bouncer-networks.md
+++ b/extensions/bouncer-networks.md
@@ -71,7 +71,7 @@ The server replies with:
 
 And then ends the list (even if empty) with:
 
-    BOUNCER LISTNETWORKS RPL_OK
+    BOUNCER LISTNETWORKS *
 
 ### Errors
 
@@ -119,4 +119,4 @@ Listing networks:
     C: BOUNCER LISTNETWORKS
     S: BOUNCER LISTNETWORKS 42 name=Freenode;state=connected
     S: BOUNCER LISTNETWORKS 43 name=My\sAwesome\sNetwork;state=disconnected
-    S: BOUNCER LISTNETWORKS RPL_OK
+    S: BOUNCER LISTNETWORKS *

--- a/extensions/bouncer-networks.md
+++ b/extensions/bouncer-networks.md
@@ -1,0 +1,122 @@
+---
+title: IRCv3 bouncer networks extension
+layout: spec
+work-in-progress: true
+copyrights:
+  -
+    name: "Darren Whitlen"
+    period: "2020"
+    email: "darren@kiwiirc.com"
+  -
+    name: "Simon Ser"
+    period: "2021"
+    email: "contact@emersion.fr"
+---
+
+## Notes for implementing work-in-progress version
+
+This is a work-in-progress specification.
+
+Software implementing this work-in-progress specification MUST NOT use the
+unprefixed `bouncer-networks` CAP names. Instead, implementations SHOULD use
+the `draft/bouncer-networks` CAP names to be interoperable with other software
+implementing a compatible work-in-progress version. The final version of the
+specification will use unprefixed CAP names.
+
+## Description
+
+This document describes the `bouncer-networks` extension. This enables clients
+to discover servers that are bouncers, list and edit upstream networks the
+bouncer is connected to.
+
+Each network has a unique per-user ID called "netid". It MUST NOT change during
+the lifetime of the network. TODO: character restrictions for network IDs.
+
+Networks also have attributes. Attributes are encoded in the message-tag
+format.
+
+## Implementation
+
+The `bouncer-networks` extension defines a new `RPL_ISUPPORT` token and a new
+`BOUNCER` command.
+
+### `RPL_ISUPPORT` token
+
+The server can advertise a `BOUNCER_NETID` token in its `RPL_ISUPPORT` message.
+Its optional value is the network ID bound for the current connection.
+
+### `BOUNCER` command
+
+A new `BOUNCER` command is introduced. It has a case-insensitive subcommand:
+
+    BOUNCER <subcommand> <params...>
+
+#### `BIND` subcommand
+
+The `BIND` subcommand selects an upstream network to bind to for the lifetime
+of the current connection. Clients can only send it after authentication but
+before the registration completes.
+
+    BOUNCER BIND <netid>
+
+#### `LISTNETWORKS` subcommand
+
+The `LISTNETWORKS` subcommand queries the list of upstream networks.
+
+    BOUNCER LISTNETWORKS
+
+The server replies with:
+
+    BOUNCER LISTNETWORKS <netid> <attributes>
+
+And then ends the list (even if empty) with:
+
+    BOUNCER LISTNETWORKS RPL_OK
+
+### Errors
+
+Errors are returned using the standard replies syntax. The general syntax is:
+
+    FAIL BOUNCER <code> <subcommand> [context...] <description>
+
+If a client sends a `BIND` subcommand before authentication:
+
+    FAIL BOUNCER ACCOUNT_REQUIRED BIND Authentication required
+
+If a client sends a `BIND` subcommand after registration:
+
+    FAIL BOUNCER REGISTRATION_IS_COMPLETED BIND Cannot bind to a network after registration
+
+If a client sends a `BIND` subcommand with an invalid network ID:
+
+    FAIL BOUNCER INVALID_NETID BIND <netid> Network not found
+
+TODO: more errors
+
+### Standard network attributes
+
+* `name`: the human-readable name for the network.
+* `state`: one of `connected`, `connecting` or `disconnected`. Indicates the
+  current state of the connection to the upstream network.
+
+TODO: more attributes
+
+### Examples
+
+Binding to a network:
+
+    C: CAP LS 302
+    C: NICK emersion
+    C: USER emersion 0 0 :Simon
+    S: CAP * LS :sasl=PLAIN bouncer-networks
+    C: CAP REQ :sasl bouncer-networks
+    [SASL authentication]
+    C: BOUNCER BIND 42
+    C: CAP END
+
+Listing networks:
+
+    C: BOUNCER LISTNETWORKS
+    S: BOUNCER LISTNETWORKS 42 name=Freenode;state=connected
+    S: BOUNCER LISTNETWORKS 43 name=My\sAwesome\sNetwork;state=disconnected
+    S: BOUNCER LISTNETWORKS RPL_OK

--- a/extensions/bouncer-networks.md
+++ b/extensions/bouncer-networks.md
@@ -33,7 +33,7 @@ Each network has a unique per-user ID called "netid". It MUST NOT change during
 the lifetime of the network. TODO: character restrictions for network IDs.
 
 Networks also have attributes. Attributes are encoded in the message-tag
-format.
+format. Clients MUST ignore unknown attributes.
 
 ## Implementation
 
@@ -73,6 +73,66 @@ And then ends the list (even if empty) with:
 
     BOUNCER LISTNETWORKS *
 
+#### `ADDNETWORK` subcommand
+
+The `ADDNETWORK` subcommand registers a new upstream network in the bouncer.
+
+    BOUNCER ADDNETWORK <attributes>
+
+The bouncer MAY reject this new network for any reason, in this case it MUST
+reply with an error. If the request is accepted, the bouncer MUST generate a
+new unique network ID. The bouncer MAY populate unspecified attributes with
+implementation-defined defaults.
+
+Clients MUST specify at least the `host` attribute.
+
+If the client doesn't specify the `tls` attribute, the server SHOULD use the
+default `1`. If the client doesn't specify the `port` attribute, the server
+SHOULD use the default `6697` if `tls=1` or `6667` if `tls=0`.
+
+On success, the server replies with:
+
+    BOUNCER ADDNETWORK <netid>
+
+#### `CHANGENETWORK` subcommand
+
+The `CHANGENETWORK` subcommand changes attributes of an existing upstream
+network.
+
+    BOUNCER CHANGENETWORK <netid> <attributes>
+
+The bouncer MAY reject the change for any reason, in this case it MUST reply
+with an error. At least one attribute MUST be specified by the client.
+
+On success, the server replies with:
+
+    BOUNCER CHANGENETWORK <netid>
+
+#### `DELNETWORK` subcommand
+
+The `DELNETWORK` subcommand removes an existing upstream network.
+
+    BOUNCER DELNETWORK <netid>
+
+The bouncer MAY reject the change for any reason, in this case it MUST reply
+with an error.
+
+On success, the server replies with:
+
+    BOUNCER DELNETWORK <netid>
+
+### Network notifications
+
+When a network attributes are updated, the bouncer MUST broadcast a
+`BOUNCER NETWORK` message to all connected clients with the updated attributes:
+
+    BOUNCER NETWORK <netid> <attributes>
+
+When a network is removed, the bouncer MUST broadcast a `BOUNCER NETWORK`
+message to all connected clients:
+
+    BOUNCER NETWORK <netid> *
+
 ### Errors
 
 Errors are returned using the standard replies syntax. The general syntax is:
@@ -81,23 +141,51 @@ Errors are returned using the standard replies syntax. The general syntax is:
 
 If a client sends a `BIND` subcommand before authentication:
 
-    FAIL BOUNCER ACCOUNT_REQUIRED BIND Authentication required
+    FAIL BOUNCER ACCOUNT_REQUIRED BIND :Authentication required
 
 If a client sends a `BIND` subcommand after registration:
 
-    FAIL BOUNCER REGISTRATION_IS_COMPLETED BIND Cannot bind to a network after registration
+    FAIL BOUNCER REGISTRATION_IS_COMPLETED BIND :Cannot bind to a network after registration
 
 If a client sends a `BIND` subcommand with an invalid network ID:
 
-    FAIL BOUNCER INVALID_NETID BIND <netid> Network not found
+    FAIL BOUNCER INVALID_NETID BIND <netid> :Network not found
+
+If a client sends an `ADDNETWORK` subcommand with an invalid attribute:
+
+    FAIL BOUNCER INVALID_ATTRIBUTE ADDNETWORK * <attribute> :Invalid attribute value
+
+If a client sends a `CHANGENETWORK` subcommand with an invalid attribute:
+
+    FAIL BOUNCER INVALID_ATTRIBUTE CHANGENETWORK <netid> <attribute> :Invalid attribute value
+
+If a client attempts to change a read-only network attribute:
+
+    FAIL BOUNCER READ_ONLY_ATTRIBUTE CHANGENETWORK <netid> <attribute> :Read-only attribute
+
+If a client sends an `ADDNETWORK` subcommand with an unknown attribute:
+
+    FAIL BOUNCER UNKNOWN_ATTRIBUTE ADDNETWORK * <attribute> :Unknown attribute
+
+If a client sends an `ADDNETWORK` subcommand without a mandatory attribute:
+
+    FAIL BOUNCER NEED_ATTRIBUTE ADDNETWORK <attribute> :Missing required attribute
 
 TODO: more errors
 
 ### Standard network attributes
 
+Bouncers MUST recognise the following network attributes:
+
 * `name`: the human-readable name for the network.
-* `state`: one of `connected`, `connecting` or `disconnected`. Indicates the
-  current state of the connection to the upstream network.
+* `state` (read-only): one of `connected`, `connecting` or `disconnected`.
+  Indicates the current state of the connection to the upstream network.
+* `host`: the hostname or literal IP address to connect to.
+* `port`: the TCP port to connect to.
+* `tls`: `1` to use a TLS connection, `0` to use a cleartext connection.
+* `nickname`: the nickname to use during registration.
+* `username`: the username to use during registration.
+* `realname`: the realname to use during registration.
 
 TODO: more attributes
 
@@ -120,3 +208,22 @@ Listing networks:
     S: BOUNCER LISTNETWORKS 42 name=Freenode;state=connected
     S: BOUNCER LISTNETWORKS 43 name=My\sAwesome\sNetwork;state=disconnected
     S: BOUNCER LISTNETWORKS *
+
+Adding a new network:
+
+    C: BOUNCER ADDNETWORK name=OFTC;host=irc.oftc.net
+    S: BOUNCER NETWORK 44 status=connecting
+    S: BOUNCER ADDNETWORK 44
+    S: BOUNCER NETWORK 44 status=connected
+
+Changing an existing network:
+
+    C: BOUNCER CHANGENETWORK 44 realname=Simon
+    S: BOUNCER NETWORK 44 realname=Simon
+    S: BOUNCER CHANGENETWORK 44
+
+Removing an existing network:
+
+    C: BOUNCER DELNETWORK 44
+    S: BOUNCER NETWORK 44 *
+    S: BOUNCER DELNETWORK 44


### PR DESCRIPTION
This is based on a previous proposal by Darren Whitlen [1], but with
its scope reduced to networks (buffers are left out). Discussion has
happened in an ircv3-ideas issue [2].

[1]: https://gist.github.com/prawnsalad/d864822d9bb8116626a4370bee6e6fc6
[2]: https://github.com/ircv3/ircv3-ideas/issues/39

cc @prawnsalad 