### PR TITLE
UTF8ONLY: remove suggestion to disconnect the client

### DIFF
--- a/extensions/utf8-only.md
+++ b/extensions/utf8-only.md
@@ -17,7 +17,7 @@ copyrights:
 IRC predates the Unicode standard. Consequently, although UTF-8 has been widely adopted on IRC, clients cannot assume that all IRC data is UTF-8. This specification defines a way for servers to advertise that they only allow UTF-8 on their network, letting clients change their processing of outgoing and incoming messages accordingly.
 
 ## The `UTF8ONLY` ISUPPORT token
-This specification introduces a new token `UTF8ONLY` that servers can include in their [ISUPPORT](https://modern.ircdocs.horse/#feature-advertisement) (`005`) output. Servers publishing this token MUST NOT relay content (such as `PRIVMSG` or `NOTICE` message data, channel topics, or realnames) containing non-UTF-8 data to clients. Clients implementing this specification MUST NOT send non-UTF-8 data to the server once they have seen this token. Server handling of such messages is implementation-defined; for example, they MAY send the `INVALID_UTF8` code described below, disconnect the client with an `ERROR` message, or respond in some other way.
+This specification introduces a new token `UTF8ONLY` that servers can include in their [ISUPPORT](https://modern.ircdocs.horse/#feature-advertisement) (`005`) output. Servers publishing this token MUST NOT relay content (such as `PRIVMSG` or `NOTICE` message data, channel topics, or realnames) containing non-UTF-8 data to clients. Clients implementing this specification MUST NOT send non-UTF-8 data to the server once they have seen this token. Server handling of such messages is implementation-defined; for example, they MAY send the `INVALID_UTF8` code described below, or respond in some other way.
 
 If a client implementing this specification sees this token, they MUST set their outgoing encoding to UTF-8 without requiring any user intervention. This allows clients to work transparently on networks that only allow UTF-8 traffic.
 
@@ -34,12 +34,6 @@ Server: FAIL PRIVMSG INVALID_UTF8 :Message rejected, your IRC software MUST use 
 ```
 Client: USER u s e :<non-utf8 realname>
 Server: FAIL USER INVALID_UTF8 :Message rejected, your IRC software MUST use UTF-8 encoding on this network
-```
-
-```
-Client: PRIVMSG #ircv3 :<non-utf-8 message>
-Server: ERROR :Your IRC software MUST use UTF-8 encoding on this network
-... server disconnects the client ...
 ```
 
 ```


### PR DESCRIPTION
cc @DanielOaks @vanosg 

This is a response to the discussion on #456. It deletes the suggestion that servers disconnect noncompliant clients; this was unnecessarily controversial. Other language implying that UTF8 is now the preferred encoding for IRC remains in place.

Since there are no normative implications to this change (the server behavior remains implementation-defined; servers MAY still disconnect the client, although no server does so and I don't think any ever will), this shouldn't require an erratum notice.