### PR TITLE
delete requirement to filter RPL_WHOISKEYVALUE

### DIFF
--- a/extensions/metadata.md
+++ b/extensions/metadata.md
@@ -372,7 +372,7 @@ Replies:
 
 ### `RPL_WHOISKEYVALUE` numeric
 
-When a user runs `WHOIS` on a user with metadata, a subset of that metadata MAY be sent with `RPL_WHOISKEYVALUE` numerics. This subset MUST be chosen explicitly, and optimised for keys that can be easily read by users. For a complete view of user metadata, see the [`LIST`](#metadata-list) subcommand.
+When a user with the capability enabled runs `WHOIS` on a user with metadata set, a subset of that metadata MAY be sent with `RPL_WHOISKEYVALUE` numerics.
 
 ## Examples
 


### PR DESCRIPTION
I brought this up in #ircv3 but I wanted a "written" discussion. IMO, the requirement for the server to filter `RPL_WHOISKEYVALUE` does not make sense:

1. It seems to assume that clients will display raw keys and values directly in the whois output. But in fact, even key names will require individual client support (to translate the internal identifier into something user-readable). The correct place for this filtering is on the client side, where the client can display the keys and values it understands and ignore the others.
2. The goal of controlling the size of the WHOIS response is subsumed under controlling the total size of user metadata, for which `FAIL METADATA LIMIT_REACHED` has been specified (we could probably use some non-normative implementation recommendations on setting limits)