### PR TITLE
clarify CHATHISTORY TARGETS semantics

### DIFF
--- a/extensions/chathistory.md
+++ b/extensions/chathistory.md
@@ -114,7 +114,7 @@ Unlike the other subcommands, `TARGETS` does not return message history. Instead
 
     CHATHISTORY TARGETS <timestamp=YYYY-MM-DDThh:mm:ss.sssZ> <timestamp=YYYY-MM-DDThh:mm:ss.sssZ> <limit>
 
-The parameters have the same semantics as `BETWEEN`, except that they MUST be timestamps and not msgids. Returned messages have the syntax:
+The parameters have the same semantics as `BETWEEN`, except that they MUST be timestamps and not msgids, and they match against the latest message stored for the target (i.e. a target is not returned if its latest message is outside of the selection parameters, even if it has other messages inside them). Returned messages have the syntax:
 
     CHATHISTORY TARGETS <nickname | channel name> <YYYY-MM-DDThh:mm:ss.sssZ>
 


### PR DESCRIPTION
Clarify CHATHISTORY TARGETS semantics as follows:

>The parameters have the same semantics as `BETWEEN`, except that they MUST be timestamps and not msgids, and they match against the latest message stored for the target (i.e. a target is not returned if its latest message is outside of the selection parameters, even if it has other messages inside them).

This appears to be a source of confusion, which is understandable because the previous text was ambiguous. However, the emendation here was always the intent (otherwise the selectors could not be used effectively for pagination).