### PR TITLE
Disallow : as the first character of metadata keys

### DIFF
--- a/extensions/metadata.md
+++ b/extensions/metadata.md
@@ -79,7 +79,7 @@ The ABNF format of the `metadata` capability is:
     capability ::= 'metadata' ['=' tokens]
     tokens     ::= token [',' token]*
     token      ::= key ['=' value]
-    key        ::= <sequence of a-zA-Z0-9_./:->
+    key        ::= <sequence of a-zA-Z0-9_./:- not starting with :>
     value      ::= <utf8>
 
 These are the defined tokens:


### PR DESCRIPTION
It can't be serialized as a non-trailing parameter, eg. in 'METADATA <Target> <Key> <Visibility> <Value>'

Found by @slingamn 