### PR TITLE
Add WHOX

### DIFF
--- a/extensions/whox.md
+++ b/extensions/whox.md
@@ -30,20 +30,25 @@ The second argument contains a percent character followed by a list of fields
 requested by the client. Each field is represented by a letter. The standard
 fields are:
 
-- 't': return the `<token>` specified by the client
-- 'c': return an arbitrary channel the client is joined to
-- 'u': return the username
-- 'i': return the IP address
-- 'h': return the hostname
-- 's': return the server name
-- 'n': return the nickname
-- 'f': return the `WHO` flags (away, server operator, etc)
-- 'l': return the number of seconds the user has been idle for
-- 'a': return the account name
-- 'r': return the realname
+- `t`: return the `<token>` specified by the client
+- `c`: return an arbitrary channel the client is joined to
+- `u`: return the username
+- `i`: return the IP address
+- `h`: return the hostname
+- `s`: return the server name
+- `n`: return the nickname
+- `f`: return the `WHO` flags (away, server operator, etc)
+- `d`: return the hop count (distance)
+- `l`: return the number of seconds the user has been idle for
+- `a`: return the account name
+- `o`: return the channel op level
+- `r`: return the realname
 
 Servers MAY support additional non-standard fields. Servers MUST NOT rely on
 the ordering of the fields.
+
+Clients SHOULD avoid requesting the hop count (`d`) and the channel op
+level (`o`), because they are ill-defined and unreliable.
 
 Clients can also specify a token which will be returned by the server in the
 replies. The token MUST contain only digit characters and MUST contain at most
@@ -57,7 +62,7 @@ by a final `RPL_ENDOFWHO` reply. Servers MUST NOT send `RPL_WHOREPLY` replies.
 
 ## `RPL_WHOSPCRPL` (354) numeric reply
 
-    :<server> 354 <client> [token] [channel] [user] [ip] [host] [server] [nick] [flags] [idle] [account] [:realname]
+    :<server> 354 <client> [token] [channel] [user] [ip] [host] [server] [nick] [flags] [hopcount] [idle] [account] [oplevel] [:realname]
 
 Servers MUST send the fields in the order specified above. Servers MUST include
 in their reply all of the standard fields requested by the client, and MUST NOT
@@ -72,6 +77,7 @@ are used:
 - `255.255.255.255` is used for `[ip]` when the server refuses to disclose the
   IP address
 - `0` is used for `[account]` when the user is logged out
+- `n/a` is used for `[oplevel]` when the server doesn't support op levels
 
 ## Examples
 

--- a/extensions/whox.md
+++ b/extensions/whox.md
@@ -1,0 +1,83 @@
+---
+title: WHOX
+layout: spec
+copyrights:
+  -
+    name: "Simon Ser"
+    period: "2021"
+    email: "contact@emersion.fr"
+---
+
+## Introduction
+
+The `WHO` command allows clients to obtain information about other clients.
+However, `WHO` doesn't allow clients to request extra data (e.g. account names)
+nor a subset of the data (e.g. omit user and host).
+
+## `ISUPPORT` token
+
+Servers supporting this specification MUST include the `WHOX` token in
+`RPL_ISUPPORT` without any value. Clients MUST accept `WHOX` tokens with a
+value for forwards compatibility.
+
+## Extended `WHO` command
+
+The `WHO` command is extended with an optional argument:
+
+    WHO <mask> [%<fields>[,<token>]]
+
+The second argument contains a percent character followed by a list of fields
+requested by the client. Each field is represented by a letter. The standard
+fields are:
+
+- 't': return the `<token>` specified by the client
+- 'c': return an arbitrary channel the client is joined to
+- 'u': return the username
+- 'i': return the IP address
+- 'h': return the hostname
+- 's': return the server name
+- 'n': return the nickname
+- 'f': return the `WHO` flags (away, server operator, etc)
+- 'l': return the number of seconds the user has been idle for
+- 'a': return the account name
+- 'r': return the realname
+
+Servers MAY support additional non-standard fields.
+
+Clients can also specify a token which will be returned by the server in the
+replies. The token MUST contain only digit characters and MUST contain at most
+3 characters. Clients MUST NOT include 't' in `<fields>` without specifying a
+token.
+
+Servers MAY support additional non-standard flags before the percent character.
+
+The server will reply with zero, one or more `RPL_WHOSPCRPL` replies, followed
+by a final `RPL_ENDOFWHO` reply. Servers MUST NOT send `RPL_WHOREPLY` replies.
+
+## `RPL_WHOSPCRPL` (354) numeric reply
+
+    :<server> 354 <client> [token] [channel] [user] [ip] [host] [server] [nick] [flags] [idle] [account] [:realname]
+
+Exactly the fields requested by the client MUST be returned by the server. When
+the server omits a field the client has requested, the following placeholders
+are used:
+
+- `*` is used for `[channel]` when no channel is returned
+- `255.255.255.255` is used for `[ip]` when the server refuses to disclose the
+  IP address
+- `0` is used for `[account]` when the user is logged out
+
+## Examples
+
+### Without a token
+
+    WHO cooluser %cuhnar
+    :irc.example.org 354 mynick #ircv3 ~cooluser coolhost cooluser coolaccount :Cool User
+    :irc.example.org 315 mynick cooluser :End of WHO list
+
+### With a token
+
+    WHO #ircv3 %tnfa,42
+    :irc.example.org 354 mynick #ircv3 42 cooluser H coolaccount
+    :irc.example.org 354 mynick #ircv3 42 cooloper H* cooloper
+    :irc.example.org 315 mynick #ircv3 :End of WHO list

--- a/extensions/whox.md
+++ b/extensions/whox.md
@@ -68,13 +68,14 @@ non-standard field they don't support.
 
 Exactly the fields requested by the client MUST be returned by the server. When
 the server omits a field the client has requested, the following placeholders
-are used:
+MUST be used:
 
-- `*` is used for `[channel]` when no channel is returned
+- `*` is used for `[channel]` when no channel is returned.
 - `255.255.255.255` is used for `[ip]` when the server refuses to disclose the
-  IP address
-- `0` is used for `[account]` when the user is logged out
-- `n/a` is used for `[oplevel]` when the server doesn't support op levels
+  IP address.
+- `0` is used for `[account]` when the user is logged out.
+- Any syntactically correct placeholder can be used for `[oplevel]` when the
+  server doesn't support op levels, for instance `n/a`.
 
 Clients SHOULD ignore the values of the hop count (`d`) and the channel op
 level (`o`) fields, because they are ill-defined and unreliable.

--- a/extensions/whox.md
+++ b/extensions/whox.md
@@ -47,9 +47,6 @@ fields are:
 Servers MAY support additional non-standard fields. Servers MUST NOT rely on
 the ordering of the fields.
 
-Clients SHOULD avoid requesting the hop count (`d`) and the channel op
-level (`o`), because they are ill-defined and unreliable.
-
 Clients can also specify a token which will be returned by the server in the
 replies. The token MUST contain only digit characters and MUST contain at most
 3 characters. Clients MUST NOT include 't' in `<fields>` without specifying a
@@ -78,6 +75,9 @@ are used:
   IP address
 - `0` is used for `[account]` when the user is logged out
 - `n/a` is used for `[oplevel]` when the server doesn't support op levels
+
+Clients SHOULD ignore the values of the hop count (`d`) and the channel op
+level (`o`), because these fields are ill-defined and unreliable.
 
 ## Examples
 

--- a/extensions/whox.md
+++ b/extensions/whox.md
@@ -10,9 +10,9 @@ copyrights:
 
 ## Introduction
 
-The `WHO` command allows clients to obtain information about other clients.
-However, `WHO` doesn't allow clients to request extra data (e.g. account names)
-nor a subset of the data (e.g. omit user and host).
+The WHOX extension allows clients to request additional fields in the `WHO`
+response (e.g. account name) or omit default fields (e.g. username and
+hostname).
 
 ## `ISUPPORT` token
 

--- a/extensions/whox.md
+++ b/extensions/whox.md
@@ -77,7 +77,7 @@ are used:
 - `n/a` is used for `[oplevel]` when the server doesn't support op levels
 
 Clients SHOULD ignore the values of the hop count (`d`) and the channel op
-level (`o`), because these fields are ill-defined and unreliable.
+level (`o`) fields, because they are ill-defined and unreliable.
 
 ## Examples
 

--- a/extensions/whox.md
+++ b/extensions/whox.md
@@ -42,7 +42,8 @@ fields are:
 - 'a': return the account name
 - 'r': return the realname
 
-Servers MAY support additional non-standard fields.
+Servers MAY support additional non-standard fields. Servers MUST NOT rely on
+the ordering of the fields.
 
 Clients can also specify a token which will be returned by the server in the
 replies. The token MUST contain only digit characters and MUST contain at most
@@ -57,6 +58,11 @@ by a final `RPL_ENDOFWHO` reply. Servers MUST NOT send `RPL_WHOREPLY` replies.
 ## `RPL_WHOSPCRPL` (354) numeric reply
 
     :<server> 354 <client> [token] [channel] [user] [ip] [host] [server] [nick] [flags] [idle] [account] [:realname]
+
+Servers MUST send the fields in the order specified above. Servers MUST include
+in their reply all of the standard fields requested by the client, and MUST NOT
+add any additional field not requested by the client. Servers MUST ignore any
+non-standard field they don't support.
 
 Exactly the fields requested by the client MUST be returned by the server. When
 the server omits a field the client has requested, the following placeholders
@@ -77,7 +83,7 @@ are used:
 
 ### With a token
 
-    WHO #ircv3 %tnfa,42
+    WHO #ircv3 %afnt,42
     :irc.example.org 354 mynick #ircv3 42 cooluser H coolaccount
     :irc.example.org 354 mynick #ircv3 42 cooloper H* cooloper
     :irc.example.org 315 mynick #ircv3 :End of WHO list


### PR DESCRIPTION
This PR documents a common subset of the WHOX extension. The goal here is not to draft a new standard, but document what already exists in the wild. We can extend this spec as a second step if desirable.

"querytype" has been renamed to "token", because it's a much more descriptive name IMHO (and happens to have the same first letter). Let me know if you want to change it back.

Intentionally left out:

- WHOX flags, unimplemented by some servers
- ~~'d' (distance/hopcount) and 'o' (oplevel), unreliable and not well-defined~~

References:

- https://github.com/quakenet/snircd/blob/master/doc/readme.who
- http://faerion.sourceforge.net/doc/irc/whox.var
- Ergo impl: https://github.com/ergochat/ergo/pull/1184
- Tentative WHO spec: https://github.com/ircdocs/modern-irc/pull/138

Closes: https://github.com/ircv3/ircv3-specifications/issues/81