### PR TITLE
Clarify only sending values with CAP LS and NEW

### DIFF
--- a/extensions/capability-negotiation.md
+++ b/extensions/capability-negotiation.md
@@ -248,7 +248,7 @@ As an overview, these are the new features introduced with each `CAP LS` version
 #### Capability Values
 
 If the client supports CAP version `302`, the server MAY specify additional data for each
-capability using the `<name>=<value>` format in `CAP LS` and `CAP NEW` replies.
+capability using the `<name>=<value>` format in `CAP LS` and `CAP NEW` replies, but MUST NOT specify additional data for any other CAP subcommands.
 
 Each capability, if it supports a value, defines what this value means in its specification.
 
@@ -398,8 +398,7 @@ messages to cancel the capabilities in `CAP DEL`, as they have already been canc
 the server.
 
 Servers MUST cancel any capability-specific behavior for a client after sending the
-`CAP DEL` message to the client. Servers MUST NOT send values with any capabilities sent
-via `CAP DEL`.
+`CAP DEL` message to the client.
 
 Clients MUST gracefully handle situations when the server removes support for any
 capability.

--- a/extensions/capability-negotiation.md
+++ b/extensions/capability-negotiation.md
@@ -398,7 +398,8 @@ messages to cancel the capabilities in `CAP DEL`, as they have already been canc
 the server.
 
 Servers MUST cancel any capability-specific behavior for a client after sending the
-`CAP DEL` message to the client.
+`CAP DEL` message to the client. Servers MUST NOT send values with any capabilities sent
+via `CAP DEL`.
 
 Clients MUST gracefully handle situations when the server removes support for any
 capability.


### PR DESCRIPTION
Closes #469 

Add sentence clarifying values are not to be sent via CAP DEL