### PR TITLE
clarify that the order of CAP REQ parameters is not significant

### DIFF
--- a/extensions/capability-negotiation.md
+++ b/extensions/capability-negotiation.md
@@ -311,6 +311,7 @@ which is not enabled, the server MUST continue processing the REQ subcommand as 
 handling this capability was successful.
 
 The capability identifier set must be accepted as a whole, or rejected entirely.
+The order of capabilities within the list is not significant.
 
 Clients SHOULD ensure that their list of requested capabilities is not too long to be
 replied to with a single ACK or NAK message. If a REQ's final parameter gets sufficiently

--- a/extensions/capability-negotiation.md
+++ b/extensions/capability-negotiation.md
@@ -550,3 +550,6 @@ Previous versions of this spec did not state that capability names MUST NOT star
 
 Previous versions of this spec did not state that space-separated capability lists may end with
 a trailing space.
+
+Previous versions of this spec did not state that the order of capabilities within a single
+CAP REQ line is not meaningful.


### PR DESCRIPTION
As per discussion here: https://github.com/ircv3/ircv3-specifications/pull/543#discussion_r1702186139

my understanding is that this is not currently specified, but that it's not a behavior change for any actually existing servers, and there's no use case for having order matter within the same line (if the client cares about ordering or dependencies, it should use multiple lines, or rely on the `CAP LS` output).