### PR TITLE
Params should not be required

### DIFF
--- a/extensions/message-tags.md
+++ b/extensions/message-tags.md
@@ -39,7 +39,7 @@ Tagged messages can be sent by both servers and clients. The usage of individual
 
 The message pseudo-BNF, as defined in [RFC 1459, section 2.3.1][rfc1459] is extended as follows:
 
-    <message>       ::= ['@' <tags> <SPACE>] [':' <prefix> <SPACE> ] <command> <params> <crlf>
+    <message>       ::= ['@' <tags> <SPACE>] [':' <prefix> <SPACE> ] <command> [params] <crlf>
     <tags>          ::= <tag> [';' <tag>]*
     <tag>           ::= <key> ['=' <escaped_value>]
     <key>           ::= [ <client_prefix> ] [ <vendor> '/' ] <key_name>


### PR DESCRIPTION
I know it's somewhat trivial, and `<params>` (erroneously) is required in RFC1459, but I believe it shouldn't be.

RFC 1459 defines params as:
```ebnf
<params>   ::= <SPACE> [ ':' <trailing> | <middle> <params> ]
```

Which would meant at minimum, we would need to format a message like this
```ebnf
<command> <SPACE> <crlf>
```

I know that IRC doesn't require a space between `<command>` and `<crlf>` where there are no middle or trailing parameters, but that's what seems to be indicated.

It's also very possible I could be misreading this - I'm certainly not a Backus–Naur form expert.