### PR TITLE
Add more FAIL codes for client-initiated batches

### DIFF
--- a/extensions/client-batch.md
+++ b/extensions/client-batch.md
@@ -63,8 +63,14 @@ Servers MUST use `FAIL` messages from the [standard replies][] framework
 to notify clients of errors with client-initiated batches.
 The command is `BATCH` and the following codes are defined:
 
+* `INVALID_REFTAG <reference-tag>`: the provided reference tag contains
+  disallowed characters, all past and future messages in this batch
+  will be ignored.
 * `TIMEOUT <reference-tag>`: the batch was left open for too long,
   all past and future messages in this batch will be ignored.
+* `UNKNOWN_TYPE <reference-tag> <type>`: the batch type is not recognized
+  by the server, all past and future messages in this batch will be
+  ignored.
 
 ## Implementation considerations
 


### PR DESCRIPTION
While building out my implementation of this, I noticed that many instances of clients sending garbage to the server did not have a defined error code. My implementation provides a baseline support for the BATCH command while allowing other modules to define recognized batch types. As such, the handler for the BATCH command itself is generic and agnostic to the actual type being used. It still needs to do some basic tracking on the supplied reference tag and type before handing it off to the handler module, so cases where the reference tag and/or type are not valid need error messages.

Rather than making something implementation-defined, it'd probably be best to specify some messages that can be used in this case. An implementation that doesn't split things up like mine does isn't required to use these additional messages, but having them specified lets clients know to expect them.