### PR TITLE
Clarify that the WHOX reply RPL_WHOSPCRPL may contain multiple prefixes even without the multi-prefix capability

### DIFF
--- a/extensions/whox.md
+++ b/extensions/whox.md
@@ -77,6 +77,9 @@ MUST be used:
 - Any syntactically correct placeholder can be used for `[oplevel]` when the
   server doesn't support op levels, for instance `n/a`.
 
+Servers MAY return multiple or all applicable prefixes in the `[flags]` (`f`)
+field, regardless of whether [`multi-prefix`](multi-prefix.html) is enabled.
+
 Clients SHOULD ignore the values of the hop count (`d`) and the channel op
 level (`o`) fields, because they are ill-defined and unreliable.
 


### PR DESCRIPTION
For historical context: ircu [first introduced WHOX in version 2.10.01](https://ircu.sourceforge.net/release.2.10.01-who.html) and appears to have originally only returned the highest prefix like regular WHO (verified in version 2.10.08.01). https://github.com/UndernetIRC/ircu2/commit/7ec4144c6b646292025b62ebeb1f974e02c03698 introduced returning all prefixes and was first released in version 2.10.11. Charybdis adopted this behaviour from the first version that implemented WHOX support (3.1, commits https://github.com/charybdis-ircd/charybdis/commit/48957a495191764aa3222fd8b15371c979621b61 and https://github.com/charybdis-ircd/charybdis/commit/02eca3f19a01a0fb55fdb65b83f3ec8fd9d7ad5f). I haven't inspected other ircds. Since both behaviours exist in released ircds, the wording is intentionally vague.