### PR TITLE
Clarify that netjoin batches can contain non-JOINs

### DIFF
--- a/batches/netsplit.md
+++ b/batches/netsplit.md
@@ -19,10 +19,11 @@ When a netsplit occurs, the server MUST put all resulting QUITs into
 a single `netsplit` batch. Similarly, all netjoin-related JOINs MUST be
 put into a *single* `netjoin` batch. Both types have 2 arguments, which are
 the names of the servers that are splitting or joining, or *.net *.split
-and *.net *.join if the server has chosen to hide links.
-
-Servers MAY additionally send AWAYs and MODEs within the same `netjoin` batch
-containing the JOINs.
+and *.net *.join if the server has chosen to hide links. Servers MAY
+include additional data within these batches relevant to the state of
+joined or split clients, such as AWAY status to clients who have enabled the
+[`away-notify` capability][away-notify] and MODEs for channel operator,
+voice, or other channel status.
 
 Clients that do not understand the `netsplit` and `netjoin` batch types
 can safely interpret the batched QUITs and JOINs as standard QUITs
@@ -52,5 +53,8 @@ An example netjoin is as follows:
 ## Errata
 
 For consistency with capabilities and tags these types were renamed to lower case
-(from `NETSPLIT` to `netsplit`). Additionally, clarification was added that AWAY
-and MODE may also optionally appear within `netjoin` batches.
+(from `NETSPLIT` to `netsplit`). Additionally, clarification was added that
+messages beyond JOIN and QUIT that are relevant to client state tracking may also
+appear within these batches.
+
+[away-notify]: ../extensions/away-notify.html


### PR DESCRIPTION
When bursting a netjoin, AWAY may be sent to away-notify clients and MODE may be set on introduced nicks to give them e.g. channel operator status. Right now the language of the spec doesn't indicate one way or another whether these additional commands are valid inside of a netjoin batch. If they have to be excluded, then we run into issues where a client may process those unbatched AWAYs and MODEs before processing the netjoin batch and be very confused about receiving information for a user that they don't know about or isn't on the channel.

Instead, clarify that these are explicitly allowed within these batches. I narrowly scoped to messages relevant for client state tracking in the spec (with AWAY and MODE being called out as examples). Other things like TOPIC aren't order-dependent on a user being in the channel or not yet from a client's point of view and need not be included.