### PR TITLE
Add a capability for sending arbitrary standard replies.

### DIFF
--- a/extensions/standard-replies.md
+++ b/extensions/standard-replies.md
@@ -54,7 +54,9 @@ Reply codes (especially more widely-applicable ones such as `NO_SUCH_NICK`) may 
 
 This specification adds the `standard-replies` capability. This capability allows servers to send arbitrary standard replies other than ones enabled by a specific specification. It also allows clients to indicate support for receiving any well-formed standard reply, whether or not it is recognised and used.
 
-It is RECOMMENDED that servers use standard replies instead of vendor-specific error numerics or server notices for non-standardised features when responding to a client which supports this capability. It is NOT RECOMMENDED that servers which support this capability add new custom error numerics. Also, servers which support this capability SHOULD NOT replace standardised error numerics with a standard reply unless enabled to by some other specification.
+It is RECOMMENDED that servers use standard replies instead of vendor-specific error numerics or server notices for non-standardised features when responding to a client which supports this capability. It is NOT RECOMMENDED that servers which support this capability add new custom error numerics. Servers which support this capability SHOULD NOT replace standardised error numerics with standard replies, unless the replacement is explicitly described by some other specification.
+
+
 
 ## Examples
 

--- a/extensions/standard-replies.md
+++ b/extensions/standard-replies.md
@@ -50,6 +50,11 @@ Reply codes (especially more widely-applicable ones such as `NO_SUCH_NICK`) may 
 
 `<description>` is a required final parameter, containing a plain-text description of the reply message. For example, for a `FAIL` message, the description should clearly state what error occurred, and how the user should act to resolve it. Implementers should write their descriptions to be easily understood by end users, for example _"Passwords must contain lowercase and uppercase letters, and be 8 or more characters"_ is a more clear description than _"Password consistency and strength enumerability (sec/* internal) check failed"_.
 
+### Capabilities
+
+This specification adds the `standard-replies` capability. This capability allows servers to send arbitrary standard replies other than ones enabled by a specific specification. It also allows clients to indicate support for receiving any well-formed standard reply, whether or not it is recognised and used.
+
+It is RECOMMENDED that servers use standard replies instead of error numerics or notices when responding to a client which supports this capability. It is NOT RECOMMENDED that servers which support this capability add new error numerics.
 
 ## Examples
 

--- a/extensions/standard-replies.md
+++ b/extensions/standard-replies.md
@@ -54,7 +54,7 @@ Reply codes (especially more widely-applicable ones such as `NO_SUCH_NICK`) may 
 
 This specification adds the `standard-replies` capability. This capability allows servers to send arbitrary standard replies other than ones enabled by a specific specification. It also allows clients to indicate support for receiving any well-formed standard reply, whether or not it is recognised and used.
 
-It is RECOMMENDED that servers use standard replies instead of custom error numerics or server notices for non-standardised features when responding to a client which supports this capability. It is NOT RECOMMENDED that servers which support this capability add new custom error numerics.
+It is RECOMMENDED that servers use standard replies instead of vendor-specific error numerics or server notices for non-standardised features when responding to a client which supports this capability. It is NOT RECOMMENDED that servers which support this capability add new custom error numerics. Also, servers which support this capability SHOULD NOT replace standardised error numerics with a standard reply unless enabled to by some other specification.
 
 ## Examples
 

--- a/extensions/standard-replies.md
+++ b/extensions/standard-replies.md
@@ -54,7 +54,7 @@ Reply codes (especially more widely-applicable ones such as `NO_SUCH_NICK`) may 
 
 This specification adds the `standard-replies` capability. This capability allows servers to send arbitrary standard replies other than ones enabled by a specific specification. It also allows clients to indicate support for receiving any well-formed standard reply, whether or not it is recognised and used.
 
-It is RECOMMENDED that servers use standard replies instead of error numerics or notices when responding to a client which supports this capability. It is NOT RECOMMENDED that servers which support this capability add new error numerics.
+It is RECOMMENDED that servers use standard replies instead of custom error numerics or server notices for non-standardised features when responding to a client which supports this capability. It is NOT RECOMMENDED that servers which support this capability add new custom error numerics.
 
 ## Examples
 


### PR DESCRIPTION
This capability allows clients to signal that they support receiving arbitrary standard replies that are not otherwise enabled by a specific specification.

InspIRCd has something similar to this as a vendor capability and I'm planning on switching all of our custom numerics and notices over to it in v4. It'd be nice if we could standardise it so clients don't have to rely on a proprietary feature.