### PR TITLE
Ratify the channel-context client tag specification.

### DIFF
--- a/client-tags/channel-context.md
+++ b/client-tags/channel-context.md
@@ -1,24 +1,12 @@
 ---
 title: "`channel-context` client tag"
 layout: spec
-work-in-progress: true
 copyrights:
   -
     name: "delthas"
     period: 2022
     email: "delthas@dille.cc"
 ---
-
-## Notes for implementing work-in-progress version
-
-This is a work-in-progress specification.
-
-Software implementing this work-in-progress specification MUST NOT use the
-unprefixed `+channel-context` tag name. Instead, implementations SHOULD use the
-`+draft/channel-context` tag name to be interoperable with other software
-implementing a compatible work-in-progress version.
-
-The final version of the specification will use an unprefixed tag name.
 
 ## Introduction
 
@@ -40,7 +28,7 @@ Clients wishing to use this tag MUST negotiate the [`message-tags`](../extension
 
 The channel-context tag is sent by a client with the client-only prefix `+`. The value MUST be a valid channel name.
 
-    +draft/channel-context=<channel>
+    +channel-context=<channel>
 
 This tag MUST be attached to PRIVMSG and NOTICE messages to users only. Clients MUST ignore this tag if it is not attached to a private PRIVMSG or NOTICE message or if its value is not a valid channel name.
 
@@ -57,4 +45,4 @@ To prevent abuse, client implementations might allow users to hide these message
 In this example, user `me` requests documentation from bots in channel `#chan`, then gets the response in private, but in the context of that channel, using `channel-context`.
 
     C: PRIVMSG #chan :!help
-    S: @+draft/channel-context=#chan :bot!bot@bot NOTICE me :I'm helping.
+    S: @+channel-context=#chan :bot!bot@bot NOTICE me :I'm helping.


### PR DESCRIPTION
I don't think there are any objections relating to this and we have enough implementations so lets ratify and ship it!

---

## Known implementations

### Client

* [x] gamja
* [x] Goguma
* [x] IRCCloud
* [x] ObsidianIRC
* [x] senpai

### Bots

* [x] Anope (entry messages on compatible IRCds)
* [x] Limnoria
