### PR TITLE
Add draft account-registration spec

### DIFF
--- a/extensions/account-registration.md
+++ b/extensions/account-registration.md
@@ -71,7 +71,7 @@ as if it used SASL.
 Sent by the server as a response to `REGISTER` when further action is required
 to complete registration of the `<account>`, as explain in the human-readable `<message>`.
 
-    FAIL REGISTER USERNAME_EXISTS <account> <message>
+    FAIL REGISTER ACCOUNT_EXISTS <account> <message>
 
 Sent by the server as a response to `REGISTER` when the client tried to register
 while using a nick that is not available as a new account's name

--- a/extensions/account-registration.md
+++ b/extensions/account-registration.md
@@ -28,8 +28,8 @@ for future organic expansion.
 
 ### Capability
 
-This specification adds the `draft/register` capability, whose presence
-signifies that the server accepts the `REGISTER` command.
+This specification adds the `draft/account-registration` capability, whose
+presence signifies that the server accepts the `REGISTER` command.
 
 The capability has an optional value, a comma-separated list of key-value
 pairs; the format is intended to follow the precedent set by
@@ -42,22 +42,28 @@ The defined keys are:
    `FAIL REGISTER COMPLETE_CONNECTION_REQUIRED`
  * `email-required` - if present, registrations require a valid email address
    to process
+ * `custom-accountname` - if present, the account name can be different
+   from the user's current nickname
 
 Clients MUST ignore any value assigned to these keys, and MUST ignore
 any unknown key.
 
 Software implementing this work-in-progress specification MUST NOT use
 the unprefixed `register` or `account-registration` capability names.
-Instead, implementations SHOULD use the `draft/register`
+Instead, implementations SHOULD use the `draft/account-registration`
 capability name to be interoperable with other software implementing
 a compatible work-in-progress version.
 
 ### Commands
 
-    REGISTER {<email> | "*"} <password>
+    REGISTER <accountname> {<email> | "*"} <password>
     
 The `REGISTER` command informs the server of a request to register
 an account named for the current nick of the requestor.
+
+If `<accountname>` is `*`, then this value is the user's current nickname.
+If the server advertises the `custom-accountname` key, then this desired
+account name can be different from the user's current nickname.
 
 The `REGISTER` command MAY be sent at any point during the connection
 that the client has a valid nickname.
@@ -90,13 +96,24 @@ to complete registration of the `<account>`, as explain in the human-readable
 
 Sent by the server as a response to `REGISTER` when the client tried to register
 while using a nick that is not available as a new account's name
-(for example, because someone already registered it).
+because someone already registered it.
 
 The server MUST NOT send this response before the client sent a `NICK` command.
 
 The client MAY try registering again later.
 Clients should not automatically retry immediately without changing
 their nickname or waiting.
+
+    FAIL REGISTER BAD_ACCOUNTNAME <account> <message>
+
+Sent by the server to indicate that the desired accountname is invalid or
+otherwise restricted/disallowed. The message should tell the user how or why
+the desired name has been rejected.
+
+    FAIL REGISTER ACCOUNTNAME_MUST_BE_NICK <account> <message>
+
+Sent by the server to indicate that the desired accountname does not match
+the user's current nick, when it must match.
 
     FAIL REGISTER NEED_NICK * <message>
 

--- a/extensions/account-registration.md
+++ b/extensions/account-registration.md
@@ -152,6 +152,11 @@ like a `privmsg` to nickserv), which are limited in length, servers may want to
 prevent or discourage users from setting passwords so long they may not fit
 in these messages. 300 bytes should be a safe reasonable limit.
 
+Servers should ensure that if they allow REGISTER before connection registration,
+this functionality cannot be used to bypass any authentication restrictions
+defined in the server configuration, e.g. requirements that clients send
+a server password with PASS.
+
 
 
 [multiline]: https://github.com/ircv3/ircv3-specifications/pull/398/

--- a/extensions/account-registration.md
+++ b/extensions/account-registration.md
@@ -176,11 +176,9 @@ unavailable.
 
 This section is non-normative.
 
-Passwords are opaque byte strings.
-It is recommended for them to be valid UTF-8;
+Passwords are opaque byte strings. It is recommended for them to be valid UTF-8;
 or authentication may be impossible later (eg. with SASL PLAIN).
-Servers may also choose to reject any non-UTF-8 password with
-`UNACCEPTABLE_PASSWORD`.
+Servers may also choose to reject any non-UTF-8 password with `UNACCEPTABLE_PASSWORD`.
 
 As passwords may need to be sent in non-`authenticate` messages,
 like a `PRIVMSG` to NickServ), which are limited in length, clients may want to

--- a/extensions/account-registration.md
+++ b/extensions/account-registration.md
@@ -83,6 +83,11 @@ The client MAY try registering again later.
 Clients should not automatically retry immediately without changing their nickname
 or waiting.
 
+    FAIL REGISTER NEED_NICK * <message>
+
+Sent by the server if the client sends `REGISTER` before sending a NICK command.
+This is only possible in setups that advertise the `before-connect` key.
+
     FAIL REGISTER ALREADY_REGISTERED <account> <message>
     FAIL VERIFY ALREADY_REGISTERED <account> <message>
 

--- a/extensions/account-registration.md
+++ b/extensions/account-registration.md
@@ -91,7 +91,7 @@ This is only possible in setups that advertise the `before-connect` key.
     FAIL REGISTER ALREADY_REGISTERED <account> <message>
     FAIL VERIFY ALREADY_REGISTERED <account> <message>
 
-Sent by the server is the client is already authenticated.
+Sent by the server if the client is already authenticated.
 
     FAIL REGISTER WEAK_PASSWORD <account> <message>
 

--- a/extensions/account-registration.md
+++ b/extensions/account-registration.md
@@ -40,6 +40,12 @@ The defined keys are:
 
 Clients MUST ignore any value assigned to these keys, and MUST ignore any unknown key.
 
+Software implementing this work-in-progress specification MUST NOT use
+the unprefixed `register` or `account-registration` capability names.
+Instead, implementations SHOULD use the `draft/register`
+capability name to be interoperable with other software implementing
+a compatible work-in-progress version.
+
 ### Commands
 
     REGISTER {<email> | "*"} <password>

--- a/extensions/account-registration.md
+++ b/extensions/account-registration.md
@@ -104,13 +104,13 @@ The client MAY try registering again later.
 Clients should not automatically retry immediately without changing
 their nickname or waiting.
 
-    FAIL REGISTER BAD_ACCOUNTNAME <account> <message>
+    FAIL REGISTER BAD_ACCOUNT_NAME <account> <message>
 
 Sent by the server to indicate that the desired account name is invalid or
 otherwise restricted/disallowed. The message should tell the user how or why
 the desired name has been rejected.
 
-    FAIL REGISTER ACCOUNTNAME_MUST_BE_NICK <account> <message>
+    FAIL REGISTER ACCOUNT_NAME_MUST_BE_NICK <account> <message>
 
 Sent by the server to indicate that the desired account name does not match
 the user's current nick, when it must match.

--- a/extensions/account-registration.md
+++ b/extensions/account-registration.md
@@ -27,12 +27,18 @@ The final version of the specification will use an unprefixed capability name.
 
 ## Motivation
 
-The lack of a standardized way to register an account has been a source
-of frustration for many participants for several years.
+A standard method of registering a user account has historically been missing
+from IRC. Instead various methods such as sending messages to services bots
+(e.g. NickServ) have been employed.
 
-This specification is intentionally restricted in scope to be appealing
-to implementors by being severely. The authors hope that this solution
-will serve as the basis for future organic expansion.
+This specification aims to provide a standard baseline for account
+registration that allows client developers to build more reliable and
+integrated user experiences around account registration.
+
+It does not aim to cover all registration-related use cases that may currently
+be in use by server implementations to varying degrees. However, future
+extensions to the specification might be proposed given a broad enough
+consensus.
 
 ### Capability
 

--- a/extensions/account-registration.md
+++ b/extensions/account-registration.md
@@ -30,12 +30,9 @@ The final version of the specification will use an unprefixed capability name.
 The lack of a standardized way to register an account has been a source
 of frustration for many participants for several years.
 
-This isn't the first attempt to fix it. Unlike the withdrawn `ACC` proposal,
-this effort aims to be more appealing to implementors by being severely
-restricted in scope.
-The only register-verify flows supported are those already in use in the wild.
-The authors hope that this stripped-down solution will serve as the basis
-for future organic expansion.
+This specification is intentionally restricted in scope to be appealing
+to implementors by being severely. The authors hope that this solution
+will serve as the basis for future organic expansion.
 
 ### Capability
 

--- a/extensions/account-registration.md
+++ b/extensions/account-registration.md
@@ -67,7 +67,8 @@ a second attempt after it receives the welcome message.
 
     VERIFY <account> <code>
     
-The `VERIFY` command completes a registration that required email verification.
+The `VERIFY` command completes a registration that required verification
+(eg. via email or CAPTCHA).
 
 ### Responses
 

--- a/extensions/account-registration.md
+++ b/extensions/account-registration.md
@@ -153,7 +153,7 @@ account registration.
 Sent by the server if the client sent a `REGISTER` command before connection
 registration.
 The server MUST NOT sent these replies if it advertizes the `before-connect`
-key of the `draft/register` capability.
+key of the `draft/account-registration` capability.
 
     FAIL VERIFY INVALID_CODE <account> <message>
 

--- a/extensions/account-registration.md
+++ b/extensions/account-registration.md
@@ -13,6 +13,17 @@ copyrights:
     email: "progval+ircv3@progval.net"
 ---
 
+## Notes for implementing work-in-progress version
+
+This is a work-in-progress specification.
+
+Software implementing this work-in-progress specification MUST NOT use
+the unprefixed `account-registration` capability name.
+Instead, implementations SHOULD use the `draft/account-registration`
+capability name to be interoperable with other software implementing
+a compatible work-in-progress version.
+
+The final version of the specification will use an unprefixed capability name.
 
 ## Motivation
 
@@ -47,12 +58,6 @@ The defined keys are:
 
 Clients MUST ignore any value assigned to these keys, and MUST ignore
 any unknown key.
-
-Software implementing this work-in-progress specification MUST NOT use
-the unprefixed `register` or `account-registration` capability names.
-Instead, implementations SHOULD use the `draft/account-registration`
-capability name to be interoperable with other software implementing
-a compatible work-in-progress version.
 
 ### Commands
 

--- a/extensions/account-registration.md
+++ b/extensions/account-registration.md
@@ -42,11 +42,17 @@ for future organic expansion.
 This specification adds the `draft/account-registration` capability, whose
 presence signifies that the server accepts the `REGISTER` command.
 
-The capability has an optional value, a comma-separated list of key-value
-pairs; the format is intended to follow the precedent set by
-[the multiline draft][multiline].
+The capability MAY be advertised by servers with an OPTIONAL value:
+a comma (`,`) (0x2C) separated list of tokens. Each token consists of a key
+with an optional value attached. If there is a value attached, the value
+is separated from the key by an equals sign (`=`) (0x3D).
+That is, `<key>[=<value>][,<key2>[=<value2>][,<keyN>[=<valueN>]]]`.
+Keys specified in this document MUST only occur at most once.
 
-The defined keys are:
+Clients MUST ignore every token with a key that they don't understand,
+and MUST ignore any value in these tokens.
+
+The only defined capability keys so far are:
 
  * `before-connect` - if present, indicates the server supports early
    registration, so it MUST NOT use
@@ -55,9 +61,6 @@ The defined keys are:
    to process
  * `custom-account-name` - if present, the account name can be different
    from the user's current nickname
-
-Clients MUST ignore any value assigned to these keys, and MUST ignore
-any unknown key.
 
 ### Commands
 
@@ -202,7 +205,3 @@ Servers should ensure that if they allow REGISTER before connection registration
 this functionality cannot be used to bypass any authentication restrictions
 defined in the server configuration, e.g. requirements that clients send
 a server password with PASS.
-
-
-
-[multiline]: https://github.com/ircv3/ircv3-specifications/pull/398/

--- a/extensions/account-registration.md
+++ b/extensions/account-registration.md
@@ -16,29 +16,35 @@ copyrights:
 
 ## Motivation
 
-The lack of a standardized way to register an account has been a source of frustration for many participants
-for several years.
+The lack of a standardized way to register an account has been a source
+of frustration for many participants for several years.
 
-This isn't the first attempt to fix it. Unlike the withdrawn `ACC` proposal, this effort aims to be more
-appealing to implementors by being severely restricted in scope. The only register-verify flows supported
-are those already in use in the wild. The authors hope that this stripped-down solution will serve as the
-basis for future organic expansion.
+This isn't the first attempt to fix it. Unlike the withdrawn `ACC` proposal,
+this effort aims to be more appealing to implementors by being severely
+restricted in scope.
+The only register-verify flows supported are those already in use in the wild.
+The authors hope that this stripped-down solution will serve as the basis
+for future organic expansion.
 
 ### Capability
 
-This specification adds the `draft/register` capability, whose presence signifies that the server
-accepts the `REGISTER` command.
+This specification adds the `draft/register` capability, whose presence
+signifies that the server accepts the `REGISTER` command.
 
-The capability has an optional value, a comma-separated list of key-value pairs; the format is intended
-to follow the precedent set by [the multiline draft][multiline].
+The capability has an optional value, a comma-separated list of key-value
+pairs; the format is intended to follow the precedent set by
+[the multiline draft][multiline].
 
 The defined keys are:
 
- * `before-connect` - if present, indicates the server supports early registration, so it
-   MUST NOT use `FAIL REGISTER COMPLETE_CONNECTION_REQUIRED`
- * `email-required` - if present, registrations require a valid email address to process
+ * `before-connect` - if present, indicates the server supports early
+   registration, so it MUST NOT use
+   `FAIL REGISTER COMPLETE_CONNECTION_REQUIRED`
+ * `email-required` - if present, registrations require a valid email address
+   to process
 
-Clients MUST ignore any value assigned to these keys, and MUST ignore any unknown key.
+Clients MUST ignore any value assigned to these keys, and MUST ignore
+any unknown key.
 
 Software implementing this work-in-progress specification MUST NOT use
 the unprefixed `register` or `account-registration` capability names.
@@ -50,13 +56,14 @@ a compatible work-in-progress version.
 
     REGISTER {<email> | "*"} <password>
     
-The `REGISTER` command informs the server of a request to register an account named for the current
-nick of the requestor.
+The `REGISTER` command informs the server of a request to register
+an account named for the current nick of the requestor.
 
-The `REGISTER` command MAY be sent at any point during the connection that the client has a valid
-nickname. If the client sends `REGISTER` before completing connection registration, and receives a
-`FAIL REGISTER COMPLETE_CONNECTION_REQUIRED`, it SHOULD make a second attempt after it receives the
-welcome message.
+The `REGISTER` command MAY be sent at any point during the connection
+that the client has a valid nickname.
+If the client sends `REGISTER` before completing connection registration,
+and receives a `FAIL REGISTER COMPLETE_CONNECTION_REQUIRED`, it SHOULD make
+a second attempt after it receives the welcome message.
 
     VERIFY <account> <code>
     
@@ -75,7 +82,8 @@ as if it used SASL.
     REGISTER VERIFICATION_REQUIRED <account> <message>
     
 Sent by the server as a response to `REGISTER` when further action is required
-to complete registration of the `<account>`, as explain in the human-readable `<message>`.
+to complete registration of the `<account>`, as explain in the human-readable
+`<message>`.
 
     FAIL REGISTER ACCOUNT_EXISTS <account> <message>
 
@@ -86,8 +94,8 @@ while using a nick that is not available as a new account's name
 The server MUST NOT send this response before the client sent a `NICK` command.
 
 The client MAY try registering again later.
-Clients should not automatically retry immediately without changing their nickname
-or waiting.
+Clients should not automatically retry immediately without changing
+their nickname or waiting.
 
     FAIL REGISTER NEED_NICK * <message>
 
@@ -107,7 +115,8 @@ The client MAY try registering again.
 
     FAIL REGISTER UNACCEPTABLE_PASSWORD <account> <message>
 
-Sent by the server if the password is invalid for any reason other than weakness.
+Sent by the server if the password is invalid for any reason other than
+weakness.
 
 The client MAY try registering again.
 
@@ -117,23 +126,27 @@ Sent by the server if it cannot send emails to the provided address.
 
     FAIL REGISTER UNACCEPTABLE_EMAIL <account> <message>
 
-Sent by the server if the email address is valid, but not available for account registration.
+Sent by the server if the email address is valid, but not available for
+account registration.
 
     FAIL REGISTER COMPLETE_CONNECTION_REQUIRED <message>
     FAIL VERIFY COMPLETE_CONNECTION_REQUIRED <message>
 
-Sent by the server if the client sent a `REGISTER` command before connection registration.
-The server MUST NOT sent these replies if it advertizes the `before-connect` key of the
-`draft/register` capability.
+Sent by the server if the client sent a `REGISTER` command before connection
+registration.
+The server MUST NOT sent these replies if it advertizes the `before-connect`
+key of the `draft/register` capability.
 
     FAIL VERIFY INVALID_CODE <account> <message>
 
-Sent by the server if the `<code>` in the `VERIFY` command is invalid or expired.
+Sent by the server if the `<code>` in the `VERIFY` command is invalid
+or expired.
 
     FAIL REGISTER TEMPORARILY_UNAVAILABLE <account> <message>
     FAIL VERIFY TEMPORARILY_UNAVAILABLE <account> <message>
 
-Sent by the server if the `REGISTER`/`VERIFY` commands are temporarily unavailable.
+Sent by the server if the `REGISTER`/`VERIFY` commands are temporarily
+unavailable.
 
 
 # Client considerations
@@ -143,7 +156,8 @@ This section is non-normative.
 Passwords are opaque byte strings.
 It is recommended for them to be valid UTF-8;
 or authentication may be impossible later (eg. with SASL PLAIN).
-Servers may also choose to reject any non-UTF-8 password with `UNACCEPTABLE_PASSWORD`.
+Servers may also choose to reject any non-UTF-8 password with
+`UNACCEPTABLE_PASSWORD`.
 
 As passwords may need to be sent in non-`authenticate` messages,
 like a `privmsg` to nickserv), which are limited in length, clients may want to

--- a/extensions/account-registration.md
+++ b/extensions/account-registration.md
@@ -42,7 +42,7 @@ The defined keys are:
    `FAIL REGISTER COMPLETE_CONNECTION_REQUIRED`
  * `email-required` - if present, registrations require a valid email address
    to process
- * `custom-accountname` - if present, the account name can be different
+ * `custom-account-name` - if present, the account name can be different
    from the user's current nickname
 
 Clients MUST ignore any value assigned to these keys, and MUST ignore
@@ -56,13 +56,13 @@ a compatible work-in-progress version.
 
 ### Commands
 
-    REGISTER <accountname> {<email> | "*"} <password>
+    REGISTER <account> {<email> | "*"} <password>
     
 The `REGISTER` command informs the server of a request to register
 an account named for the current nick of the requestor.
 
-If `<accountname>` is `*`, then this value is the user's current nickname.
-If the server advertises the `custom-accountname` key, then this desired
+If `<account>` is `*`, then this value is the user's current nickname.
+If the server advertises the `custom-account-name` key, then this desired
 account name can be different from the user's current nickname.
 
 The `REGISTER` command MAY be sent at any point during the connection
@@ -106,13 +106,13 @@ their nickname or waiting.
 
     FAIL REGISTER BAD_ACCOUNTNAME <account> <message>
 
-Sent by the server to indicate that the desired accountname is invalid or
+Sent by the server to indicate that the desired account name is invalid or
 otherwise restricted/disallowed. The message should tell the user how or why
 the desired name has been rejected.
 
     FAIL REGISTER ACCOUNTNAME_MUST_BE_NICK <account> <message>
 
-Sent by the server to indicate that the desired accountname does not match
+Sent by the server to indicate that the desired account name does not match
 the user's current nick, when it must match.
 
     FAIL REGISTER NEED_NICK * <message>

--- a/extensions/account-registration.md
+++ b/extensions/account-registration.md
@@ -26,7 +26,7 @@ basis for future organic expansion.
 
 ### Capability
 
-This specification adds the `draft/account-registration` capability, whose presence signifies that the server
+This specification adds the `draft/register` capability, whose presence signifies that the server
 accepts the `REGISTER` command.
 
 The capability has an optional value, a comma-separated list of key-value pairs; the format is intended
@@ -118,7 +118,7 @@ Sent by the server if the email address is valid, but not available for account 
 
 Sent by the server if the client sent a `REGISTER` command before connection registration.
 The server MUST NOT sent these replies if it advertizes the `before-connect` key of the
-`draft/account-registration` capability.
+`draft/register` capability.
 
     FAIL VERIFY INVALID_CODE <account> <message>
 

--- a/extensions/account-registration.md
+++ b/extensions/account-registration.md
@@ -120,8 +120,8 @@ the user's current nick, when it must match.
 Sent by the server if the client sends `REGISTER` before sending a NICK command.
 This is only possible in setups that advertise the `before-connect` key.
 
-    FAIL REGISTER ALREADY_REGISTERED <account> <message>
-    FAIL VERIFY ALREADY_REGISTERED <account> <message>
+    FAIL REGISTER ALREADY_AUTHENTICATED <account> <message>
+    FAIL VERIFY ALREADY_AUTHENTICATED <account> <message>
 
 Sent by the server if the client is already authenticated.
 

--- a/extensions/account-registration.md
+++ b/extensions/account-registration.md
@@ -178,7 +178,7 @@ Servers may also choose to reject any non-UTF-8 password with
 `UNACCEPTABLE_PASSWORD`.
 
 As passwords may need to be sent in non-`authenticate` messages,
-like a `privmsg` to nickserv), which are limited in length, clients may want to
+like a `PRIVMSG` to NickServ), which are limited in length, clients may want to
 prevent or discourage users from setting passwords so long they may not fit
 in these messages. 300 bytes should be a safe reasonable limit.
 
@@ -191,7 +191,7 @@ Server implementations should be careful not to accidentally send `INVALID_EMAIL
 as a response to a valid address.
 
 As passwords may need to be sent in non-`authenticate` messages,
-like a `privmsg` to nickserv), which are limited in length, servers may want to
+like a `PRIVMSG` to NickServ), which are limited in length, servers may want to
 prevent or discourage users from setting passwords so long they may not fit
 in these messages. 300 bytes should be a safe reasonable limit.
 

--- a/extensions/account-registration.md
+++ b/extensions/account-registration.md
@@ -1,5 +1,5 @@
 ---
-title: The REGISTER command
+title: `account-registration` Extension
 layout: spec
 work-in-progress: true
 copyrights:
@@ -26,7 +26,7 @@ basis for future organic expansion.
 
 ### Capability
 
-This specification adds the `draft/register` capability, whose presence signifies that the server
+This specification adds the `draft/account-registration` capability, whose presence signifies that the server
 accepts the `REGISTER` command.
 
 The capability has an optional value, a comma-separated list of key-value pairs; the format is intended
@@ -113,7 +113,7 @@ Sent by the server if the email address is valid, but not available for account 
 
 Sent by the server if the client sent a `REGISTER` command before connection registration.
 The server MUST NOT sent these replies if it advertizes the `before-connect` key of the
-`draft/register` capability.
+`draft/account-registration` capability.
 
     FAIL VERIFY INVALID_CODE <account> <message>
 

--- a/extensions/register.md
+++ b/extensions/register.md
@@ -108,8 +108,8 @@ Sent by the server if it cannot send emails to the provided address.
 
 Sent by the server if the email address is valid, but not available for account registration.
 
-    FAIL REGISTER COMPLETE_CONNECTION_REQUIRED
-    FAIL VERIFY COMPLETE_CONNECTION_REQUIRED
+    FAIL REGISTER COMPLETE_CONNECTION_REQUIRED <message>
+    FAIL VERIFY COMPLETE_CONNECTION_REQUIRED <message>
 
 Sent by the server if the client sent a `REGISTER` command before connection registration.
 The server MUST NOT sent these replies if it advertizes the `before-connect` key of the

--- a/extensions/register.md
+++ b/extensions/register.md
@@ -38,6 +38,8 @@ The defined keys are:
    MUST NOT use `FAIL REGISTER COMPLETE_CONNECTION_REQUIRED`
  * `email-required` - if present, registrations require a valid email address to process
 
+Clients MUST ignore any value assigned to these keys, and MUST ignore any unknown key.
+
 ### Commands
 
     REGISTER {<email> | "*"} <password>

--- a/extensions/register.md
+++ b/extensions/register.md
@@ -134,6 +134,11 @@ It is recommended for them to be valid UTF-8;
 or authentication may be impossible later (eg. with SASL PLAIN).
 Servers may also choose to reject any non-UTF-8 password with `UNACCEPTABLE_PASSWORD`.
 
+As passwords may need to be sent in non-`authenticate` messages,
+like a `privmsg` to nickserv), which are limited in length, clients may want to
+prevent or discourage users from setting passwords so long they may not fit
+in these messages. 300 bytes should be a safe reasonable limit.
+
 
 # Server considerations
 
@@ -141,6 +146,11 @@ This section is non-normative.
 
 Server implementations should be careful not to accidentally send `INVALID_EMAIL`
 as a response to a valid address.
+
+As passwords may need to be sent in non-`authenticate` messages,
+like a `privmsg` to nickserv), which are limited in length, servers may want to
+prevent or discourage users from setting passwords so long they may not fit
+in these messages. 300 bytes should be a safe reasonable limit.
 
 
 

--- a/extensions/register.md
+++ b/extensions/register.md
@@ -44,6 +44,7 @@ The `VERIFY` command completes a registration that required email verification.
 ### Responses
 
     REGISTER SUCCESS <account> <message>
+    VERIFY SUCCESS <account> <message>
     
 TBC
 
@@ -57,6 +58,12 @@ TBC
     FAIL REGISTER INVALID_EMAIL <account> <message>
     FAIL REGISTER UNACCEPTABLE_EMAIL <account> <message>
     FAIL REGISTER COMPLETE_CONNECTION_REQUIRED
+    FAIL VERIFY USERNAME_EXISTS <account> <message>
+    FAIL VERIFY ALREADY_REGISTERED <account> <message>
+    FAIL VERIFY WEAK_PASSWORD <account> <message>
+    FAIL VERIFY INVALID_EMAIL <account> <message>
+    FAIL VERIFY UNACCEPTABLE_EMAIL <account> <message>
+    FAIL VERIFY COMPLETE_CONNECTION_REQUIRED
 
 TBC
 

--- a/extensions/register.md
+++ b/extensions/register.md
@@ -32,9 +32,6 @@ accepts the `REGISTER` command.
 The capability has an optional value, a comma-separated list of key-value pairs; the format is intended
 to follow the precedent set by [the multiline draft][multiline].
 
-The `draft/register` capability SHOULD NOT be requested. Servers MAY `NAK` any such request. The
-`REGISTER` command MUST be accepted regardless of any attempt to negotiate or disable the capability.
-
 The defined keys are:
 
  * `before-connect` - if present, indicates the server supports early registration, so it

--- a/extensions/register.md
+++ b/extensions/register.md
@@ -1,0 +1,65 @@
+# /register
+
+## Motivation
+
+The lack of a standardized way to register an account has been a source of frustration for many participants
+for several years.
+
+This isn't the first attempt to fix it. Unlike the withdrawn `ACC` proposal, this effort aims to be more
+appealing to implementors by being severely restricted in scope. The only register-verify flows supported
+are those already in use in the wild. The authors hope that this stripped-down solution will serve as the
+basis for future organic expansion.
+
+### Capability
+
+This specification adds the `draft/register` capability, whose presence signifies that the server
+accepts the `REGISTER` command.
+
+The capability has an optional value, a comma-separated list of key-value pairs; the format is intended
+to follow the precedent set by [the multiline draft][multiline].
+
+The `draft/register` capability SHOULD NOT be requested. Servers MAY `NAK` any such request. The
+`REGISTER` command MUST be accepted regardless of any attempt to negotiate or disable the capability.
+
+The defined keys are:
+
+ * `email-required` - if present, registrations require a valid email address to process
+
+### Commands
+
+    REGISTER {<email> | "*"} <password>
+    
+The `REGISTER` command informs the server of a request to register an account named for the current
+nick of the requestor.
+
+The `REGISTER` command MAY be sent at any point during the connection that the client has a valid
+nickname. If the client sends `REGISTER` before completing connection registration, and receives a
+`FAIL REGISTER COMPLETE_CONNECTION_REQUIRED`, it SHOULD make a second attempt after it receives the
+welcome message.
+
+    VERIFY <account> <code>
+    
+The `VERIFY` command completes a registration that required email verification.
+
+### Responses
+
+    REGISTER SUCCESS <account> <message>
+    
+TBC
+
+    REGISTER VERIFICATION_REQUIRED <account> <message>
+    
+TBC
+
+    FAIL REGISTER USERNAME_EXISTS <account> <message>
+    FAIL REGISTER ALREADY_REGISTERED <account> <message>
+    FAIL REGISTER WEAK_PASSWORD <account> <message>
+    FAIL REGISTER INVALID_EMAIL <account> <message>
+    FAIL REGISTER UNACCEPTABLE_EMAIL <account> <message>
+    FAIL REGISTER COMPLETE_CONNECTION_REQUIRED
+
+TBC
+
+
+
+[multiline]: https://github.com/ircv3/ircv3-specifications/pull/398/

--- a/extensions/register.md
+++ b/extensions/register.md
@@ -23,7 +23,8 @@ The `draft/register` capability SHOULD NOT be requested. Servers MAY `NAK` any s
 
 The defined keys are:
 
- * `before-connect` - if present, clients may register before completing connection registration
+ * `before-connect` - if present, indicates the server supports early registration, so it
+   MUST NOT use `FAIL REGISTER COMPLETE_CONNECTION_REQUIRED`
  * `email-required` - if present, registrations require a valid email address to process
 
 ### Commands

--- a/extensions/register.md
+++ b/extensions/register.md
@@ -59,16 +59,27 @@ Sent by the server as a response to `REGISTER` when further action is required
 to complete registration of the `<account>`, as explain in the human-readable `<message>`.
 
     FAIL REGISTER USERNAME_EXISTS <account> <message>
+
+TBC
+
     FAIL REGISTER ALREADY_REGISTERED <account> <message>
-    FAIL REGISTER WEAK_PASSWORD <account> <message>
-    FAIL REGISTER INVALID_EMAIL <account> <message>
-    FAIL REGISTER UNACCEPTABLE_EMAIL <account> <message>
-    FAIL REGISTER COMPLETE_CONNECTION_REQUIRED
-    FAIL VERIFY USERNAME_EXISTS <account> <message>
     FAIL VERIFY ALREADY_REGISTERED <account> <message>
-    FAIL VERIFY WEAK_PASSWORD <account> <message>
-    FAIL VERIFY INVALID_EMAIL <account> <message>
-    FAIL VERIFY UNACCEPTABLE_EMAIL <account> <message>
+
+TBC
+
+    FAIL REGISTER WEAK_PASSWORD <account> <message>
+
+TBC
+
+    FAIL REGISTER INVALID_EMAIL <account> <message>
+
+TBC
+
+    FAIL REGISTER UNACCEPTABLE_EMAIL <account> <message>
+
+TBC
+
+    FAIL REGISTER COMPLETE_CONNECTION_REQUIRED
     FAIL VERIFY COMPLETE_CONNECTION_REQUIRED
 
 TBC

--- a/extensions/register.md
+++ b/extensions/register.md
@@ -112,5 +112,16 @@ Sent by the server if the client sent a `REGISTER` command before connection reg
 The server MUST NOT sent these replies if it advertizes the `before-connect` key of the
 `draft/register` capability.
 
+    FAIL VERIFY INVALID_CODE <account> <message>
+
+Sent by the server if the `<code>` in the `VERIFY` command is invalid or expired.
+
+    FAIL REGISTER TEMPORARILY_UNAVAILABLE <account> <message>
+    FAIL VERIFY TEMPORARILY_UNAVAILABLE <account> <message>
+
+Sent by the server if the `REGISTER`/`VERIFY` commands are temporarily unavailable.
+
+
+
 
 [multiline]: https://github.com/ircv3/ircv3-specifications/pull/398/

--- a/extensions/register.md
+++ b/extensions/register.md
@@ -1,4 +1,18 @@
-# /register
+---
+title: The REGISTER command
+layout: spec
+work-in-progress: true
+copyrights:
+  -
+    name: "Ed Kellett"
+    period: "2020"
+    email: "e@kellett.im"
+  -
+    name: "Val Lorentz"
+    period: "2021"
+    email: "progval+ircv3@progval.net"
+---
+
 
 ## Motivation
 
@@ -97,5 +111,6 @@ Sent by the server if the email address is valid, but not available for account 
 Sent by the server if the client sent a `REGISTER` command before connection registration.
 The server MUST NOT sent these replies if it advertizes the `before-connect` key of the
 `draft/register` capability.
+
 
 [multiline]: https://github.com/ircv3/ircv3-specifications/pull/398/

--- a/extensions/register.md
+++ b/extensions/register.md
@@ -94,11 +94,15 @@ Sent by the server if the password is considered too weak.
 
 The client MAY try registering again.
 
+    FAIL REGISTER UNACCEPTABLE_PASSWORD <account> <message>
+
+Sent by the server if the password is invalid for any reason other than weakness.
+
+The client MAY try registering again.
+
     FAIL REGISTER INVALID_EMAIL <account> <message>
 
 Sent by the server if it cannot send emails to the provided address.
-Server implementations should be careful not to accidentally send this as a response
-to a valid address.
 
     FAIL REGISTER UNACCEPTABLE_EMAIL <account> <message>
 
@@ -120,6 +124,23 @@ Sent by the server if the `<code>` in the `VERIFY` command is invalid or expired
 
 Sent by the server if the `REGISTER`/`VERIFY` commands are temporarily unavailable.
 
+
+# Client considerations
+
+This section is non-normative.
+
+Passwords are opaque byte strings.
+It is recommended for them to be valid UTF-8 with no null character;
+otherwise authentication may be impossible later (eg. with SASL PLAIN).
+Servers may also choose to reject any non-UTF-8 password with `UNACCEPTABLE_PASSWORD`.
+
+
+# Server considerations
+
+This section is non-normative.
+
+Server implementations should be careful not to accidentally send `INVALID_EMAIL`
+as a response to a valid address.
 
 
 

--- a/extensions/register.md
+++ b/extensions/register.md
@@ -130,8 +130,8 @@ Sent by the server if the `REGISTER`/`VERIFY` commands are temporarily unavailab
 This section is non-normative.
 
 Passwords are opaque byte strings.
-It is recommended for them to be valid UTF-8 with no null character;
-otherwise authentication may be impossible later (eg. with SASL PLAIN).
+It is recommended for them to be valid UTF-8;
+or authentication may be impossible later (eg. with SASL PLAIN).
 Servers may also choose to reject any non-UTF-8 password with `UNACCEPTABLE_PASSWORD`.
 
 

--- a/extensions/register.md
+++ b/extensions/register.md
@@ -60,30 +60,42 @@ to complete registration of the `<account>`, as explain in the human-readable `<
 
     FAIL REGISTER USERNAME_EXISTS <account> <message>
 
-TBC
+Sent by the server as a response to `REGISTER` when the client tried to register
+while using a nick that is not available as a new account's name
+(for example, because someone already registered it).
+
+The server MUST NOT send this response before the client sent a `NICK` command.
+
+The client MAY try registering again later.
+Clients should not automatically retry immediately without changing their nickname
+or waiting.
 
     FAIL REGISTER ALREADY_REGISTERED <account> <message>
     FAIL VERIFY ALREADY_REGISTERED <account> <message>
 
-TBC
+Sent by the server is the client is already authenticated.
 
     FAIL REGISTER WEAK_PASSWORD <account> <message>
 
-TBC
+Sent by the server if the password is considered too weak.
+
+The client MAY try registering again.
 
     FAIL REGISTER INVALID_EMAIL <account> <message>
 
-TBC
+Sent by the server if it cannot send emails to the provided address.
+Server implementations should be careful not to accidentally send this as a response
+to a valid address.
 
     FAIL REGISTER UNACCEPTABLE_EMAIL <account> <message>
 
-TBC
+Sent by the server if the email address is valid, but not available for account registration.
 
     FAIL REGISTER COMPLETE_CONNECTION_REQUIRED
     FAIL VERIFY COMPLETE_CONNECTION_REQUIRED
 
-TBC
-
-
+Sent by the server if the client sent a `REGISTER` command before connection registration.
+The server MUST NOT sent these replies if it advertizes the `before-connect` key of the
+`draft/register` capability.
 
 [multiline]: https://github.com/ircv3/ircv3-specifications/pull/398/

--- a/extensions/register.md
+++ b/extensions/register.md
@@ -23,6 +23,7 @@ The `draft/register` capability SHOULD NOT be requested. Servers MAY `NAK` any s
 
 The defined keys are:
 
+ * `before-connect` - if present, clients may register before completing connection registration
  * `email-required` - if present, registrations require a valid email address to process
 
 ### Commands

--- a/extensions/register.md
+++ b/extensions/register.md
@@ -48,11 +48,15 @@ The `VERIFY` command completes a registration that required email verification.
     REGISTER SUCCESS <account> <message>
     VERIFY SUCCESS <account> <message>
     
-TBC
+Sent by the server when the `REGISTER` or `VERIFY` fully succeeded, and no
+further action is needed.
+Afterward, the client is assumed to be authenticated to the `<account>`
+as if it used SASL.
 
     REGISTER VERIFICATION_REQUIRED <account> <message>
     
-TBC
+Sent by the server as a response to `REGISTER` when further action is required
+to complete registration of the `<account>`, as explain in the human-readable `<message>`.
 
     FAIL REGISTER USERNAME_EXISTS <account> <message>
     FAIL REGISTER ALREADY_REGISTERED <account> <message>


### PR DESCRIPTION
This draft specification adds **simple** `REGISTER` and `VERIFY` commands to standardize account creation, as a replacement for the withdrawn [Account Management Framework](https://github.com/ircv3/ircv3-specifications/pull/276)

It is based on @edk0's [draft](https://gist.github.com/edk0/bf3b50fc219fd1bed1aa15d98bfb6495), and is implemented by Oragono and Limnoria.

[rendered view](https://github.com/ProgVal/ircv3-specifications/blob/register/extensions/register.md)