### PR TITLE
chathistory: soften FAIL code guarantees for programming errors

### DIFF
--- a/extensions/chathistory.md
+++ b/extensions/chathistory.md
@@ -107,6 +107,8 @@ If the server receives a syntactically invalid `CHATHISTORY` command, e.g., an u
     FAIL CHATHISTORY INVALID_PARAMS the_given_command :Too many parameters
     FAIL CHATHISTORY INVALID_PARAMS the_given_command the_given_timestamp :Invalid timestamp
 
+If an existing error numeric such as `ERR_NEEDMOREPARAMS` is appropriate, it MAY be used instead.
+
 If the target does not exist or the client does not have permissions to query it, the `INVALID_TARGET` error code SHOULD be returned:
 
     FAIL CHATHISTORY INVALID_TARGET the_given_command the_given_target :Messages could not be retrieved

--- a/extensions/chathistory.md
+++ b/extensions/chathistory.md
@@ -100,23 +100,18 @@ Servers SHOULD provide clients with a consistent message order that is valid acr
 #### Errors and Warnings
 Errors are returned using the standard replies syntax.
 
-If the server receives a `CHATHISTORY` command with an unknown subcommand, the `UNKNOWN_COMMAND` error code MUST be returned.
+If the server receives a syntactically invalid `CHATHISTORY` command, e.g., an unknown subcommand, missing parameters, excess parameters, or parameters that cannot be parsed, the `INVALID_PARAMS` error code SHOULD be returned:
 
-    FAIL CHATHISTORY UNKNOWN_COMMAND the_given_command :Unknown command
+    FAIL CHATHISTORY INVALID_PARAMS the_given_command :Unknown command
+    FAIL CHATHISTORY INVALID_PARAMS the_given_command :Insufficient parameters
+    FAIL CHATHISTORY INVALID_PARAMS the_given_command :Too many parameters
+    FAIL CHATHISTORY INVALID_PARAMS the_given_command the_given_timestamp :Invalid timestamp
 
-If the server receives a `CHATHISTORY` command with missing parameters, the `NEED_MORE_PARAMS` error code MUST be returned.
+If the target does not exist or the client does not have permissions to query it, the `INVALID_TARGET` error code SHOULD be returned:
 
-    FAIL CHATHISTORY NEED_MORE_PARAMS the_given_command :Missing parameters
+    FAIL CHATHISTORY INVALID_TARGET the_given_command the_given_target :Messages could not be retrieved
 
-If the selectors or limit supplied were invalid, the `INVALID_PARAMS` error code SHOULD be returned.
-
-    FAIL CHATHISTORY INVALID_PARAMS the_given_command [the_invalid_parameters] :Invalid parameters
-
-If the target does not exist or the client does not have permissions to query it, the `INVALID_TARGET` error code SHOULD be returned.
-
-    FAIL CHATHISTORY INVALID_TARGET the_given_command :Messages could not be retrieved
-
-If no message history can be returned due to an error, the `MESSAGE_ERROR` error code SHOULD be returned.
+If no message history can be returned due to an error, the `MESSAGE_ERROR` error code SHOULD be returned:
 
     FAIL CHATHISTORY MESSAGE_ERROR the_given_command the_given_target [extra_context] :Messages could not be retrieved
 


### PR DESCRIPTION
@kylef alerted me to the fact that Oragono violates a MUST of the current spec: "If the server receives a `CHATHISTORY` command with missing parameters, the `NEED_MORE_PARAMS` error code MUST be returned." Oragono will send `461 ERR_NEEDMOREPARAMS` in some cases, based on generic command-handling logic.

Upon consideration, there doesn't seem to be much of a point in having a MUST here at all, or in requiring distinct error codes for `UNKNOWN_COMMAND` and `NEED_MORE_PARAMS`: these are both programming errors, rather than runtime errors, and they're unrecoverable at runtime, so the only job of the error message is to illuminate the problem for debugging. Hence this proposed change does the following:

1. All FAIL codes are now SHOULD
2. All unrecoverable programming errors are now `INVALID_PARAMS`
3. `INVALID_TARGET` (which is a potentially recoverable runtime error) now includes the target as its second parameter