### PR TITLE
Add `draft/oper-tag` spec

### DIFF
--- a/extensions/oper-tag.md
+++ b/extensions/oper-tag.md
@@ -27,7 +27,7 @@ The tag MUST be named `draft/oper`. The value of the tag, if specified, MUST ide
 The tag MUST be added by the ircd to all commands sent by a user (e.g. PRIVMSG,
 MODE, NOTICE, and all others) and numeric replies sent on behalf of the user.
 
-Servers supporting this capabilty MAY be configured to restrict visibility of this tag or its value.
+Servers supporting this capability MAY be configured to restrict visibility of this tag or its value.
 
 ## Example
 

--- a/extensions/oper-tag.md
+++ b/extensions/oper-tag.md
@@ -25,7 +25,7 @@ The `draft/oper` capability causes the server to add a [message tag][] to messag
 The tag MUST be named `draft/oper`. The value of the tag, if specified, MUST identify the operator.
 
 The tag MUST be added by the ircd to all commands sent by a user (e.g. PRIVMSG,
-MODE, NOTICE, and all others) and numeric replies sent on behalf of the user.
+MODE, NOTICE, and all others) and SHOULD be added to any numeric replies sent on behalf of the user.
 
 Servers supporting this capability MAY be configured to restrict visibility of this tag or its value.
 

--- a/extensions/oper-tag.md
+++ b/extensions/oper-tag.md
@@ -1,0 +1,40 @@
+---
+title: "`oper-tag` Extension"
+layout: spec
+work-in-progress: true
+copyrights:
+  -
+    name: "David Schultz"
+    period: "2022"
+    email: "me@zpld.me"
+---
+
+## Notes for implementing work-in-progress version
+
+This is a work-in-progress specification.
+
+Software implementing this work-in-progress specification MUST NOT use the
+unprefixed `oper` tag name. Instead, implementations SHOULD use the
+`draft/oper` tag name to be interoperable with other software
+implementing a compatible work-in-progress version.
+
+## Description
+
+The `draft/oper` capability causes the server to add a [message tag][] to messages sent by a user who is currently an IRC operator.
+
+The tag MUST be named `draft/oper`. The value of the tag, if specified, MUST identify the operator.
+
+The tag MUST be added by the ircd to all commands sent by a user (e.g. PRIVMSG,
+MODE, NOTICE, and all others) and numeric replies sent on behalf of the user.
+
+Servers supporting this capabilty MAY be configured to restrict visibility of this tag or its value.
+
+## Example
+
+Consider that I am identified to the `launchd` operator account while chatting with the `lunchd` nickname. I will send messages to three users with different configured levels of visibility.
+
+    @draft/oper=launchd :lunchd PRIVMSG full_access_friend :it's me!
+    @draft/oper :lunchd PRIVMSG partial_access_friend :you can see I'm an oper
+    :lunchd PRIVMSG unprivileged_friend :don't mind me
+
+[message tag]: ../extensions/message-tags

--- a/extensions/oper-tag.md
+++ b/extensions/oper-tag.md
@@ -20,7 +20,7 @@ implementing a compatible work-in-progress version.
 
 ## Description
 
-The `draft/oper` capability causes the server to add a [message tag][] to messages sent by a user who is currently an IRC operator.
+The `draft/oper-tag` capability causes the server to add a [message tag][] to messages sent by a user who is currently an IRC operator.
 
 The tag MUST be named `draft/oper`. The value of the tag, if specified, MUST identify the operator.
 


### PR DESCRIPTION
This is based on the solanum [implementation](https://github.com/solanum-ircd/solanum/blob/main/extensions/cap_oper.c). The solanum spec can be found [here](https://solanum.chat/oper).