### PR TITLE
chathistory: Replace invalid character in tag example

### DIFF
--- a/extensions/chathistory.md
+++ b/extensions/chathistory.md
@@ -137,7 +137,7 @@ Requesting the latest conversation upon joining a channel
 [s] :irc.host BATCH +ID chathistory #channel
 [s] @batch=ID;msgid=1234;time=2019-01-04T14:33:26.123Z :nick!ident@host PRIVMSG #channel :message
 [s] @batch=ID;msgid=1235;time=2019-01-04T14:33:38.123Z :nick!ident@host NOTICE #channel :message
-[s] @batch=ID;msgid=1238;time=2019-01-04T14:34:17.123Z;+client_tag=val :nick!ident@host PRIVMSG #channel :ACTION message
+[s] @batch=ID;msgid=1238;time=2019-01-04T14:34:17.123Z;+client-tag=val :nick!ident@host PRIVMSG #channel :ACTION message
 [s] :irc.host BATCH -ID
 ~~~~
 


### PR DESCRIPTION
Minor nitpick

"<key_name>      ::= <non-empty sequence of ascii letters, digits, hyphens ('-')>"
-- https://ircv3.net/specs/extensions/message-tags