### PR TITLE
Add `draft/extoidc` and `draft/OBJECTSTORAGE`

### DIFF
--- a/extensions/extoidc.md
+++ b/extensions/extoidc.md
@@ -1,0 +1,105 @@
+---
+title: OpenID Connect with the Client-Initiated Backchannel Authentication Flow (CIBA) for authentication to external services
+layout: spec
+work-in-progress: true
+copyrights:
+  -
+    name: "Reese Armstrong"
+    email: "me@reeseric.ci"
+    period: "2026"
+---
+
+# extoidc
+
+This is a work-in-progress specification.
+
+This specification introduces the `draft/EXTOIDC` CAP token for servers to indicate support for this specification.
+
+Software implementing this work-in-progress specification MUST NOT use the unprefixed `EXTOIDC` CAP name. Instead, implementations SHOULD use the `draft/EXTOIDC` CAP name to be interoperable with other software implementing a compatible work-in-progress version. The final version of the specification will use unprefixed CAP names.
+
+## Motivation
+
+This specification allows for end-users to authenticate to external services securely over IRC transport without a web-browser requirement. It additionally forms the core of the draft/OBJECTSTORAGE` authentication system.
+
+## Definitions
+
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED",  "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.
+
+“Server” refers to the IRC daemon
+
+“Client” refers to the end-user software interacting with the server
+
+“Relying Party” refers to the service requiring authentication from the client.
+
+## Flow
+
+The client SHALL utilize the `EXTOIDC token` command to issue a single-use token for authentication.
+
+The client SHALL present the token to the Relying Party to begin an authentication session.
+
+The Relying Party MAY send an Authentication Request to the server to begin a CIBA session, and SHALL present the token as a `login_token_hint`.
+
+Upon receipt of an Authentication Request, the server SHALL validate the signature and ID of the token. Once validated, the server SHALL notify the client of a pending authorization request with a `standard-reply` in the following format:
+
+```
+NOTE EXTOIDC AUTHORIZE [UUID] :A new authorization request requires action.
+```
+
+The client SHOULD then utilize the `EXTOIDC info` command to get the required information to present to the user for informed consent.
+
+Once the end-user has either consented or rejected the authorization request, the client SHALL either use the `EXTOIDC authorize` or `EXTOIDC reject` commands corresponding to the user action.
+
+## OpenID Connect
+
+Servers SHALL implement a discoverable [OpenID Connect](https://openid.net/specs/openid-connect-core-1_0.html) provider with a published JSON Web Key Set that is used to sign tokens.
+
+Servers SHALL implement the [OpenID Connect Client-Initiated Backchannel Authentication Flow](https://openid.net/specs/openid-client-initiated-backchannel-authentication-core-1_0.html#rfc.section.2) which SHOULD be the primary or exclusive flow.
+
+Servers SHALL register Relying Parties and store metadata about the Relying Party to surface for informed consent. Servers MAY use the [OpenID Connect Dynamic Client Registration](https://openid.net/specs/openid-connect-registration-1_0.html#ClientMetadata) specification for this.
+
+The out-of-band mechanism for authenticating a client SHALL be the `EXTOIDC` command.
+
+### Claims
+
+*This section is non-normative*
+
+This specification does not attempt to dictate what claims may be provided by the server and how client consent for claims is dictated. However, clients should make an active effort to determine informed consent for claims requested by the Relying Party.
+
+## `EXTOIDC` command
+
+The `EXTOIDC` command is used to authorize an external CIBA session and retrieve info about the Relying Party to surface for informed consent.
+
+### `EXTOIDC token`
+
+Upon the receipt of this command, the server SHALL issue and return a signed (with the published JWKS) JSON Web Token with an associated UUID as the `jti`.
+
+The server SHALL record the requesting client and token UUID.
+
+The client SHALL record the token UUID until action on the authorization request is taken.
+
+### `EXTOIDC authorize [UUID]`
+
+Upon receipt of this command, the server SHALL return a successful authorization and any claim data to the Relying Party in accordance with the negotiated CIBA mode. 
+
+After the authorization and claims are consumed by the Relying Party, the server and client SHALL discard the token record.
+
+### `EXTOIDC reject [UUID]`
+
+Upon receipt of this command, the server SHALL return a failed authorization to the Relying Party in accordance with the negotiated CIBA mode. 
+
+After the failure is consumed by the Relying Party, the server and client SHALL discard the token record.
+
+### `EXTOIDC info [UUID]`
+
+This subcommand fetches the info of the Relying Party as registered with the server, as well as the requested claim scopes and other information of the authentication request for a given session ID.
+
+It should provide the information in an array containing the following items:
+
+0. A relying party metadata object, as defined in [OpenID Connect Dynamic Client Registration § 2](https://openid.net/specs/openid-connect-registration-1_0.html#ClientMetadata)
+1. The full [Authentication Request](https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest) sent by the Relying Party, **with the exception of the login_token_hint, which contains the shared secret.**
+
+### `EXTOIDC config`
+
+#### `EXTOIDCDC config claims [LANG]`
+
+This subcommand provides user-facing descriptions for OpenID Connect claims advertised by the server. Upon receipt of the command, the server SHALL return a dictionary of claims and their associated descriptions.

--- a/extensions/extoidc.md
+++ b/extensions/extoidc.md
@@ -49,6 +49,26 @@ The client SHOULD then utilize the `extoidc info` command to get the required in
 
 Once the end-user has either consented or rejected the authorization request, the client SHALL either use the `extoidc authorize` or `extoidc reject` commands corresponding to the user action.
 
+### Diagram
+
+```mermaid
+sequenceDiagram
+	actor Alice
+	participant Server
+	participant RP@{ "type" : "control" } as Relying Party
+    Alice->>Server: /extoidc token
+	Server-->>Alice: signed JWT with UUID
+   	Alice->>RP: JWT from server
+	RP->>Server:Authentication Request with JWT
+	Server->>Server: Validate JWT signature
+	Server->>Alice:Do you authorize this authentication request?
+	Alice->>Server: Who is it? (/extoidc info)
+	Server-->>Alice: Info about RP & claim requests
+	Alice-->>Server: Authorize authentication (/extoidc authorize)
+	Server->>RP:Authentication Response & claim data
+	Server->>Server:Invalidate JWT
+```
+
 ## OpenID Connect
 
 Servers SHALL implement a discoverable [OpenID Connect](https://openid.net/specs/openid-connect-core-1_0.html) provider with a published JSON Web Key Set that is used to sign tokens.
@@ -100,6 +120,6 @@ It should provide the information in an array containing the following items:
 
 ### `extoidc config`
 
-#### `extoidcDC config claims [LANG]`
+#### `extoidc config claims [LANG]`
 
 This subcommand provides user-facing descriptions for OpenID Connect claims advertised by the server. Upon receipt of the command, the server SHALL return a dictionary of claims and their associated descriptions.

--- a/extensions/extoidc.md
+++ b/extensions/extoidc.md
@@ -13,9 +13,9 @@ copyrights:
 
 This is a work-in-progress specification.
 
-This specification introduces the `draft/EXTOIDC` CAP token for servers to indicate support for this specification.
+This specification introduces the `draft/extoidc` CAP token for servers to indicate support for this specification.
 
-Software implementing this work-in-progress specification MUST NOT use the unprefixed `EXTOIDC` CAP name. Instead, implementations SHOULD use the `draft/EXTOIDC` CAP name to be interoperable with other software implementing a compatible work-in-progress version. The final version of the specification will use unprefixed CAP names.
+Software implementing this work-in-progress specification MUST NOT use the unprefixed `extoidc` CAP name. Instead, implementations SHOULD use the `draft/extoidc` CAP name to be interoperable with other software implementing a compatible work-in-progress version. The final version of the specification will use unprefixed CAP names.
 
 ## Motivation
 
@@ -33,7 +33,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 
 ## Flow
 
-The client SHALL utilize the `EXTOIDC token` command to issue a single-use token for authentication.
+The client SHALL utilize the `extoidc token` command to issue a single-use token for authentication.
 
 The client SHALL present the token to the Relying Party to begin an authentication session.
 
@@ -42,12 +42,12 @@ The Relying Party MAY send an Authentication Request to the server to begin a CI
 Upon receipt of an Authentication Request, the server SHALL validate the signature and ID of the token. Once validated, the server SHALL notify the client of a pending authorization request with a `standard-reply` in the following format:
 
 ```
-NOTE EXTOIDC AUTHORIZE [UUID] :A new authorization request requires action.
+NOTE extoidc AUTHORIZE [UUID] :A new authorization request requires action.
 ```
 
-The client SHOULD then utilize the `EXTOIDC info` command to get the required information to present to the user for informed consent.
+The client SHOULD then utilize the `extoidc info` command to get the required information to present to the user for informed consent.
 
-Once the end-user has either consented or rejected the authorization request, the client SHALL either use the `EXTOIDC authorize` or `EXTOIDC reject` commands corresponding to the user action.
+Once the end-user has either consented or rejected the authorization request, the client SHALL either use the `extoidc authorize` or `extoidc reject` commands corresponding to the user action.
 
 ## OpenID Connect
 
@@ -57,7 +57,7 @@ Servers SHALL implement the [OpenID Connect Client-Initiated Backchannel Authent
 
 Servers SHALL register Relying Parties and store metadata about the Relying Party to surface for informed consent. Servers MAY use the [OpenID Connect Dynamic Client Registration](https://openid.net/specs/openid-connect-registration-1_0.html#ClientMetadata) specification for this.
 
-The out-of-band mechanism for authenticating a client SHALL be the `EXTOIDC` command.
+The out-of-band mechanism for authenticating a client SHALL be the `extoidc` command.
 
 ### Claims
 
@@ -65,11 +65,11 @@ The out-of-band mechanism for authenticating a client SHALL be the `EXTOIDC` com
 
 This specification does not attempt to dictate what claims may be provided by the server and how client consent for claims is dictated. However, clients should make an active effort to determine informed consent for claims requested by the Relying Party.
 
-## `EXTOIDC` command
+## `extoidc` command
 
-The `EXTOIDC` command is used to authorize an external CIBA session and retrieve info about the Relying Party to surface for informed consent.
+The `extoidc` command is used to authorize an external CIBA session and retrieve info about the Relying Party to surface for informed consent.
 
-### `EXTOIDC token`
+### `extoidc token`
 
 Upon the receipt of this command, the server SHALL issue and return a signed (with the published JWKS) JSON Web Token with an associated UUID as the `jti`.
 
@@ -77,19 +77,19 @@ The server SHALL record the requesting client and token UUID.
 
 The client SHALL record the token UUID until action on the authorization request is taken.
 
-### `EXTOIDC authorize [UUID]`
+### `extoidc authorize [UUID]`
 
 Upon receipt of this command, the server SHALL return a successful authorization and any claim data to the Relying Party in accordance with the negotiated CIBA mode. 
 
 After the authorization and claims are consumed by the Relying Party, the server and client SHALL discard the token record.
 
-### `EXTOIDC reject [UUID]`
+### `extoidc reject [UUID]`
 
 Upon receipt of this command, the server SHALL return a failed authorization to the Relying Party in accordance with the negotiated CIBA mode. 
 
 After the failure is consumed by the Relying Party, the server and client SHALL discard the token record.
 
-### `EXTOIDC info [UUID]`
+### `extoidc info [UUID]`
 
 This subcommand fetches the info of the Relying Party as registered with the server, as well as the requested claim scopes and other information of the authentication request for a given session ID.
 
@@ -98,8 +98,8 @@ It should provide the information in an array containing the following items:
 0. A relying party metadata object, as defined in [OpenID Connect Dynamic Client Registration § 2](https://openid.net/specs/openid-connect-registration-1_0.html#ClientMetadata)
 1. The full [Authentication Request](https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest) sent by the Relying Party, **with the exception of the login_token_hint, which contains the shared secret.**
 
-### `EXTOIDC config`
+### `extoidc config`
 
-#### `EXTOIDCDC config claims [LANG]`
+#### `extoidcDC config claims [LANG]`
 
 This subcommand provides user-facing descriptions for OpenID Connect claims advertised by the server. Upon receipt of the command, the server SHALL return a dictionary of claims and their associated descriptions.

--- a/extensions/extoidc.md
+++ b/extensions/extoidc.md
@@ -37,7 +37,7 @@ The client SHALL utilize the `extoidc token` command to issue a single-use token
 
 The client SHALL present the token to the Relying Party to begin an authentication session.
 
-The Relying Party MAY send an Authentication Request to the server to begin a CIBA session, and SHALL present the token as a `login_token_hint`.
+The Relying Party MAY send an Authentication Request to the server to begin a CIBA session, and SHALL present the token as a `login_hint_token`.
 
 Upon receipt of an Authentication Request, the server SHALL validate the signature and ID of the token. Once validated, the server SHALL notify the client of a pending authorization request with a `standard-reply` in the following format:
 
@@ -113,10 +113,10 @@ After the failure is consumed by the Relying Party, the server and client SHALL 
 
 This subcommand fetches the info of the Relying Party as registered with the server, as well as the requested claim scopes and other information of the authentication request for a given session ID.
 
-It should provide the information in an array containing the following items:
+It should provide the information in a JSON string array containing the following items:
 
 0. A relying party metadata object, as defined in [OpenID Connect Dynamic Client Registration § 2](https://openid.net/specs/openid-connect-registration-1_0.html#ClientMetadata)
-1. The full [Authentication Request](https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest) sent by the Relying Party, **with the exception of the login_token_hint, which contains the shared secret.**
+1. The full [Authentication Request](https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest) sent by the Relying Party, **with the exception of the login_hint_token, which contains the shared secret.**
 
 ### `extoidc config`
 

--- a/extensions/objectstorage.md
+++ b/extensions/objectstorage.md
@@ -49,6 +49,49 @@ a) The `X-Session-Token` provided after either the creation or a previous reques
 
 b) A `EXTOIDC` token to begin an authentication session with. The provider SHALL begin a CIBA authentication session and SHALL immediately return a `401 Unauthorized`  and a new `X-Session-Token` to indicate that the authorization session has not been completed.
 
-Providers SHALL include an `X-Session-Token` with each successful request after an `EXTOIDC` CIBA session.
+Providers SHALL ensure the valid authentication status for an `X-Session-Token` and that usage of a valid `X-Session-Token` does not require a new CIBA authentication session. Providers SHALL include an `X-Session-Token` with each successful request after an `EXTOIDC` CIBA session. Clients SHALL replace any existing `X-Session-Token` with one provided in the `X-Session-Token` header in a given response.
+
+> [!TIP]
+> Providers may "staple" `X-Session-Token` tokens to avoid storing perpetually a list of authenticated token IDs, since any `X-Session-Token` provided on a subsequent request shall replace any previous token. This is demonstrated in the Diagram below.
 
 Once the upload is completed, the upload URL is now usable to point to the file in IRC conversation and can be managed with either an unexpired `X-Session-Token` or by starting a new `EXTOIDC` session.
+
+## Diagram
+
+```mermaid
+sequenceDiagram
+  actor Alice
+	participant Server
+	participant Provider@{"type": "boundary"} as Provider Root
+	Alice-->Server: Establish IRC connection
+	Server-->>Alice: ISUPPORT data advertising<br> OBJECTSTORAGE provider root
+  Alice->>Server: /extoidc token
+	Server-->>Alice: signed extoidc JWT
+  Alice->>Provider: File upload session creation request with extoidc JWT
+  create participant UploadResource@{"type": "entity"} as Upload Resource
+  Provider->UploadResource: Create upload resource
+  Provider->>Provider: Create session JWT with<br> upload resource as subject, and <br>in-memory record of the associated id
+  par
+    Provider-->>Alice: Upload resource URL and session JWT
+  and
+    Provider->>Server:Authentication Request with extoidc JWT
+    Server->>Server: Validate extoidc JWT
+    Server-)Alice:Do you authorize this authentication request?
+    Alice->>Server: Who is it? (/extoidc info)
+    Server-->>Alice: Info about RP & claim requests
+    Alice-->>Server: Authorize authentication (/extoidc authorize)
+    par
+      Server->>Provider:Authentication Response & claim data
+      Provider->>Provider:Save session JWT ID and<br>authentication status to in-memory record
+    and
+      Server->>Server:Revoke extoidc JWT
+    end
+	end
+	Alice->>UploadResource:Uploads chunk using tus.io spec, provides session JWT
+	UploadResource->>UploadResource: Verifies session JWT is authenticated and<br> discards in-memory record of session JWT
+	UploadResource-->>Alice: Returns "stapled" session JWT marked as authenticated
+	loop
+		Alice->>UploadResource: Uploads chunk using tus.io spec, providing stapled session JWT
+	end
+	Alice->>Server: Sends upload resource URL as<br> reference to file in IRC message
+```

--- a/extensions/objectstorage.md
+++ b/extensions/objectstorage.md
@@ -1,0 +1,54 @@
+---
+title: Discovery and authentication of external object storage providers
+layout: spec
+work-in-progress: true
+copyrights:
+  -
+    name: "Reese Armstrong"
+    email: "me@reeseric.ci"
+    period: "2026"
+---
+
+# objectstorage
+
+This is a work-in-progress specification.
+
+Software implementing this work-in-progress specification SHALL NOT use the unprefixed `OBJECTSTORAGE` ISUPPORT name. Instead, implementations SHOULD use the `draft/OBJECTSTORAGE` ISUPPORT name to be interoperable with other software implementing a compatible work-in-progress version. The final version of the
+specification will use unprefixed ISUPPORT names.
+
+## Motivation
+
+This specification offers a way for servers to advertise an object storage provider for authenticated users to upload files (such as text or images), so they can post them on IRC.
+
+## Definitions
+
+“Server” refers to the IRC daemon
+
+“Client” refers to the end-user software interacting with the server
+
+“Provider” refers to the advertised (by the server) object storage provider
+
+
+## Architecture
+
+This specification introduces the `draft/OBJECTSTORAGE`  isupport token.
+
+Its value SHALL be a URI and SHOULD use the `https` scheme. Clients SHALL ignore tokens with an URI scheme they don't support. Clients SHALL refuse to use unencrypted URI transports (such as plain `http`) if the IRC connection is encrypted (e.g. via TLS).
+
+Providers SHALL support the [tus.io](https://tus.io/protocols/resumable-upload) resumable upload protocol and the creation extension.
+
+When clients wish to upload a file using the server's advertised provider, they SHALL begin an `EXTOIDC` authentication session by requesting a token with `EXTOIDC token`. 
+
+The client then SHALL send a tus.io creation `POST` request to the provider, while providing the `EXTOIDC` token in the `Authorization` header with the Bearer scheme. 
+
+The provider SHALL immediately return an upload URL in the Location header and a signed JWT which shall expire in 1 hour in the `X-Session-Token` header, while beginning an `EXTOIDC` CIBA authentication in the background with the provided `EXTOIDC` token.
+
+Once authentication is complete, clients SHALL then use the tus.io core protocol to upload or manage the file at the provider at the upload URL while providing either in the `Authorization` header with the Bearer scheme:
+
+a) The `X-Session-Token` provided after either the creation or a previous request,
+
+b) A `EXTOIDC` token to begin an authentication session with. The provider SHALL begin a CIBA authentication session and SHALL immediately return a `401 Unauthorized`  and a new `X-Session-Token` to indicate that the authorization session has not been completed.
+
+Providers SHALL include an `X-Session-Token` with each successful request after an `EXTOIDC` CIBA session.
+
+Once the upload is completed, the upload URL is now usable to point to the file in IRC conversation and can be managed with either an unexpired `X-Session-Token` or by starting a new `EXTOIDC` session.


### PR DESCRIPTION
This pull request provides a secure and standardized flow for authenticating external services using OpenID Connect over an IRC backchannel (no web redirects!), as well as secure object storage provider discovery and authentication using extoidc, as well as resumable uploads using tus.io.

Stemmed from:

#562
https://github.com/ircv3/ircv3-specifications/issues/562#issuecomment-4179169125
https://github.com/ircv3/ircv3-specifications/issues/562#issuecomment-4104704886
