### PR TITLE
remove confusing 'target' from 730/1

### DIFF
--- a/extensions/monitor.md
+++ b/extensions/monitor.md
@@ -112,7 +112,7 @@ online.
 
 The server MAY send a hostmask with the target.
 
-The server may send "*" instead of the target nick (`<nick>`). (This makes it
+The server may send "*" instead of the nick (`<nick>`). (This makes it
 possible to send the exact same message to all clients monitoring a certain
 target.)
 
@@ -126,7 +126,7 @@ list is offline.
 
 The argument is a chained list of targets that are offline.
 
-As with 730, the server may send "*" instead of the target nick.
+As with 730, the server may send "*" instead of the nick.
 
 ### 732 - `RPL_MONLIST`
 

--- a/extensions/monitor.md
+++ b/extensions/monitor.md
@@ -126,7 +126,7 @@ list is offline.
 
 The argument is a chained list of targets that are offline.
 
-As with 730, the server may send "*" instead of the nick.
+As with 730, the server may send "*" instead of the nick (`<nick>`).
 
 ### 732 - `RPL_MONLIST`
 


### PR DESCRIPTION
The word target is consistently applied to the nickname that is being monitored. In these lines, target is mainly used throughout the document (and even within the same sentence) to refer to the nickname of the person sending the monitor request, not who is being monitored. By simply using 'nick' instead of 'target' or 'target nick', this clarifies the who this refers to for a new developer.