### PR TITLE
multiline: Clarify what counts toward max-bytes

### DIFF
--- a/extensions/multiline.md
+++ b/extensions/multiline.md
@@ -51,8 +51,8 @@ Clients MUST ignore every token with a key that they don't understand.
 
 The only defined capability key so far is:
 
-* `max-bytes` - This defines the maximum allowed total byte length of multiline batched content *REQUIRED*
-* `max-lines` - This defines the maximum allowed number of lines in a multiline batch content *RECOMMENDED*
+* `max-bytes` - This defines the maximum allowed total byte length of multiline batch, as defined below *REQUIRED*
+* `max-lines` - This defines the maximum allowed number of lines in a multiline batch *RECOMMENDED*
 
 Only the last parameter of PRIVMSG and NOTICE are counted toward `max-bytes`; not origin, command, or target.
 

--- a/extensions/multiline.md
+++ b/extensions/multiline.md
@@ -54,6 +54,8 @@ The only defined capability key so far is:
 * `max-bytes` - This defines the maximum allowed total byte length of multiline batched content *REQUIRED*
 * `max-lines` - This defines the maximum allowed number of lines in a multiline batch content *RECOMMENDED*
 
+Only the last parameter of PRIVMSG and NOTICE are counted toward `max-bytes`; not origin, command, or target.
+
 ### Tags
 
 This specification adds the `draft/multiline-concat` message tag, which has no value and is used to send message lines that extend beyond the usual byte length limit. Its usage is described below.

--- a/extensions/multiline.md
+++ b/extensions/multiline.md
@@ -51,7 +51,7 @@ Clients MUST ignore every token with a key that they don't understand.
 
 The only defined capability key so far is:
 
-* `max-bytes` - This defines the maximum allowed total byte length of multiline batch, as defined below *REQUIRED*
+* `max-bytes` - This defines the maximum allowed total byte length of a multiline batch's combined message value, as defined below *REQUIRED*
 * `max-lines` - This defines the maximum allowed number of lines in a multiline batch *RECOMMENDED*
 
 Only the last parameter of PRIVMSG and NOTICE are counted toward `max-bytes`; not origin, command, or target.


### PR DESCRIPTION
This matches the behavior [in Ergo](https://github.com/ergochat/ergo/blob/4317016a09a2629603fb6198cbeddf6afa28c8ce/irc/handlers.go#L2163-L2170) and [in Limnoria](https://github.com/progval/limnoria/blob/96b7f51e7162f540475ed9dd8763dff38a256e64/src/callbacks.py#L927-L946).

[BitBot ignores `max-bytes`](https://github.com/bitbot-irc/bitbot/blob/4a6037c77405f3584efadc10ae75826b6b9ac422/modules/ircv3_multiline.py); and I did not check how the IRCCloud server implements it (though the client does not seem to enforce it at all before sending).

Resolves #516.