### PR TITLE
Bot mode (+B)

### DIFF
--- a/extensions/bot-mode.md
+++ b/extensions/bot-mode.md
@@ -35,7 +35,7 @@ This numeric is returned as part of a bot's `WHOIS` reply.
 When a `RPL_WHOREPLY` `(352)` numeric is returned for a bot, the character used as the value of the ISUPPORT `BOT` token is returned in the flags (alongside `H|G`).
 
 ## The `draft/bot` tag
-The `draft/bot` tag indicates that the given user is a bot. This tag SHOULD be added by the server to all commands sent by a bot (e.g. `PRIVMSG`, `JOIN`, `MODE`, `NOTICE`, and all others). The tag SHOULD also be added by the ircd to all numerics directly caused by the bot. This tag MUST only be sent to users who have requested the `message-tags` capability.
+The `draft/bot` tag indicates that the given user is a bot. This tag SHOULD be added by the server to all commands sent by a bot (e.g. `PRIVMSG`, `JOIN`, `MODE`, `NOTICE`, and all others). The tag SHOULD also be added by the ircd to all numerics directly caused by the bot. This tag MUST only be sent to users who have requested the `message-tags` capability. Servers MUST NOT send this tag with a value, and clients MUST ignore any value if it exists.
 
 ## Examples
 
@@ -74,3 +74,8 @@ Server: :irc.ircv3.net 315 alice #chat :End of WHO list
 Server: @draft/bot :robodan!~u@203.0.113.22 PRIVMSG #chat :Hello! Try typing .help to see my commands!
 ```
 The conventional `BOT` ISUPPORT value is `"B"`, but this example uses `"b"` to demonstrate where the value's used.
+
+```
+Server: @draft/bot=someFutureValueHere=2343 :robodan!~u@203.0.113.22 PRIVMSG #chat :Hello! Try typing .help to see my commands!
+```
+Example of some future value being sent, which the receiving client will ignore and process as a bare `@draft/bot` tag.

--- a/extensions/bot-mode.md
+++ b/extensions/bot-mode.md
@@ -1,0 +1,64 @@
+---
+title: Bot Mode
+layout: spec
+meta-description: A user mode that indicates a user is a bot.
+copyrights:
+  -
+    name: "Daniel Oaks"
+    period: "2021"
+    email: "daniel@danieloaks.net"
+---
+
+## Introduction
+This is a standardised mode that lets clients mark themselves as bots, and lets other clients see them as bots.
+
+## The `BOT` ISUPPORT token
+Servers publishing the `BOT` [ISUPPORT](https://modern.ircdocs.horse/#feature-advertisement) token let clients mark themselves as bots by setting a user mode. The value of the `BOT` token is the mode character which is used to enable bot mode (e.g. `BOT=B` or `BOT=b`).
+
+When a client is marked as a bot, they are given a special numeric as part of their `WHOIS` response, it is indicated in their `WHO` flags, and servers may include the `bot` tag on that client's outgoing messages.
+
+## The `RPL_WHOISBOT` `(335)` numeric
+This numeric is returned as part of a bot's `WHOIS` reply.
+
+## The `B` `WHO` flag
+When a `RPL_WHOREPLY` `(352)` numeric is returned for a bot, the `"B"` character is returned in the flags (alongside `H|G`).
+
+## The `bot` tag
+The `bot` tag indicates that the given user is a bot. This tag SHOULD be added by the server to all commands sent by a bot (e.g. `PRIVMSG`, `JOIN`, `MODE`, `NOTICE`, and all others). The tag SHOULD also be added by the ircd to all numerics directly caused by the bot. This tag MUST only be sent to users who have requested the `message-tags` capability.
+
+## Examples
+
+```
+Bot:    NICK robodan
+Bot:    USER u * * :Hi, I'm a bot!
+Server: :irc.ircv3.net 001 robodan :Welcome to the IRCv3 IRC Network robodan
+Server: [ ... ]
+Server: :irc.ircv3.net 005 robodan BOT=b CASEMAPPING=ascii CHANNELLEN=64 CHANTYPES=# ELIST=U EXCEPTS EXTBAN=,m :are supported by this server
+Server: [ ... ]
+Bot:    MODE robodan +b
+Server: :robodan!~u@203.0.113.22 MODE robodan +b
+Bot:    WHOIS robodan
+Server: :irc.ircv3.net 311 robodan robodan ~u 203.0.113.22 * :Hi, I'm a bot!
+Server: :irc.ircv3.net 338 robodan robodan ~u@203.0.113.22 203.0.113.22 :Actual user@host, Actual IP
+Server: :irc.ircv3.net 379 robodan robodan :is using modes +bi
+Server: :irc.ircv3.net 335 robodan robodan :is a Bot on IRCv3
+Server: :irc.ircv3.net 317 robodan robodan 24 1614290357 :seconds idle, signon time
+Server: :irc.ircv3.net 318 robodan robodan :End of /WHOIS list
+Bot:    WHO robodan
+Server: :irc.ircv3.net 352 robodan * ~u 203.0.113.22 irc.ircv3.net robodan HB :0 Hi, I'm a bot!
+Server: :irc.ircv3.net 315 robodan robodan!*@* :End of WHO list
+
+
+Alice:  whois robodan
+Server: :irc.ircv3.net 311 alice robodan ~u 203.0.113.22 * :Hi, I'm a bot!
+Server: :irc.ircv3.net 319 alice robodan :#chat
+Server: :irc.ircv3.net 335 alice robodan :is a Bot on IRCv3
+Server: :irc.ircv3.net 317 alice robodan 258 1614290467 :seconds idle, signon time
+Server: :irc.ircv3.net 318 alice robodan :End of /WHOIS list
+Alice:  who #chat
+Server: :irc.ircv3.net 352 alice #chat ~u 198.51.100.103 irc.ircv3.net alice H :0 I'm a human!
+Server: :irc.ircv3.net 352 alice #chat ~u 203.0.113.22 irc.ircv3.net robodan HB :0 Hi, I'm a bot!
+Server: :irc.ircv3.net 315 alice #chat :End of WHO list
+[ ... ]
+Server: @bot :robodan!~u@203.0.113.22 PRIVMSG #chat :Hello! Try typing .help to see my commands!
+```

--- a/extensions/bot-mode.md
+++ b/extensions/bot-mode.md
@@ -39,6 +39,7 @@ The `draft/bot` tag indicates that the given user is a bot. This tag SHOULD be a
 
 ## Examples
 
+The conventional `BOT` ISUPPORT value is `"B"`, but this example uses `"b"` to demonstrate where the value's used:
 ```
 Bot:    NICK robodan
 Bot:    USER u * * :Hi, I'm a bot!
@@ -73,9 +74,8 @@ Server: :irc.ircv3.net 315 alice #chat :End of WHO list
 [ ... ]
 Server: @draft/bot :robodan!~u@203.0.113.22 PRIVMSG #chat :Hello! Try typing .help to see my commands!
 ```
-The conventional `BOT` ISUPPORT value is `"B"`, but this example uses `"b"` to demonstrate where the value's used.
 
+Example of some future value being sent, which the receiving client will ignore and process as a bare `@draft/bot` tag:
 ```
 Server: @draft/bot=someFutureValueHere=2343 :robodan!~u@203.0.113.22 PRIVMSG #chat :Hello! Try typing .help to see my commands!
 ```
-Example of some future value being sent, which the receiving client will ignore and process as a bare `@draft/bot` tag.

--- a/extensions/bot-mode.md
+++ b/extensions/bot-mode.md
@@ -13,15 +13,15 @@ copyrights:
 This is a standardised mode that lets clients mark themselves as bots, and lets other clients see them as bots.
 
 ## The `BOT` ISUPPORT token
-Servers publishing the `BOT` [ISUPPORT](https://modern.ircdocs.horse/#feature-advertisement) token let clients mark themselves as bots by setting a user mode. The value of the `BOT` token is the mode character which is used to enable bot mode (e.g. `BOT=B` or `BOT=b`).
+Servers publishing the `BOT` [ISUPPORT](https://modern.ircdocs.horse/#feature-advertisement) token let clients mark themselves as bots by setting a user mode. The value of the `BOT` token is the mode character which is used to enable bot mode and is also the flag used in `WHO` responses of bots (e.g. `BOT=B` or `BOT=b`).
 
 When a client is marked as a bot, they are given a special numeric as part of their `WHOIS` response, it is indicated in their `WHO` flags, and servers may include the `bot` tag on that client's outgoing messages.
 
 ## The `RPL_WHOISBOT` `(335)` numeric
 This numeric is returned as part of a bot's `WHOIS` reply.
 
-## The `B` `WHO` flag
-When a `RPL_WHOREPLY` `(352)` numeric is returned for a bot, the `"B"` character is returned in the flags (alongside `H|G`).
+## The `WHO` bot flag
+When a `RPL_WHOREPLY` `(352)` numeric is returned for a bot, the character used as the value of the ISUPPORT `BOT` token is returned in the flags (alongside `H|G`).
 
 ## The `bot` tag
 The `bot` tag indicates that the given user is a bot. This tag SHOULD be added by the server to all commands sent by a bot (e.g. `PRIVMSG`, `JOIN`, `MODE`, `NOTICE`, and all others). The tag SHOULD also be added by the ircd to all numerics directly caused by the bot. This tag MUST only be sent to users who have requested the `message-tags` capability.
@@ -45,7 +45,7 @@ Server: :irc.ircv3.net 335 robodan robodan :is a Bot on IRCv3
 Server: :irc.ircv3.net 317 robodan robodan 24 1614290357 :seconds idle, signon time
 Server: :irc.ircv3.net 318 robodan robodan :End of /WHOIS list
 Bot:    WHO robodan
-Server: :irc.ircv3.net 352 robodan * ~u 203.0.113.22 irc.ircv3.net robodan HB :0 Hi, I'm a bot!
+Server: :irc.ircv3.net 352 robodan * ~u 203.0.113.22 irc.ircv3.net robodan Hb :0 Hi, I'm a bot!
 Server: :irc.ircv3.net 315 robodan robodan!*@* :End of WHO list
 
 
@@ -57,8 +57,9 @@ Server: :irc.ircv3.net 317 alice robodan 258 1614290467 :seconds idle, signon ti
 Server: :irc.ircv3.net 318 alice robodan :End of /WHOIS list
 Alice:  who #chat
 Server: :irc.ircv3.net 352 alice #chat ~u 198.51.100.103 irc.ircv3.net alice H :0 I'm a human!
-Server: :irc.ircv3.net 352 alice #chat ~u 203.0.113.22 irc.ircv3.net robodan HB :0 Hi, I'm a bot!
+Server: :irc.ircv3.net 352 alice #chat ~u 203.0.113.22 irc.ircv3.net robodan Hb :0 Hi, I'm a bot!
 Server: :irc.ircv3.net 315 alice #chat :End of WHO list
 [ ... ]
 Server: @bot :robodan!~u@203.0.113.22 PRIVMSG #chat :Hello! Try typing .help to see my commands!
 ```
+The conventional `BOT` ISUPPORT value is `"B"`, but this example uses `"b"` to demonstrate where the value's used.

--- a/extensions/bot-mode.md
+++ b/extensions/bot-mode.md
@@ -9,6 +9,17 @@ copyrights:
     email: "daniel@danieloaks.net"
 ---
 
+## Notes for implementing work-in-progress version
+
+This is a work-in-progress specification.
+
+Software implementing this work-in-progress specification MUST NOT use the
+unprefixed `bot` tag name. Instead, implementations SHOULD use the
+`draft/bot` tag name to be interoperable with other software
+implementing a compatible work-in-progress version.
+
+The final version of the specification will use an unprefixed tag name.
+
 ## Introduction
 This is a standardised mode that lets clients mark themselves as bots, and lets other clients see them as bots.
 
@@ -23,8 +34,8 @@ This numeric is returned as part of a bot's `WHOIS` reply.
 ## The `WHO` bot flag
 When a `RPL_WHOREPLY` `(352)` numeric is returned for a bot, the character used as the value of the ISUPPORT `BOT` token is returned in the flags (alongside `H|G`).
 
-## The `bot` tag
-The `bot` tag indicates that the given user is a bot. This tag SHOULD be added by the server to all commands sent by a bot (e.g. `PRIVMSG`, `JOIN`, `MODE`, `NOTICE`, and all others). The tag SHOULD also be added by the ircd to all numerics directly caused by the bot. This tag MUST only be sent to users who have requested the `message-tags` capability.
+## The `draft/bot` tag
+The `draft/bot` tag indicates that the given user is a bot. This tag SHOULD be added by the server to all commands sent by a bot (e.g. `PRIVMSG`, `JOIN`, `MODE`, `NOTICE`, and all others). The tag SHOULD also be added by the ircd to all numerics directly caused by the bot. This tag MUST only be sent to users who have requested the `message-tags` capability.
 
 ## Examples
 
@@ -60,6 +71,6 @@ Server: :irc.ircv3.net 352 alice #chat ~u 198.51.100.103 irc.ircv3.net alice H :
 Server: :irc.ircv3.net 352 alice #chat ~u 203.0.113.22 irc.ircv3.net robodan Hb :0 Hi, I'm a bot!
 Server: :irc.ircv3.net 315 alice #chat :End of WHO list
 [ ... ]
-Server: @bot :robodan!~u@203.0.113.22 PRIVMSG #chat :Hello! Try typing .help to see my commands!
+Server: @draft/bot :robodan!~u@203.0.113.22 PRIVMSG #chat :Hello! Try typing .help to see my commands!
 ```
 The conventional `BOT` ISUPPORT value is `"B"`, but this example uses `"b"` to demonstrate where the value's used.


### PR DESCRIPTION
This specification defines the Bot mode, ISUPPORT token and WHO flags which are already in use by a number of IRC servers. It also defines the `bot` tag, which is in use as a vendor tag by InspIRCd right now (as `inspircd.org/bot`).

Short, sweet, simple. Mostly explains existing behaviour apart from that `bot` tag, and I don't really feel like it's necessary to go through the whole `draft/` prefix for six months stage for something which is a simple tag like this.

Discussion happened in https://github.com/ircv3/ircv3-ideas/issues/43 and servers implemented and converged on this behaviour (apart from the tag) during that discussion.