### PR TITLE
Ratify websocket support

### DIFF
--- a/extensions/websocket.md
+++ b/extensions/websocket.md
@@ -1,7 +1,6 @@
 ---
 title: WebSocket support
 layout: spec
-work-in-progress: true
 copyrights:
   -
     name: Shivaram Lingamneni


### PR DESCRIPTION
This specification has been stable for a while, it is actively implemented by at least three popular ircd's ([Ergo](https://ergo.chat/), [InspIRCd](https://www.inspircd.org/), [UnrealIRCd](https://www.unrealircd.org/)). It is also used by at least 2 Clients ([Kiwi IRC](https://github.com/kiwiirc/kiwiirc), [gamja](https://sr.ht/~emersion/gamja/)).



> **Note**
> gamja does not yet support subprotocols