### PR TITLE
Add `+draft/unreact` tag to reaction specification

### DIFF
--- a/client-tags/react.md
+++ b/client-tags/react.md
@@ -14,19 +14,25 @@ copyrights:
 This is a work-in-progress specification.
 
 Software implementing this work-in-progress specification MUST NOT use the
-unprefixed `+react` tag name. Instead, implementations SHOULD use the
-`+draft/react` tag name to be interoperable with other software
+unprefixed `+react` or `+unreact` tag names. Instead, implementations SHOULD use the
+`+draft/react` and `+draft/unreact` tag names to be interoperable with other software
 implementing a compatible work-in-progress version.
 
-The final version of the specification will use an unprefixed tag name.
+The final version of the specification will use unprefixed tag names.
 
 ## Introduction
 
-This specification defines a client-only message tag to indicate reactions to other messages
+This specification defines a client-only message tag to indicate reactions and unreactions to other messages
 
 ## Motivation
 
 This tag provides a means of communicating with context-sensitive, potentially non-textual reactions. It allows chat participants to respond to each other with text, symbols, emoticons, or emoji that don't necessarily appear as full messages, but instead as lightweight annotations, displayed adjacent to a parent message.
+
+While most IRC users do not expect messages to be removable, reactions are meant to be sent quickly, changed based on opinion and removed if sent on accident. For this reason, most implementations of emoji reactions allow an unreaction feature.
+
+One may wonder why an unreaction tag is needed when the [`draft/message-redaction`](../extensions/message-redaction.md.html) also allows for message removal. However, these two methods of message removal serve different purposes. Redaction is a server-moderated process to hide previous client actions, e.g., such that they do not show up in history. This capability is usually only given to users authorized to hide the action, such as a logged-in author or operators. 
+
+On the contrary, unreaction is its own action designed to change a previous choice (e.g., in response to a “voting” message), or remedy a misclick. If sent to clients as a text message, previous reactions need not be removed on an unreact message.
 
 ## Architecture
 
@@ -40,7 +46,11 @@ The react tag is sent by a client with the client-only prefix `+`. The value has
 
     +draft/react=<reaction>
 
-This tag MAY be attached to an empty message.
+The unreact tag is sent by a client with the client-only prefix `+`. The value has no restrictions.
+
+    +draft/unreact=<reaction>
+
+These tags MAY be attached to an empty message.
 
 ## Client implementation considerations
 
@@ -80,3 +90,11 @@ An example of an emoji reaction
 An example of a reaction sent as a `PRIVMSG` with an additional message body
 
     C: @+draft/reply=123;+draft/react=lol PRIVMSG #channel :lol
+
+An example of an reaction and unreaction sent as a `TAGMSG`s
+
+    S: @msgid=123 :nick!user@host PRIVMSG #football :They won!
+    C: @+draft/reply=123;+draft/react=🇦🇷 TAGMSG #football
+    S: @msgid=124 :nick!user@host PRIVMSG #football :Actually it was Germany...
+    C: @+draft/reply=123;+draft/unreact=🇦🇷 TAGMSG #football
+    C: @+draft/reply=123;+draft/react=🇩🇪 TAGMSG #football


### PR DESCRIPTION
This edit is in response to my client implementations—especially [halloy](https://halloy.chat) which does not yet support message redaction—and much reaction testing. In the draft phase, most implementations have settled on reactions being nick-based, but message redaction is account based. This creates an asymmetry between creating and removing reactions, which most users consider to be equivalent features.

I think it's OK for authorized users to remove reactions through a `REDACT`, but this should be performed for moderation reasons. Meanwhile average users may freely use `+draft/react` and `+draft/unreact` to change their reactions.

This specification is implemented in squidowl/halloy#1039.