### PR TITLE
[multiline] Relax restriction on clients sending unrelated messages

### DIFF
--- a/extensions/multiline.md
+++ b/extensions/multiline.md
@@ -80,8 +80,6 @@ Servers MUST NOT reject blank lines other than in the following cases:
 * Clients MUST NOT send blank lines with the `draft/multiline-concat` tag.
 * Clients MUST NOT send messages consisting entirely of blank lines.
 
-Clients MUST NOT send messages other than PRIVMSG while a multiline batch is open.
-
 ### Fallback
 
 When delivering multiline batches to clients that have not negotiated the multiline capability, servers MUST deliver the component messages without using a multiline BATCH.


### PR DESCRIPTION
Upholding this requirement can be excessively hard to implement
for some clients (eg. if they have multiple queues and/or are threaded).

S2C batches do not have this constraint, so C2S batches
shouldn't either, unless this is a significant burden on server
implementations.

(I'm aware this conflicts with #436, but I'd like a discussion on the
idea behind the change)