### PR TITLE
Drop 3.2/3.3 suffix in links, make sure .html suffix is consistently used

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,7 @@ Contributing to the [ircv3-ideas](https://github.com/ircv3/ircv3-ideas) reposito
 
 ## Feature Proposals
 
-A new feature proposal includes things like [`account-tag`](http://ircv3.net/specs/extensions/account-tag-3.2.html), [`cap-notify`](http://ircv3.net/specs/core/capability-negotiation.html) and [`echo-message`](http://ircv3.net/specs/extensions/echo-message-3.2.html).
+A new feature proposal includes things like [`account-tag`](http://ircv3.net/specs/extensions/account-tag.html), [`cap-notify`](http://ircv3.net/specs/core/capability-negotiation.html) and [`echo-message`](http://ircv3.net/specs/extensions/echo-message.html).
 
 Contributing a proposal to the IRCv3-Specifications repo requires a few things. These include:
 
@@ -50,7 +50,7 @@ If your proposal is accepted, in the course of drafting an IRCv3 release it will
 
 ### Existing Implementations
 
-If a feature specifies capabilities that already exist in the IRC ecosystem, such as [`monitor`](http://ircv3.net/specs/core/monitor-3.2.html), it should be ensured that any proposal of this type is backwards-compatible with existing implementations.
+If a feature specifies capabilities that already exist in the IRC ecosystem, such as [`monitor`](http://ircv3.net/specs/core/monitor.html), it should be ensured that any proposal of this type is backwards-compatible with existing implementations.
 
 ## Ratifying Feature Proposals
 

--- a/batches/chathistory.md
+++ b/batches/chathistory.md
@@ -43,5 +43,5 @@ be tagged with the time at which they were originally sent.
     @batch=sxtUfAeXBgNoD;time=2015-06-26T19:43:53.410Z :local!bar@example.com PRIVMSG remote :Tortoises are better.
     :irc.host BATCH -sxtUfAeXBgNoD
 
-[batch]: ../batch.html
-[server-time]: ../server-time.html
+[batch]: ../extensions/batch.html
+[server-time]: ../extensions/server-time.html

--- a/batches/chathistory.md
+++ b/batches/chathistory.md
@@ -43,5 +43,5 @@ be tagged with the time at which they were originally sent.
     @batch=sxtUfAeXBgNoD;time=2015-06-26T19:43:53.410Z :local!bar@example.com PRIVMSG remote :Tortoises are better.
     :irc.host BATCH -sxtUfAeXBgNoD
 
-[batch]: ../batch-3.2.html
-[server-time]: ../server-time-3.2.html
+[batch]: ../batch.html
+[server-time]: ../server-time.html

--- a/client-tags/reply.md
+++ b/client-tags/reply.md
@@ -28,7 +28,7 @@ This specification defines a client-only message tag to indicate replies to othe
 
 ### Dependencies
 
-Clients wishing to use this tag MUST negotiate the [`message-tags`](../extensions/message-tags.html) capability with the server. Additionally, this tag relies on messages being sent with the [`msgid`](../extensions/message-ids.html) tag. Clients SHOULD negotiate the [`echo-message`](../extensions/echo-message-3.2.html) capability in order to receive message IDs for their own messages, and therefore understand any replies.
+Clients wishing to use this tag MUST negotiate the [`message-tags`](../extensions/message-tags.html) capability with the server. Additionally, this tag relies on messages being sent with the [`msgid`](../extensions/message-ids.html) tag. Clients SHOULD negotiate the [`echo-message`](../extensions/echo-message.html) capability in order to receive message IDs for their own messages, and therefore understand any replies.
 
 ### Format
 

--- a/client-tags/typing.md
+++ b/client-tags/typing.md
@@ -75,5 +75,5 @@ Client begins typing then clears the text-input field without sending the messag
 
     Client: @+typing=done :nick!ident@host TAGMSG target
 
-[batch]: ../extensions/batch-3.2.html
+[batch]: ../extensions/batch.html
 [tags]: ../extensions/message-tags.html

--- a/extensions/batch.md
+++ b/extensions/batch.md
@@ -83,8 +83,8 @@ For example, that happens if the type is unknown to the client.
 To submit a new batch type please follow the extension submission procedure
 [found here](/participation.html).
 
- * [IRC Version 3.2: `netsplit` and `netjoin`](batch/netsplit-3.2.html)
- * [IRC Version 3.3: `chathistory`](batch/chathistory-3.3.html)
+ * [`netsplit` and `netjoin`](batch/netsplit.html)
+ * [`chathistory`](batch/chathistory.html)
 
 ## Examples
 

--- a/extensions/batch.md
+++ b/extensions/batch.md
@@ -83,8 +83,8 @@ For example, that happens if the type is unknown to the client.
 To submit a new batch type please follow the extension submission procedure
 [found here](/participation.html).
 
- * [`netsplit` and `netjoin`](batch/netsplit.html)
- * [`chathistory`](batch/chathistory.html)
+ * [`netsplit` and `netjoin`](../batches/netsplit.html)
+ * [`chathistory`](../batches/chathistory.html)
 
 ## Examples
 

--- a/extensions/chathistory.md
+++ b/extensions/chathistory.md
@@ -196,8 +196,8 @@ Given conventional expectations around channel membership, servers MAY wish to d
 
 While an ISUPPORT token value of `0` may be used to indicate no message limit exists, servers SHOULD set and enforce a reasonable maximum and properly throttle `CHATHISTORY` commands to prevent abuse.
 
-[batch/chathistory]: ../extensions/batch/chathistory-3.3
-[batch]: ../extensions/batch-3.2
-[server-time]: ../extensions/server-time-3.2
-[message-tags]: ../extensions/message-tags
-[message-ids]: ../extensions/message-ids
+[batch/chathistory]: ../extensions/batch/chathistory.html
+[batch]: ../extensions/batch.html
+[server-time]: ../extensions/server-time.html
+[message-tags]: ../extensions/message-tags.html
+[message-ids]: ../extensions/message-ids.html

--- a/extensions/chathistory.md
+++ b/extensions/chathistory.md
@@ -196,7 +196,7 @@ Given conventional expectations around channel membership, servers MAY wish to d
 
 While an ISUPPORT token value of `0` may be used to indicate no message limit exists, servers SHOULD set and enforce a reasonable maximum and properly throttle `CHATHISTORY` commands to prevent abuse.
 
-[batch/chathistory]: ../extensions/batch/chathistory.html
+[batch/chathistory]: ../batches/chathistory.html
 [batch]: ../extensions/batch.html
 [server-time]: ../extensions/server-time.html
 [message-tags]: ../extensions/message-tags.html

--- a/extensions/extended-join.md
+++ b/extensions/extended-join.md
@@ -36,5 +36,5 @@ prior to channel ingress. As the penultimate parameter is an asterisk,
 this means that an asterisk is not a valid account name (which it is
 not in P10 or TS6 or ESVID).
 
-Please see [`account-notify`](account-notify-3.1.html) for information
+Please see [`account-notify`](account-notify.html) for information
 on how to take advantage of this capability.

--- a/extensions/labeled-response.md
+++ b/extensions/labeled-response.md
@@ -28,7 +28,7 @@ Additionally, labeled responses allow bouncers with multiple connected clients t
 
 ### Dependencies
 
-This specification depends on the [`batch`](../extensions/batch-3.2.html) capability which MUST be negotiated to use labeled responses. The order of capability negotiation is not significant and MUST not be enforced.
+This specification depends on the [`batch`](../extensions/batch.html) capability which MUST be negotiated to use labeled responses. The order of capability negotiation is not significant and MUST not be enforced.
 
 This specification also uses the [message tags](../extensions/message-tags.html) framework.
 
@@ -57,7 +57,7 @@ If a response consists of more than one message, a batch MUST be used to group t
 * An existing type applicable to the entire response
 * `labeled-response`
 
-When a client sends a message to itself, the server MUST NOT include the label tag, except for any acknowledgment sent with the [`echo-message`](/specs/extensions/echo-message-3.2.html) mechanism. This allows clients to differentiate between the echoed message response, and the delivered message.
+When a client sends a message to itself, the server MUST NOT include the label tag, except for any acknowledgment sent with the [`echo-message`](/specs/extensions/echo-message.html) mechanism. This allows clients to differentiate between the echoed message response, and the delivered message.
 
 #### Tag value
 

--- a/extensions/message-ids.md
+++ b/extensions/message-ids.md
@@ -36,13 +36,13 @@ The tag value MUST be a unique ID chosen by the originating server. Uniqueness i
 
 To allow their use outside the tag space, e.g. as command parameters, message IDs MUST NOT start with a colon (`:`) and MUST NOT contain any of `SPACE`, `CR`, `LF`.
 
-However, if a message is re-transmitted as-is, for example with the [`chathistory`](./batch/chathistory.html) batch type, the ID SHOULD be reused. As a result, clients MUST accept shared IDs.
+However, if a message is re-transmitted as-is, for example with the [`chathistory`](../batches/chathistory.html) batch type, the ID SHOULD be reused. As a result, clients MUST accept shared IDs.
 
 Clients MUST treat the ID as a case sensitive opaque identifier. Clients MUST NOT use case folding or normalization when comparing IDs.
 
 ### Relationships with other specifications
 
-In order to treat messages that refer to IDs consistently, clients need to know the IDs for their own messages as well. Servers that provide message IDs SHOULD also provide the [`echo-message`](./echo-message.html) capability.
+In order to treat messages that refer to IDs consistently, clients need to know the IDs for their own messages as well. Servers that provide message IDs SHOULD also provide the [`echo-message`](../extensions/echo-message.html) capability.
 
 ## Server implementation considerations
 

--- a/extensions/message-ids.md
+++ b/extensions/message-ids.md
@@ -36,13 +36,13 @@ The tag value MUST be a unique ID chosen by the originating server. Uniqueness i
 
 To allow their use outside the tag space, e.g. as command parameters, message IDs MUST NOT start with a colon (`:`) and MUST NOT contain any of `SPACE`, `CR`, `LF`.
 
-However, if a message is re-transmitted as-is, for example with the [`chathistory`](./batch/chathistory-3.3.html) batch type, the ID SHOULD be reused. As a result, clients MUST accept shared IDs.
+However, if a message is re-transmitted as-is, for example with the [`chathistory`](./batch/chathistory.html) batch type, the ID SHOULD be reused. As a result, clients MUST accept shared IDs.
 
 Clients MUST treat the ID as a case sensitive opaque identifier. Clients MUST NOT use case folding or normalization when comparing IDs.
 
 ### Relationships with other specifications
 
-In order to treat messages that refer to IDs consistently, clients need to know the IDs for their own messages as well. Servers that provide message IDs SHOULD also provide the [`echo-message`](./echo-message-3.2.html) capability.
+In order to treat messages that refer to IDs consistently, clients need to know the IDs for their own messages as well. Servers that provide message IDs SHOULD also provide the [`echo-message`](./echo-message.html) capability.
 
 ## Server implementation considerations
 

--- a/extensions/multiline.md
+++ b/extensions/multiline.md
@@ -292,8 +292,8 @@ Other invalid multiline batch
     Server: :irc.example.com FAIL BATCH MULTILINE_INVALID :Invalid multiline batch
 
 [message tags]: ../extensions/message-tags.html
-[`batch`]: ../extensions/batch-3.2.html
+[`batch`]: ../extensions/batch.html
 [standard replies]: ../extensions/standard-replies.html
 [message ids]: ../extensions/message-ids.html
 [labeled response]: ../extensions/labeled-response.html
-[echo message]: ../extensions/echo-message-3.2.html
+[echo message]: ../extensions/echo-message.html


### PR DESCRIPTION
Avoids unnecessary redirects by using canonical URLs