### PR TITLE
capability-negotiation: clarify CAP names cannot start with hyphen

### DIFF
--- a/extensions/capability-negotiation.md
+++ b/extensions/capability-negotiation.md
@@ -440,9 +440,10 @@ listed above.
 
 The full capability name MUST be treated as an opaque identifier.
 
-Capability names are case-sensitive. Typical capability names SHOULD be lowercase, and use
-hyphens (`-`) to separate words. For example: `echo-message`, `extended-join`,
-`invite-notify`, `draft/labeled-response`, `message-tags`.
+Capability names are case-sensitive, and MUST NOT start with a hyphen (`-`). Typical
+capability names SHOULD be lowercase, and use hyphens to separate words. For example:
+`echo-message`, `extended-join`, `invite-notify`, `draft/labeled-response`,
+`message-tags`.
 
 There are different types of capability names, which are described below.
 
@@ -542,4 +543,6 @@ appropriate features.
 Previous versions of this spec did not mention how servers handle clients attempting to downgrade
 their CAP LS version. It has been clarified that clients MAY NOT downgrade this.
 
-Clarify that multiline LS and LIST replies must only be used for CAP 302
+Clarified that multiline LS and LIST replies must only be used for CAP 302.
+
+Previous versions of this spec did not state that capability names MUST NOT start with a hyphen.


### PR DESCRIPTION
It's _implied_ that capability names shouldn't start with a `-`, but not explicitly specified. Capability names "MUST" be treated as opaque identifiers. However, any possibility of a capability name that starts with `-` at all introduces ambiguity at the parsing step, and disallows simple solutions like `if cap_name.startswith('-')` and `real_cap = cap_name.lstrip('-')`. This patch proposes a formal prohibition on `-` as the first character of a capability name.

None of the CAP names listed in [the IRCv3 registry](https://ircv3.net/registry#capabilities) have leading hyphens, nor have I ever seen a `draft/` or `vendor/` CAP name with one. The impact of this change on any live code should be nonexistent outside of (as a fellow developer put it) hypothetical "particularly antisocial" capability names in private use, not submitted to the registry.

### Notes
Including myself, fellow developers working on upgrading our bot client's capability negotiation skills, and third parties we consulted along the way, at least half of the group (roughly 6-7 people) believed a leading hyphen is technically allowed by the current spec as written. I hope this revision removes all doubt that it was never intended to be permissible.