### PR TITLE
account-registration: add ACCOUNTREQUIRED ISUPPORT token

### DIFF
--- a/extensions/account-registration.md
+++ b/extensions/account-registration.md
@@ -71,6 +71,19 @@ The only defined capability keys so far are:
  * `custom-account-name` - if present, the account name can be different
    from the user's current nickname
 
+### ISUPPORT token
+
+This specification also defines the `draft/ACCOUNTREQUIRED` ISUPPORT token. If
+present, it indicates that the connection to the server cannot be completed
+unless the clients authenticates, typically via SASL. Note, the absence of this
+token does not indicate that connection registration can be completed without
+authentication; it may be disallowed due to specific properties of the
+connection (e.g. an untrustworthy IP address), which will be indicated instead
+by `FAIL * ACCOUNT_REQUIRED`. If the capability value
+`draft/account-registration=before-connect` is advertised, clients should
+respond to both of these conditions by suggesting that the user register an
+account.
+
 ### Commands
 
     REGISTER <account> {<email> | "*"} <password>


### PR DESCRIPTION
Alternative to https://github.com/ircv3/ircv3-specifications/pull/492

Now that we got `extended-isupport`, we can use ISUPPORT instead of a capability.

Implementations:

- [Ergo](https://github.com/ergochat/ergo/pull/2341)
- [soju](https://codeberg.org/emersion/soju/pulls/368)
- [Goguma](https://codeberg.org/emersion/goguma/pulls/341)

Closes: https://github.com/ircv3/ircv3-ideas/issues/73