### PR TITLE
sasl: make RPL_LOGGEDIN optional on auth success

### DIFF
--- a/extensions/sasl-3.1.md
+++ b/extensions/sasl-3.1.md
@@ -76,7 +76,8 @@ The server will send a 906 numeric.
 
 If authentication fails, a 904 or 905 numeric will be sent and the
 client MAY retry from the `AUTHENTICATE <mechanism>` command.
-If authentication is successful, a 900 and 903 numeric will be sent.
+If authentication is successful, the server MAY send a 900 numeric and then
+MUST send a 903 numeric.
 
 If the client attempts to issue the AUTHENTICATE command after already
 authenticating successfully, the server MUST reject it with a 907 numeric.


### PR DESCRIPTION
Bouncers typically have two kind of authentication layers: downstream
clients authenticate with the bouncer creedentials, and the bouncer
also authenticates against upstream networks.

This causes issues when the bouncer isn't logged in on the upstream
network.

When the downstream client authenticates with SASL, they'll get a
RPL_LOGGEDIN numeric with the bouncer account name. They'll then hide
any login UI.

It would be nicer if RPL_LOGGEDIN/RPL_LOGGEDOUT could be used by
bouncers to mirror the status of the upstream connection. So downstream
clients would only get RPL_LOGGEDIN if the bouncer is authenticated
against the upstream network. That way, clients can show a login UI as
needed, and bouncer can forward post-connection-registration
AUTHENTICATE commands. Also clients would be able to display "logged in
as <network account>" instead of "logged in as <bouncer account>" in
their UI.