### PR TITLE
Add message redaction

### DIFF
--- a/extensions/message-redaction.md
+++ b/extensions/message-redaction.md
@@ -88,6 +88,7 @@ The following codes are defined, with sample plain text descriptions.
 
 * `FAIL REDACT REDACT_FORBIDDEN <target> <target-msgid> :You are not authorised to delete this message`
 * `FAIL REDACT REDACT_WINDOW_EXPIRED <target> <target-msgid> <window> :You can no longer edit this message`
+* `FAIL REDACT UNKNOWN_MSGID <target> <target-msgid> <window> :This message does not exist or is too old`
 
 ## Client implementation considerations
 

--- a/extensions/message-redaction.md
+++ b/extensions/message-redaction.md
@@ -108,6 +108,11 @@ allow users to attempt to delete any message via some mechanism.
 
 Clients SHOULD NOT provide a default reason if users do not provide one.
 
+When a `REDACT` command's `msgid` parameter references a known message not in
+the `target`'s history, clients MUST ignore it.
+This allows servers to safely relay `REDACT` commands targeting messages which they
+did not keep in their history.
+
 ## Server implementation considerations
 
 *This section is non-normative.*

--- a/extensions/message-redaction.md
+++ b/extensions/message-redaction.md
@@ -37,12 +37,12 @@ guarantees.
 
 ### Dependencies
 
-Clients wishing to use these capabilities MUST negotiate the [`message-tags`][]
+Clients wishing to use this capability MUST negotiate the [`message-tags`][]
 capability with the server.
 Additionally, this capability relies on messages being sent with the
 [`msgid`][] tag, and message ids MUST NOT contain spaces.
-Clients SHOULD negotiate the [`echo-message`][] capabilities in order to receive
-message IDs for their own messages, to allow them to be redacted.
+Clients SHOULD negotiate the [`echo-message`][] capability in order to receive
+message IDs for their own messages, so they can be redacted.
 
 
 ### Capability
@@ -50,8 +50,8 @@ message IDs for their own messages, to allow them to be redacted.
 This specification adds the `draft/message-redaction` capability.
 Clients MUST ignore this capability's value, if any.
 
-Implementations that negotiate these capabilities indicate that they are
-capable of handling the respective commands and message tags described below.
+Implementations that negotiate this capability indicate that they are
+capable of handling the command described below.
 
 
 ### Command
@@ -68,9 +68,9 @@ Where `<msgid>` is the id of the message to be redacted, which MUST be a
 If the client is authorised to delete the message, the server:
 
 * SHOULD forward this `REDACT`, with an appropriate prefix, to the target
-  recipients which negotiated the `draft/message-redaction` capability, in the
+  recipients that have negotiated the `draft/message-redaction` capability, in the
   same way as PRIVMSG messages.
-* MUST not forward this `REDACT` to target recipients which did not negotiated
+* MUST not forward this `REDACT` to target recipients that have not negotiated
   this capability (see "Fallback" below)
 
 ### Chat history
@@ -88,7 +88,7 @@ This specification defines `FAIL` messages using the [standard replies][]
 framework for notifying clients of errors with message editing and deletion.
 The following codes are defined, with sample plain text descriptions.
 
-* `FAIL REDACT INVALID_TARGET the_given_target :You cannot delete messages from the_given_target`
+* `FAIL REDACT INVALID_TARGET <target> :You cannot delete messages from <target>`
 * `FAIL REDACT REDACT_FORBIDDEN <target> <target-msgid> :You are not authorised to delete this message`
 * `FAIL REDACT REDACT_WINDOW_EXPIRED <target> <target-msgid> <window> :You can no longer edit this message`
 * `FAIL REDACT UNKNOWN_MSGID <target> <target-msgid> :This message does not exist or is too old`
@@ -117,7 +117,7 @@ did not keep in their history.
 
 ## Server implementation considerations
 
-*This section is non-normative.*
+This section is non-normative.
 
 A key motivation for specifying this capability as a server tag, rather than
 a client-only message tag, is to enable more granular redaction permissions.

--- a/extensions/message-redaction.md
+++ b/extensions/message-redaction.md
@@ -79,7 +79,9 @@ After a message is redacted, [`chathistory`][] responses SHOULD either:
 * exclude it entirely
 * replace its content and/or tags with a placeholder and
   add the `REDACT` message to the response (not counting toward message limits)
+  after the redacted message
 * add the `REDACT` message to the response (not counting toward message limits)
+  after the redacted message
 
 ### Errors
 

--- a/extensions/message-redaction.md
+++ b/extensions/message-redaction.md
@@ -77,7 +77,8 @@ If the client is authorised to delete the message, the server:
 After a message is redacted, [`chathistory`][] responses SHOULD either:
 
 * exclude it entirely
-* replace it with the `REDACT` message with the same value as `@msgid` tag
+* replace its second parameter and/or tags with a placeholder and
+  add the `REDACT` message to the response (not counting toward message limits)
 * add the `REDACT` message to the response (not counting toward message limits)
 
 ### Errors

--- a/extensions/message-redaction.md
+++ b/extensions/message-redaction.md
@@ -131,7 +131,7 @@ If a message is redacted while a client is disconnected (or parted from a channe
 a message it saw is redacted, servers may send the `REDACT` command in a `chathistory`
 batch when it re-joins the channel.
 
-If servers use predictable or guessable `msgid`s, they should considered whether errors
+If servers use predictable or guessable `msgid`s, they should consider whether errors
 returned on `REDACT` may leak a message's existence to users who did not receive it
 (in a channel they are/were not in or in private messages).
 

--- a/extensions/message-redaction.md
+++ b/extensions/message-redaction.md
@@ -177,10 +177,10 @@ Deleting a TAGMSG:
 
 Deleting someone else's PRIVMSG:
 
-    C: PRIVMSG #channel :join my network for cold hard chats
-    S: @msgid=123 :nick!u@h PRIVMSG #channel :join my network for cold hard chats
-    C: REDACT #channel 123 spam
-    S: @msgid=124 :nick!u@h REDACT #channel 123 spam
+    C1: PRIVMSG #channel :join my network for cold hard chats
+    S:  @msgid=123 :nick!u@h PRIVMSG #channel :join my network for cold hard chats
+    C2: REDACT #channel 123 spam
+    S:  @msgid=124 :chanop!u@h REDACT #channel 123 spam
 
 
 [`echo-message`]: ../extensions/echo-message.html

--- a/extensions/message-redaction.md
+++ b/extensions/message-redaction.md
@@ -49,6 +49,7 @@ them to be redacted.
 ### Capability
 
 This specification adds the `draft/message-redaction` capability.
+Clients MUST ignore this capability's value, if any.
 
 Implementations that negotiate these capabilities indicate that they are
 capable of handling the respective commands and message tags described below.

--- a/extensions/message-redaction.md
+++ b/extensions/message-redaction.md
@@ -90,7 +90,7 @@ The following codes are defined, with sample plain text descriptions.
 * `FAIL REDACT INVALID_TARGET the_given_target :You cannot delete messages from the_given_target`
 * `FAIL REDACT REDACT_FORBIDDEN <target> <target-msgid> :You are not authorised to delete this message`
 * `FAIL REDACT REDACT_WINDOW_EXPIRED <target> <target-msgid> <window> :You can no longer edit this message`
-* `FAIL REDACT UNKNOWN_MSGID <target> <target-msgid> <window> :This message does not exist or is too old`
+* `FAIL REDACT UNKNOWN_MSGID <target> <target-msgid> :This message does not exist or is too old`
 
 ## Client implementation considerations
 

--- a/extensions/message-redaction.md
+++ b/extensions/message-redaction.md
@@ -77,7 +77,7 @@ If the client is authorised to delete the message, the server:
 After a message is redacted, [`chathistory`][] responses SHOULD either:
 
 * exclude it entirely
-* replace its second parameter (if it is a `PRIVMSG` or `NOTICE`) and/or tags with a placeholder and
+* replace its content and/or tags with a placeholder and
   add the `REDACT` message to the response (not counting toward message limits)
 * add the `REDACT` message to the response (not counting toward message limits)
 

--- a/extensions/message-redaction.md
+++ b/extensions/message-redaction.md
@@ -62,7 +62,8 @@ The command is defined as follows:
 
     REDACT <target> <msgid> [:reason]
 
-Where `<msgid>` is the id of the message to be redacted.
+Where `<msgid>` is the id of the message to be redacted, which MUST be a
+`PRIVMSG`, `NOTICE`, or `TAGMSG`.
 
 If the client is authorised to delete the message, the server:
 

--- a/extensions/message-redaction.md
+++ b/extensions/message-redaction.md
@@ -100,7 +100,7 @@ Redacted messages MAY be hidden entirely from the primary message log,
 but a deletion log SHOULD be made available.
 
 For the purposes of user interface, clients MAY assume that their own messages
-are editable.
+are redactable.
 However, this will not always be the case, and there could be other messages
 that they have permission to act on.
 Pending a mechanism for discovering redaction permissions, clients SHOULD

--- a/extensions/message-redaction.md
+++ b/extensions/message-redaction.md
@@ -1,0 +1,177 @@
+---
+title: Message redaction
+layout: spec
+work-in-progress: true
+copyrights:
+  -
+    name: "James Wheare"
+    email: "james@irccloud.com"
+    period: "2020"
+  -
+    name: "Val Lorentz"
+    email: "progval+ircv3@progval.net"
+    period: "2023"
+---
+
+## Notes for implementing work-in-progress version
+
+This is a work-in-progress specification.
+
+Software implementing this work-in-progress specification MUST NOT use the
+unprefixed `message-redaction` capability name.
+Instead, implementations SHOULD use the `draft/message-redaction` capability
+name to be interoperable with other software implementing a compatible
+work-in-progress version.
+
+The final version of the specification will use an unprefixed capability name.
+
+## Introduction
+
+This specification enables messages to be deleted.
+Use cases include retracting accidentally sent messages and moderation,
+removing a [`+draft/react` client tag][], amongst others.
+These are cosmetic use cases and do not provide any operational security
+guarantees.
+
+## Architecture
+
+### Dependencies
+
+Clients wishing to use these capabilities MUST negotiate the [`message-tags`][]
+capability with the server.
+Additionally, this capability relies on messages being sent with the
+[`msgid`][] tag, and message ids MUST NOT contain spaces.
+Clients SHOULD negotiate the [`echo-message`][] and [`labeled-response`][]
+capabilities in order to receive message IDs for their own messages, to allow
+them to be redacted.
+
+
+### Capability
+
+This specification adds the `draft/message-redaction` capability.
+
+Implementations that negotiate these capabilities indicate that they are
+capable of handling the respective commands and message tags described below.
+
+
+### Command
+
+To redact a message, a client MUST negotiate the `draft/message-redaction`
+capability and send a `REDACT` command to a target nickname or channel.
+The command is defined as follows:
+
+    REDACT <target> <msgid> [:reason]
+
+Where `<msgid>` is the id of the message to be redacted.
+
+If the client is authorised to delete the message, the server:
+
+* SHOULD forward this `REDACT`, with an appropriate prefix, to the target
+  recipients which negotiated the `draft/message-redaction` capability, in the
+  same way as PRIVMSG messages.
+* MUST not forward this `REDACT` to target recipients which did not negotiated
+  this capability (see "Fallback" below)
+
+### Chat history
+
+After a message is redacted, [`chathistory`][] responses SHOULD either:
+
+* exclude it entirely
+* replace it with the `REDACT` message with the same value as `@msgid` tag
+* add the `REDACT` message to the response (not counting toward message limits)
+
+### Errors
+
+This specification defines `FAIL` messages using the [standard replies][]
+framework for notifying clients of errors with message editing and deletion.
+The following codes are defined, with sample plain text descriptions.
+
+* `FAIL REDACT REDACT_FORBIDDEN <target> <target-msgid> :You are not authorised to delete this message`
+* `FAIL REDACT REDACT_WINDOW_EXPIRED <target> <target-msgid> <window> :You can no longer edit this message`
+
+## Client implementation considerations
+
+It is strongly RECOMMENDED that clients provide visible redaction history to users.
+This helps ensure accountability, and mitigates abuse through malicious or
+surreptitious redaction. This could be done via a tool tip, or a separate log.
+Redacted messages MAY be hidden entirely from the primary message log,
+but a deletion log SHOULD be made available.
+
+For the purposes of user interface, clients MAY assume that their own messages
+are editable.
+However, this will not always be the case, and there could be other messages
+that they have permission to act on.
+Pending a mechanism for discovering redaction permissions, clients SHOULD
+allow users to attempt to delete any message via some mechanism.
+
+Clients SHOULD NOT provide a default reason if users do not provide one.
+
+## Server implementation considerations
+
+*This section is non-normative.*
+
+A key motivation for specifying this capability as a server tag, rather than
+a client-only message tag, is to enable more granular redaction permissions.
+Clients might be able to determine which messages are their own, but other
+use cases would not be feasible without server validation.
+
+Such use cases might include:
+
+* Allowing channel moderators or server admins to delete unwelcome messages from others
+* Specifying a cut-off time after which message edits are no longer allowed
+
+### Fallback
+
+Server implementations might choose to inform clients that haven't negotiated
+the capability that an edit or deletion has taken place.
+The fallback method used (if any) is left up to server implementations, but
+could take the form of a standard NOTICE or PRIVMSG with information about the
+action.
+It might be preferable to use relative time descriptions if referring to
+messages in the past, for example:
+
+    :irc.example.com NOTICE #channel :nickname redacted a message from othernick from 5 seconds ago: spam
+
+Implementations might also choose not to send a fallback, if this behaviour
+is considered too noisy for users.
+
+## Security considerations
+
+The ability to delete messages does not offer any information or operational
+security guarantees.
+Once a message has been sent, assume that it will remain visible to any
+recipients or servers, whether or not it is subsequently redacted.
+Above all else, clients that do not support this specification will not see
+any changes to the original message.
+
+## Examples
+
+Deleting a PRIVMSG:
+
+    C: PRIVMSG #channel :an example
+    S: @msgid=123 :nick!u@h PRIVMSG #channel :an example
+    C: DELETE #channel 123 :bad example
+    S: @msgid=124 :nick!u@h DELETE #channel 123 :bad example
+
+Deleting a TAGMSG:
+
+    C: @draft/react=🤞TAGMSG #channel
+    S: @msgid=123;draft/react=🤞TAGMSG #channel
+    C: DELETE #channel 123
+    S: @msgid=124 :nick@u@h DELETE #channel 123
+
+Deleting someone else's PRIVMSG:
+
+    C: PRIVMSG #channel :join my network for cold hard chats
+    S: @msgid=123 :nick!u@h PRIVMSG #channel :join my network for cold hard chats
+    C: DELETE #channel 123 spam
+    S: @msgid=124 :nick!u@h DELETE #channel 123 spam
+
+
+[`echo-message`]: ../extensions/echo-message.html
+[`+draft/react` client tag]: ../client-tags/react.html
+[`labeled-response`]: ../extensions/labeled-response.html
+[standard replies]: ../extensions/standard-replies.html
+[`message-tags`]: ../extensions/message-tags.html
+[`msgid`]: ../extensions/message-tags.html
+[`chathistory`]: ../extensions/message-tags.html

--- a/extensions/message-redaction.md
+++ b/extensions/message-redaction.md
@@ -58,11 +58,12 @@ To redact a message, a client MUST negotiate the `draft/message-redaction`
 capability and send a `REDACT` command to a target nickname or channel.
 The command is defined as follows:
 
-    REDACT <target> <msgid> [:reason]
+    REDACT <target> <msgid> [<reason>]
 
 Where `<msgid>` is the id of the message to be redacted, which MUST be a
 `PRIVMSG`, `NOTICE`, or `TAGMSG`.
 
+An optional `<reason>` MAY be provided. As the last parameter, it MAY contain spaces.
 If the client is authorised to delete the message, the server:
 
 * SHOULD forward this `REDACT`, with an appropriate prefix, to the target

--- a/extensions/message-redaction.md
+++ b/extensions/message-redaction.md
@@ -28,8 +28,8 @@ The final version of the specification will use an unprefixed capability name.
 ## Introduction
 
 This specification enables messages to be deleted.
-Use cases include retracting accidentally sent messages and moderation,
-removing a [`+draft/react` client tag][], amongst others.
+Use cases include retracting accidentally sent messages moderation,
+and removing a [`+draft/react` client tag][], amongst others.
 These are cosmetic use cases and do not provide any operational security
 guarantees.
 

--- a/extensions/message-redaction.md
+++ b/extensions/message-redaction.md
@@ -76,7 +76,7 @@ If the client is authorised to delete the message, the server:
 After a message is redacted, [`chathistory`][] responses SHOULD either:
 
 * exclude it entirely
-* replace its second parameter and/or tags with a placeholder and
+* replace its second parameter (if it is a `PRIVMSG` or `NOTICE`) and/or tags with a placeholder and
   add the `REDACT` message to the response (not counting toward message limits)
 * add the `REDACT` message to the response (not counting toward message limits)
 

--- a/extensions/message-redaction.md
+++ b/extensions/message-redaction.md
@@ -28,7 +28,7 @@ The final version of the specification will use an unprefixed capability name.
 ## Introduction
 
 This specification enables messages to be deleted.
-Use cases include retracting accidentally sent, messages moderation,
+Use cases include retracting accidentally sent messages, moderation,
 and removing a [`+draft/react` client tag][], amongst others.
 These are cosmetic use cases and do not provide any operational security
 guarantees.

--- a/extensions/message-redaction.md
+++ b/extensions/message-redaction.md
@@ -126,6 +126,10 @@ If a message is redacted while a client is disconnected (or parted from a channe
 a message it saw is redacted, servers may send the `REDACT` command in a `chathistory`
 batch when it re-joins the channel.
 
+If servers use predictable or guessable `msgid`s, they should considered whether errors
+returned on `REDACT` may leak a message's existence to users who did not receive it
+(in a channel they are/were not in or in private messages).
+
 ### Fallback
 
 Server implementations might choose to inform clients that haven't negotiated

--- a/extensions/message-redaction.md
+++ b/extensions/message-redaction.md
@@ -41,9 +41,8 @@ Clients wishing to use these capabilities MUST negotiate the [`message-tags`][]
 capability with the server.
 Additionally, this capability relies on messages being sent with the
 [`msgid`][] tag, and message ids MUST NOT contain spaces.
-Clients SHOULD negotiate the [`echo-message`][] and [`labeled-response`][]
-capabilities in order to receive message IDs for their own messages, to allow
-them to be redacted.
+Clients SHOULD negotiate the [`echo-message`][] capabilities in order to receive
+message IDs for their own messages, to allow them to be redacted.
 
 
 ### Capability
@@ -185,7 +184,6 @@ Deleting someone else's PRIVMSG:
 
 [`echo-message`]: ../extensions/echo-message.html
 [`+draft/react` client tag]: ../client-tags/react.html
-[`labeled-response`]: ../extensions/labeled-response.html
 [standard replies]: ../extensions/standard-replies.html
 [`message-tags`]: ../extensions/message-tags.html
 [`msgid`]: ../extensions/message-tags.html

--- a/extensions/message-redaction.md
+++ b/extensions/message-redaction.md
@@ -87,6 +87,7 @@ This specification defines `FAIL` messages using the [standard replies][]
 framework for notifying clients of errors with message editing and deletion.
 The following codes are defined, with sample plain text descriptions.
 
+* `FAIL REDACT INVALID_TARGET the_given_target :You cannot delete messages from the_given_target`
 * `FAIL REDACT REDACT_FORBIDDEN <target> <target-msgid> :You are not authorised to delete this message`
 * `FAIL REDACT REDACT_WINDOW_EXPIRED <target> <target-msgid> <window> :You can no longer edit this message`
 * `FAIL REDACT UNKNOWN_MSGID <target> <target-msgid> <window> :This message does not exist or is too old`

--- a/extensions/message-redaction.md
+++ b/extensions/message-redaction.md
@@ -39,8 +39,6 @@ guarantees.
 
 Clients wishing to use this capability MUST negotiate the [`message-tags`][]
 capability with the server.
-Additionally, this capability relies on messages being sent with the
-[`msgid`][] tag, and message ids MUST NOT contain spaces.
 Clients SHOULD negotiate the [`echo-message`][] capability in order to receive
 message IDs for their own messages, so they can be redacted.
 

--- a/extensions/message-redaction.md
+++ b/extensions/message-redaction.md
@@ -127,9 +127,7 @@ Such use cases might include:
 * Allowing channel moderators or server admins to delete unwelcome messages from others
 * Specifying a cut-off time after which message edits are no longer allowed
 
-If a message is redacted while a client is disconnected (or parted from a channel) while
-a message it saw is redacted, servers may send the `REDACT` command in a `chathistory`
-batch when it re-joins the channel.
+If a message is redacted while a client is not present in a channel, servers may send the `REDACT` command in a `chathistory` batch when it re-joins the channel.
 
 If servers use predictable or guessable `msgid`s, they should consider whether errors
 returned on `REDACT` may leak a message's existence to users who did not receive it

--- a/extensions/message-redaction.md
+++ b/extensions/message-redaction.md
@@ -156,22 +156,22 @@ Deleting a PRIVMSG:
 
     C: PRIVMSG #channel :an example
     S: @msgid=123 :nick!u@h PRIVMSG #channel :an example
-    C: DELETE #channel 123 :bad example
-    S: @msgid=124 :nick!u@h DELETE #channel 123 :bad example
+    C: REDACT #channel 123 :bad example
+    S: @msgid=124 :nick!u@h REDACT #channel 123 :bad example
 
 Deleting a TAGMSG:
 
     C: @draft/react=🤞TAGMSG #channel
     S: @msgid=123;draft/react=🤞TAGMSG #channel
-    C: DELETE #channel 123
-    S: @msgid=124 :nick@u@h DELETE #channel 123
+    C: REDACT #channel 123
+    S: @msgid=124 :nick@u@h REDACT #channel 123
 
 Deleting someone else's PRIVMSG:
 
     C: PRIVMSG #channel :join my network for cold hard chats
     S: @msgid=123 :nick!u@h PRIVMSG #channel :join my network for cold hard chats
-    C: DELETE #channel 123 spam
-    S: @msgid=124 :nick!u@h DELETE #channel 123 spam
+    C: REDACT #channel 123 spam
+    S: @msgid=124 :nick!u@h REDACT #channel 123 spam
 
 
 [`echo-message`]: ../extensions/echo-message.html

--- a/extensions/message-redaction.md
+++ b/extensions/message-redaction.md
@@ -166,21 +166,21 @@ Deleting a PRIVMSG:
     C: PRIVMSG #channel :an example
     S: @msgid=123 :nick!u@h PRIVMSG #channel :an example
     C: REDACT #channel 123 :bad example
-    S: @msgid=124 :nick!u@h REDACT #channel 123 :bad example
+    S: :nick!u@h REDACT #channel 123 :bad example
 
 Deleting a TAGMSG:
 
     C: @draft/react=🤞TAGMSG #channel
     S: @msgid=123;draft/react=🤞TAGMSG #channel
     C: REDACT #channel 123
-    S: @msgid=124 :nick@u@h REDACT #channel 123
+    S: :nick@u@h REDACT #channel 123
 
 Deleting someone else's PRIVMSG:
 
     C1: PRIVMSG #channel :join my network for cold hard chats
     S:  @msgid=123 :nick!u@h PRIVMSG #channel :join my network for cold hard chats
     C2: REDACT #channel 123 spam
-    S:  @msgid=124 :chanop!u@h REDACT #channel 123 spam
+    S:  :chanop!u@h REDACT #channel 123 spam
 
 
 [`echo-message`]: ../extensions/echo-message.html

--- a/extensions/message-redaction.md
+++ b/extensions/message-redaction.md
@@ -136,6 +136,20 @@ If servers use predictable or guessable `msgid`s, they should consider whether e
 returned on `REDACT` may leak a message's existence to users who did not receive it
 (in a channel they are/were not in or in private messages).
 
+### Message validation
+
+To implement validation, servers require a mechanism for determining the permissions of
+a particular edit or delete action.
+The user requesting the action would need to be compared against properties of
+the message, given only the message ID and target.
+
+Servers with message history storage could look up the message properties from the ID,
+but this might not be possible or desirable in all cases.
+Another mechanism could involve encoding any required properties within the message ID
+itself, e.g. the account ID, timestamp, etc. Servers might choose to encrypt this
+information if it isn't usually public facing. Any information encoded in a message ID
+is still opaque and not intended to be parsed by clients.
+
 ### Fallback
 
 Server implementations might choose to inform clients that haven't negotiated

--- a/extensions/message-redaction.md
+++ b/extensions/message-redaction.md
@@ -202,5 +202,5 @@ Deleting someone else's PRIVMSG:
 [`+draft/react` client tag]: ../client-tags/react.html
 [standard replies]: ../extensions/standard-replies.html
 [`message-tags`]: ../extensions/message-tags.html
-[`msgid`]: ../extensions/message-tags.html
-[`chathistory`]: ../extensions/message-tags.html
+[`msgid`]: ../extensions/message-ids.html
+[`chathistory`]: ../extensions/chathistory.html

--- a/extensions/message-redaction.md
+++ b/extensions/message-redaction.md
@@ -28,7 +28,7 @@ The final version of the specification will use an unprefixed capability name.
 ## Introduction
 
 This specification enables messages to be deleted.
-Use cases include retracting accidentally sent messages moderation,
+Use cases include retracting accidentally sent, messages moderation,
 and removing a [`+draft/react` client tag][], amongst others.
 These are cosmetic use cases and do not provide any operational security
 guarantees.

--- a/extensions/message-redaction.md
+++ b/extensions/message-redaction.md
@@ -138,7 +138,7 @@ returned on `REDACT` may leak a message's existence to users who did not receive
 ### Fallback
 
 Server implementations might choose to inform clients that haven't negotiated
-the capability that an edit or deletion has taken place.
+the capability that a deletion has taken place.
 The fallback method used (if any) is left up to server implementations, but
 could take the form of a standard NOTICE or PRIVMSG with information about the
 action.

--- a/extensions/message-redaction.md
+++ b/extensions/message-redaction.md
@@ -122,6 +122,10 @@ Such use cases might include:
 * Allowing channel moderators or server admins to delete unwelcome messages from others
 * Specifying a cut-off time after which message edits are no longer allowed
 
+If a message is redacted while a client is disconnected (or parted from a channel) while
+a message it saw is redacted, servers may send the `REDACT` command in a `chathistory`
+batch when it re-joins the channel.
+
 ### Fallback
 
 Server implementations might choose to inform clients that haven't negotiated


### PR DESCRIPTION
[Rendered](https://github.com/progval/ircv3-specifications/blob/redaction/extensions/message-redaction.md)

This is https://github.com/ircv3/ircv3-specifications/pull/425 with the following changes:

* no edits, because it's way more complicated to handle them safely, so IMO it should be deferred to a future spec
* targetmsgid is moved to a param (instead of a tag, because it didn't really make sense with a dedicated verb)
* added an optional reason (just because I can)
* renamed "delete" to "redact" so the cap name doesn't conflict with the other one (and there is some argument esp. in Matrix circles that "redact" better reflects that it's best effort and other clients might not respect it, but I don't really buy it)
* explicitly gives a lot of freedom to servers wrt chathistory
* new `UNKNOWN_MSGID` fail tag (because I noticed that's needed while implementing the spec)

Implementations:

* Ergo (server): https://github.com/ergochat/ergo/pull/2065
* Matrix2051 (gateway): https://github.com/progval/matrix2051/pull/53
* Limnoria (client): https://github.com/progval/Limnoria/pull/1538 (sending only)
* Unreal (server): https://github.com/unrealircd/unrealircd/pull/253 (new core API) + https://github.com/unrealircd/unrealircd-contrib/pull/91 (third-party module)
* Goguma (client): https://git.sr.ht/~emersion/goguma/log/redact
* IRCCloud