### PR TITLE
Display name client tag spec

### DIFF
--- a/client-tags/display-name.md
+++ b/client-tags/display-name.md
@@ -81,7 +81,7 @@ Example display from a client that supports the display name tag and performs fa
     <NoPrefixUser (bot)> I'm not sending a fallback prefix
                    <bot> Bot message
                  <alice> Hi from me!
-             <Colourful> My fallback nick is in green
+       <Colourful (bot)> My fallback nick is in green
 ```
 
 Example display from a client without support for the display name tag


### PR DESCRIPTION
This specification defines a client-only message tag to indicate a display name to use for the attached message, separate from the nickname or realname of the user.

This tag provides a way to provide further temporary context about the originator of a message. Example use cases include bots that relay messages from external contexts, or in role playing environments.

It also describes a fallback for clients without support for the tag.

It does NOT describe a method of servers to spoof the nick in messages, as proposed in #417. I maintain that we shouldn't be suggesting that behaviour. However, servers could easily use the display-name tag as a hint to perform this sort of spoofing if they wanted to.