### PR TITLE
network-icon: add prefixed ISUPPORT disclaimer

### DIFF
--- a/extensions/network-icon.md
+++ b/extensions/network-icon.md
@@ -13,7 +13,9 @@ copyrights:
 
 This is a work-in-progress specification.
 
-Software implementing this work-in-progress specification MUST NOT use the unprefixed `ICON` ISUPPORT name. Instead, implementations SHOULD use the `draft/ICON` ISUPPORT name to be interoperable with other software implementing a compatible work-in-progress version. The final version of the specification will use unprefixed ISUPPORT names.
+Software implementing this work-in-progress specification MUST NOT use the unprefixed `ICON` ISUPPORT name. Instead, implementations SHOULD use the `draft/ICON` ISUPPORT name to be interoperable with other software implementing a compatible work-in-progress version.
+
+The final version of the specification will use unprefixed ISUPPORT names.
 
 ## Description
 


### PR DESCRIPTION
This is the standard work-in-progress disclaimer found in other specs.