### PR TITLE
Add SAFERATE spec

### DIFF
--- a/extensions/saferate.md
+++ b/extensions/saferate.md
@@ -1,0 +1,34 @@
+---
+title: SAFERATE ISUPPORT token
+layout: spec
+work-in-progress: true
+copyrights:
+  -
+    name: "delthas"
+    period: "2024"
+---
+
+## Introduction
+
+This is a work-in-progress specification.
+
+This specification offers a way for servers to advertise that clients will not
+be disconnected due to server rate-limiting / anti-flood, and so that the client
+can send messages without doing its own conservative rate-limiting.
+
+## The `SAFERATE` ISUPPORT token
+
+This specification introduces the `SAFERATE` ISUPPORT token.
+
+When advertised, the server ensures that a client will not be disconnected due
+to server rate-limiting.
+
+The token MUST NOT be advertised with a value.
+
+## Implementation considerations
+
+In order to support this specification, a server can use fakelag to delay
+processing new messages rather than disconnect a client. The queue of incoming
+messages to process should be bounded.
+
+A client can disable its internal rate limiting when receiving this token.


### PR DESCRIPTION
This is an "implementation" of the [rate limiting ircv3-idea](https://github.com/ircv3/ircv3-ideas/issues/116), for the first possible solution described in it: "Add a new cap to indicate that a server won't disconnect a client because of rate limits. The server would still be free to slowly process message bursts, this would result in writes blocking on the client-side.".

## Implementations

- Server: [soju](https://github.com/emersion/soju/commit/6e4fb181d87be7f0790562844c2a3d9d3dcb346e) (as client and server)
