### PR TITLE
Ratify the no-implicit-names extension.

### DIFF
--- a/extensions/no-implicit-names.md
+++ b/extensions/no-implicit-names.md
@@ -2,21 +2,12 @@
 title: "`no-implicit-names` Extension"
 layout: spec
 meta-description: A capability to disable implicit NAME responses on JOIN
-work-in-progress: true
 copyrights:
   -
     name: "Simon Ser"
     period: "2023"
     email: "contact@emersion.fr"
 ---
-
-## Notes for implementing work-in-progress version
-
-This is a work-in-progress specification.
-
-Software implementing this work-in-progress specification MUST NOT use the unprefixed `no-implicit-names` CAP name. Instead, implementations SHOULD use the `draft/no-implicit-names` CAP name to be interoperable with other software implementing a compatible work-in-progress version. The final version of the specification will use an unprefixed CAP name.
-
-This is a work-in-progress specification.
 
 ## Description
 
@@ -26,4 +17,4 @@ Some clients don't need to query the list of channel members for all joined chan
 
 ## Implementation
 
-The `no-implicit-names` extension introduces the `draft/no-implicit-names` capability. When negotiated, servers MUST NOT send an implicit `NAMES` reply after sending a `JOIN` message. Servers MUST reply to explicit `NAMES` commands sent by the client as usual.
+The `no-implicit-names` extension introduces the `no-implicit-names` capability. When negotiated, servers MUST NOT send an implicit `NAMES` reply after sending a `JOIN` message. Servers MUST reply to explicit `NAMES` commands sent by the client as usual.


### PR DESCRIPTION
I don't think there are any objections relating to this and we have enough implementations so lets ratify and ship it!

---

## Known implementations

### Client (3/1)

* [x] Goguma
* [x] HexDroid (according to [readme](https://github.com/boxlabss/HexDroid))
* [x] ObsidianIRC

### Server (5/2)

* [x] Ergo
* [x] InspIRCd (only available on the testnet until ratified)
* [x] matrix2051
* [x] Soju (as a server)
* [x] UnrealIRCd
