### PR TITLE
Update metadata spec

### DIFF
--- a/extensions/metadata.md
+++ b/extensions/metadata.md
@@ -29,16 +29,17 @@ copyrights:
     name: "Val Lorentz"
     period: "2022-2023"
     email: "progval+ircv3@progval.net"
+  -
+    name: "Ryan Schmidt"
+    period: "2026"
+    email: "moonmoon@libera.chat"
 ---
 
 ## Notes for implementing work-in-progress version
 
 This is a work-in-progress specification.
 
-Software implementing this work-in-progress specification MUST NOT use the
-unprefixed `metadata-2` capability name.
-Instead, implementations SHOULD use the `draft/metadata-2` capability name to be interoperable with other
-software implementing a compatible work-in-progress version.
+Software implementing this work-in-progress specification MUST NOT use the unprefixed `metadata` capability name. Instead, implementations SHOULD use the `draft/metadata-2` capability name to be interoperable with other software implementing a compatible work-in-progress version.
 
 The final version of the specification will use an unprefixed capability name.
 
@@ -47,27 +48,27 @@ The final version of the specification will use an unprefixed capability name.
 It is useful to associate metadata with one's IRC presence, e.g. to make one's homepage or non-IRC contact details more discoverable.
 There are several mechanisms for doing this, but they normally rely on the presence of services and aren't really suitable for transient metadata like a user's current location.
 
-This feature lays out a command that can be used to set metadata, and a message that can be used to receive metadata updates from the server.
+This feature lays out a command that can be used to manage metadata associated with clients or channels and a notification framework to receive updates on metadata changes.
 
 ## Concepts
 
 Clients and channels can both contain metadata. Metadata acts as a key:value store (for example, the `display-name` key on a user, or the `url` key on a channel).
 
-Clients can [set/delete](#metadata-set) metadata on themselves, and on channels they administer. Privileged users (e.g. network admins) may be able to set certain metadata on other users, and set special keys on themselves or channels.
+Clients can set or delete metadata on themselves and on channels they administer. Privileged users (e.g. network admins) may be able to set certain metadata on other users, and set special keys on themselves or channels.
 
-Server administrators can setup lists of allowed or blocked keys, and may also restrict the setting/viewing of keys depending on whether the user is an admin, what kind of admin they are, etc (see the `Visibility` field).
+On joining a server, clients have to configure their 'metadata key subscriptions'. This is a list of which keys the client understands and wants to get updates about. For example, they may subscribe to a `status` key if they support user-set statuses. By default, this subscription list is empty. When metadata is updated or removed, users who have subscribed to the changed key will receive messages notifying them of the change.
 
-On joining a server, clients have to configure their 'metadata key [subscriptions](#metadata-sub)'. This is a list of which keys the client understands and wants to get updates about (for example, they may subscribe to a `status` key if they support user-set statuses). By default, this subscription list is empty.
+## Definitions
 
-When metadata is updated, users who have subscribed to the changed key will receive a [`METADATA` message](#metadata-server-message) notifying them of the change.
+*Visible channels* or *visible users* (generally, *visible target*) mean channels or users that a client would receive [metadata notifications](#notifications) about.
 
-For channel metadata, this applies only to subscribers who are members of the updated channel. For user metadata, this applies only to subscribers who either share a channel with the updated user or are [monitoring](https://ircv3.net/specs/extensions/monitor.html#monitor-command) them.
+Servers may additionally restrict the visibility of metadata keys to certain subsets of users (e.g. based on operator status). A *visible key* is a metadata key that the user has permissions to view, according to the server's implementation-defined means.
 
-On joining a channel, users will get the channel's current metadata sent to them with `METADATA` messages, and get the same information for all users who are in the channel. Specifically, they get that information for the keys they are subscribed to. The server may also tell them to request that information [at a later time](#metadata-sync).
+A *metadata-aware client* is a client who has negotiated both the `draft/metadata-2` capability and the `batch` capability.
 
 ## Relation with other specifications
 
-This specification depends on the [`batch`](../extensions/batch.html) capability which MUST be negotiated to use ``draft/metadata-2``. The order of capability negotiation is not significant and MUST NOT be enforced.
+This specification depends on the [`batch`](../extensions/batch.html) capability which MUST be negotiated to use `draft/metadata-2`. The order of capability negotiation is not significant and MUST NOT be enforced.
 
 This specification also uses the [standard replies](../extensions/standard-replies.html) framework.
 
@@ -77,9 +78,9 @@ Clients MUST NOT request both `metadata-notify` and `draft/metadata-2`. Servers 
 
 The `draft/metadata-2` capability indicates that a server supports metadata, and provides any limits and information about the system that clients must be aware of. Clients MUST request this capability in order to receive [`METADATA` notifications](#notifications).
 
-The ABNF format of the `metadata` capability is:
+The ABNF format of the `draft/metadata-2` capability is:
 
-    capability ::= 'metadata' ['=' tokens]
+    capability ::= 'draft/metadata-2' ['=' tokens]
     tokens     ::= token [',' token]*
     token      ::= key ['=' value]
     key        ::= <sequence of one or more a-z0-9_./->
@@ -87,18 +88,32 @@ The ABNF format of the `metadata` capability is:
 
 These are the defined tokens:
 
-* `before-connect`: if present, indicates the server supports `METADATA` commands during connection registration
-* `max-subs`: the maximum number of keys a client is allowed in its subscription list. See the [`SUB`](#metadata-sub) subcommand for more details.
-* `max-keys`: the maximum number of keys a client is allowed to set on its own nickname.
-* `max-value-bytes`: the maximum size of values a client is allowed to set. Servers MAY send longer values.
+* `before-connect`: If present, indicates the server supports `METADATA` commands during connection registration. This token has no value and clients MUST ignore any value sent with it.
+* `max-subs`: The maximum number of keys a client is allowed in its subscription list. See the [`METADATA SUB`](#metadata-sub) command for more details.
+* `max-keys`: The maximum number of keys a client is allowed to set on its own nickname.
+* `max-key-bytes`: The maximum size of keys a client is allowed to set. Servers MAY send longer keys.
+* `max-value-bytes`: The maximum size of values a client is allowed to set. Servers MAY send longer values.
 
-Clients MUST silently ignore any unknown tokens.
+Clients MUST silently ignore any unknown tokens. If the server does not provide a token indicating one of the above limits, clients SHOULD assume that particular item has no limit.
+
+If a client removes this capability from themselves, servers MUST clear that client's subscription list.
+
+*[[Begin non-normative examples--*
+
+In both of these examples, max-subs is specified but other tokens are not. Clients should assume that max-keys, max-key-bytes, and max-value-bytes have no limit. In practice, the key and value must still fit on a single IRC protocol line despite not having any server-specified limit.
+
+    C: CAP LS 302
+    S: CAP * LS :userhost-in-names draft/metadata-2=foo,max-subs=50,bar multi-prefix
+    C: CAP LS 302
+    S: CAP * LS :draft/metadata-2=max-subs=25 multi-prefix invite-notify
+
+*--End non-normative examples]]*
 
 ## Keys and Values
 
 Key names are restricted to the ranges `a-z`, `0-9`, and `_./-`. The empty string is an invalid value.
 
-Values can take any form, but MUST be encoded using UTF-8. The empty string is a valid value.
+Values can take any form, but MUST be encoded using UTF-8. The empty string is an invalid value.
 
 The expected handling of individual metadata keys SHOULD be [defined and listed in the IRCv3 extension registry](https://ircv3.net/registry).
 
@@ -106,64 +121,136 @@ The expected handling of individual metadata keys SHOULD be [defined and listed 
 
 This specification adds the `metadata` and `metadata-subs` batch types.
 
-The `metadata` batch type MUST be sent to clients under the following circumstances:
+The `metadata` batch type takes one parameter and clients MUST ignore extra parameters. This parameter contains the target for which the metadata was requested, allowing the client to correctly process empty batches. Clients MUST NOT assume that all metadata in the batch applies to the entity referenced in the batch parameter; for example, a batch sent in response to a channel join or [`METADATA SYNC`](#metadata-sync) on a channel may contain metadata on users as well as the channel itself. Servers MAY send one or more of any of the following messages inside of this batch type:
 
-* To enclose 0 or more `761 RPL_KEYVALUE` responses to `METADATA GET` or `METADATA LIST`
-* To enclose 0 or more `METADATA` commands in response to `METADATA SYNC`
-* To enclose 0 or more `METADATA` commands in response to a metadata-capable client completing connection registration and receiving its own metadata
+* `761 RPL_KEYVALUE`
+* `766 RPL_KEYNOTSET`
+* `NOTE METADATA`
+* `WARN METADATA`
+* `FAIL METADATA`
 
-It takes one parameter and clients MUST ignore extra parameters. This parameter contains the target for which the metadata was requested, allowing the client to correctly process empty batches. Since a batch sent in response to `METADATA SYNC` on a channel may contain metadata on users as well as the channel itself, clients MUST NOT assume that all metadata in the batch applies to the entity referenced in the batch parameter.
+The `metadata-subs` batch type takes no parameters and clients MUST ignore any parameters sent. Servers MAY send one or more of any of the following messages inside of this batch type:
 
-The `metadata-subs` batch type MUST be sent to clients in response to the `SUBS` subcommand, to enclose 0 or more `772 RPL_METADATASUBS` replies. It takes no parameters and clients MUST ignore any parameters sent.
+* `772 RPL_METADATASUBS`
+* `NOTE METADATA`
+* `WARN METADATA`
+* `FAIL METADATA`
+
+## Replies
+
+The following numerics are reserved for metadata, with these labels and parameters:
+
+| No. | Label                     | Parameters                               |
+| --- | ------------------------- | ---------------------------------------- |
+| 760 | `RPL_WHOISKEYVALUE`       | `<Target> <Key> <Visibility> :<Value>`   |
+| 761 | `RPL_KEYVALUE`            | `<Target> <Key> <Visibility> :<Value>`   |
+| 766 | `RPL_KEYNOTSET`           | `<Target> <Key> :Key not set`            |
+| 770 | `RPL_METADATASUBOK`       | `<Key1> [<Key2> ...]`                    |
+| 771 | `RPL_METADATAUNSUBOK`     | `<Key1> [<Key2> ...]`                    |
+| 772 | `RPL_METADATASUBS`        | `<Key1> [<Key2> ...]`                    |
+| 774 | `RPL_METADATASYNCLATER`   | `<Target> <RetryAfter> :Try again later` |
+
+The trailing parameter of `766 RPL_KEYNOTSET` and `774 RPL_METADATASYNCLATER` MAY vary wildly between implementations.
+
+The `<RetryAfter>` parameter of `774 RPL_METADATASYNCLATER` MUST be a non-negative integer. This parameter indicates the number of seconds clients SHOULD wait before re-trying the command.
+
+The `<Visibility>` parameter of `760 RPL_WHOISKEYVALUE` and `761 RPL_KEYVALUE` is an asterisk (`*`) for keys visible to everyone, or an implementation-defined value which describes the key’s visibility status; for instance, it MAY be a permission level or flag.
+
+The following [standard reply](../extensions/standard-replies.html) codes are used in this specification, with these labels and parameters:
+
+| Code                    | Parameters                                     |
+| ----------------------- | ---------------------------------------------- |
+| `INVALID_KEY`           | `<Key> :Invalid key`                           |
+| `INVALID_PARAMS`        | `<Command> :Invalid parameters`                |
+| `INVALID_TARGET`        | `<Target> :Invalid metadata target`            |
+| `INVALID_VALUE`         | `<Key> :Invalid value`                         |
+| `KEY_NO_PERMISSION`     | `<Target> <Key> :Permission denied`            |
+| `LIMIT_REACHED`         | `<Item> <Limit> :Limit reached`                |
+| `RATE_LIMITED`          | `<Target> <Key> <RetryAfter> :Try again later` |
+
+The trailing parameter containing the descriptive message MAY vary wildly between implementations and SHOULD contain a relevant description for the specific error encountered.
+
+The `<Command>` parameter of `INVALID_PARAMS` is the subcommand specified by the client, or an asterisk (`*`) if no subcommand was provided or the subcommand is not valid as a middle parameter.
+
+The `<Item>` parameter of `LIMIT_REACHED` will be the target if the metadata limit for a particular target was reached while performing [`METADATA SET`](#metadata-set) or the key name unable to be subscribed to if the subscription limit was reached while performing [`METADATA SUB`](#metadata-sub).
+
+The `<RetryAfter>` parameter of `RATE_LIMITED` MUST be a non-negative integer. This parameter indicates the number of seconds clients SHOULD wait before re-trying the command.
 
 ## Notifications
 
-Clients can either be subscribed to a key, or not subscribed to it. By default, clients are not subscribed to any keys. They can subscribe and unsubscribe from keys using the [`SUB`](#metadata-sub) and [`UNSUB`](#metadata-unsub) subcommands. The server MUST allow clients to subscribe to any valid keys, including privileged keys the client cannot access at the time of subscription.
+By default, clients are not subscribed to any keys. They can subscribe and unsubscribe from keys using the [`SUB`](#metadata-sub) and [`UNSUB`](#metadata-unsub) subcommands, respectively. Servers MUST allow clients to subscribe to any valid keys, including privileged keys the client cannot access at the time of subscription.
 
-The client will receive [`METADATA` messages](#metadata-server-message) about the keys they are subscribed to. They can also use the [`GET`](#metadata-get) and [`LIST`](#metadata-list) subcommands to receive information about keys they are not subscribed to.
+When a client is subscribed to a key, they automatically receive metadata updates regarding that key. These updates will be either a `761 RPL_KEYVALUE` indicating the key on the target was set to a particular value or a `766 RPL_KEYNOTSET` indicating that the key was removed from the target. Clients MAY also receive metadata notifications for keys they have not subscribed to, or even when they have not subscribed to any keys.
 
-Clients automatically receive metadata updates for:
+Servers MUST send notifications to subscribers the key is visible to for changes made:
 
-* themselves (excluding changes they make themselves)
-* channels they are joined to,
-* other clients in the channels they are joined to, and
-* users they are currently monitoring.
+* to that subscriber (excluding changes the subscriber made on themselves),
+* to channels that subscriber is joined to,
+* to other clients in the channels that subscriber is joined to, and
+* to users that subscriber is currently monitoring.
 
-Servers MUST reply to erroneous requests using [Standard Replies](https://ircv3.net/specs/extensions/standard-replies)
+## Automatic synchronization
 
------
+The notification framework provides clients updates on metadata keys for visible targets, but does not share any information about keys already set before the target became visible to the client. This section describes events outside of the `METADATA` command that trigger automatic synchronization of metadata so that the client has a usable baseline to work from.
 
-If a channel/user the client is receiving updates for changes one of the keys the client is subscribed to, they will receive a [`METADATA` message](#metadata-server-message) notifying them of the change. Clients MAY also receive metadata notifications for keys they have not subscribed to, or even when they have not subscribed to any keys.
+If the `draft/metadata-2` capability was negotiated during connection registration, servers MUST send clients a list of their current metadata (any metadata stored by the server or by services, plus any metadata set by the client during connection registration via `before-connect`) in a `metadata` batch with their own nick as target as part of the registration burst, i.e. before `RPL_ENDOFMOTD` or `ERR_NOMOTD`. This batch MUST include all visible keys set on the client, irrespective of whether the client has subscribed to that key.
 
-Here are additional cases where clients will receive `METADATA` messages:
+When server sends `730 RPL_MONONLINE` to a metadata-aware client (see [`MONITOR`](../extensions/monitor.html#monitor-command)), the server MUST additionally send either a `metadata` batch containing the monitored user's metadata to the client or a `774 RPL_METADATASYNCLATER` message to indicate postponed synchronization. If the server sends a batch, the batch MUST be identical to what would be returned if [`METADATA SYNC`](#metadata-sync) was issued against that target.
 
-- If the `metadata` capability was negotiated during connection registration, clients receive their current metadata (any metadata stored by the server or by services, plus any metadata set by the client during connection registration via `before-connect`) in a `metadata` batch with their own nick as target as part of the registration burst, i.e. before `RPL_ENDOFMOTD` or `ERR_NOMOTD`. If none exists, the server MUST send an empty batch instead.
-- When subscribing to a key, clients SHOULD receive the current value of that key for channels/users they are receiving updates for.
-- Clients SHOULD receive the current values of keys they are subscribed to when they [`MONITOR`](https://ircv3.net/specs/extensions/monitor.html#monitor-command) a user, or when one of their monitored users comes online.
+When a metadata-aware client joins a channel, the server MUST send either a `metadata` batch containing the channel's metadata as well as the metadata for all users on the channel or a `774 RPL_METADATASYNCLATER` message to indicate postponed synchronization. If the server sends a batch, the batch MUST be identical to what would be returned if [`METADATA SYNC`](#metadata-sync) was issued against that channel.
 
 ## Postponed synchronization
 
-If the client joins a large channel, or the client is already on some channels and enables the `metadata` capability, the server may not be able to send the client all current metadata for their targets.
+Servers MAY respond with `774 RPL_METADATASYNCLATER` to certain types of automatic synchronization as well as to the [`METADATA SYNC`](#metadata-sync) command for implementation-defined reasons, such as joining a channel with too many users or internal rate-limiting. This numeric indicates that the client SHOULD request synchronization of that target's metadata at a later time.
 
-In this case, the server MUST respond with a `RPL_METADATASYNCLATER` numeric instead of propagating the current metadata of the targets. This numeric indicates that the specified target has some metadata set that the client SHOULD request synchronization of at a later time.
+The client can use the `METADATA SYNC` command to request the synchronization of metadata for the given target. If the `<RetryAfter>` parameter of the numeric is nonzero, the client SHOULD wait at least that many seconds before sending the synchronization request.
 
-The client can use the [`SYNC`](#metadata-sync) subcommand to request the sync of metadata for the given target. If the `[<RetryAfter>]` is given, the client SHOULD wait at least that many seconds before sending the sync request.
+Clients SHOULD deduplicate `774 RPL_METADATASYNCLATER` numerics that they receive based on the numeric's target and only send one `METADATA SYNC` command for that target to the server after the `<RetryAfter>` waiting period.
 
-## METADATA server message
+*[[Begin non-normative examples--*
 
-Clients that request the `metadata` capability MUST be able to handle incoming `METADATA` messages. After negotiating this capability, servers MAY send this message to clients at any time.
+These examples assume the client has previously enabled the [no-implicit-names](../extensions/no-implicit-names.html) capability and has subscribed to the `display-name` metadata key for brevity.
 
-The format of the `METADATA` server message is:
+A metadata-aware client joins multiple channels and the server responds with `774 RPL_METADATASYNCLATER` to each of those joins with a target of `*`. The client deduplicates these and sends only one `METADATA * SYNC` after all channel joins are complete. This server implementation additionally responds with `766 RPL_KEYNOTSET` for subscribed keys that are not set on the target or are not visible to the user.
 
-    METADATA <Target> <Key> <Visibility> <Value>
+    C: JOIN #chan1,#chan2,#chan3,#chan4
+    S: :modernclient!modernclient@example.com JOIN #chan1
+    S: :irc.example.com 774 modernclient * 0 :Please synchronize metadata later
+    S: :modernclient!modernclient@example.com JOIN #chan2
+    S: :irc.example.com 774 modernclient * 0 :Please synchronize metadata later
+    S: :modernclient!modernclient@example.com JOIN #chan3
+    S: :irc.example.com 774 modernclient * 0 :Please synchronize metadata later
+    S: :modernclient!modernclient@example.com JOIN #chan4
+    S: :irc.example.com 774 modernclient * 0 :Please synchronize metadata later
+    C: METADATA * SYNC
+    S: BATCH +r2Nla metadata *
+    S: @batch=r2Nla :irc.example.com 761 modernclient #chan1 display-name * :channel 1️⃣
+    S: @batch=r2Nla :irc.example.com 761 modernclient #chan2 display-name * :channel 2️⃣
+    S: @batch=r2Nla :irc.example.com 766 modernclient #chan3 display-name :Key not set
+    S: @batch=r2Nla :irc.example.com 761 modernclient #chan4 display-name * :channel 4️⃣
+    S: @batch=r2Nla :irc.example.com 761 modernclient userA display-name * :A User
+    S: @batch=r2Nla :irc.example.com 766 modernclient userB display-name :Key not set
+    S: @batch=r2Nla :irc.example.com 761 modernclient userC display-name * :C User
+    ... and many more messages
+    S: BATCH -r2Nla
 
-`Target` is a valid nickname or channel name.
+A metdata-aware client joins a large channel and the server responds with `774 RPL_METADATASYNCLATER` with a defined delay. After the initial delay, the server is still not ready to process the command. This server implementation additionally omits subscribed keys that are not set on the target or are not visible to the user.
 
-`Key` is a valid key name
+    C: JOIN #bigchannel
+    S: :modernclient!modernclient@example.com JOIN #bigchannel
+    S: :irc.example.com 774 modernclient #bigchannel 4 :Please synchronize metadata later
+    -- 4 seconds later --
+    C: METADATA #bigchannel SYNC
+    S: :irc.example.com 774 modernclient #bigchannel 6 :Please synchronize metadata later
+    -- 6 more seconds later --
+    C: METADATA #bigchannel SYNC
+    S: BATCH +M40ad metadata #bigchannel
+    S: @batch=M40ad :irc.example.com 761 modernclient userA display-name * :A User
+    S: @batch=M40ad :irc.example.com 761 modernclient userC display-name * :C User
+    ... and many more messages
+    S: BATCH -M40ad
 
-`Visibility` is an asterisk (`*`) for keys visible to everyone, or an implementation-defined value which describes the key's visibility status; for instance, it MAY be a permission level or flag. (TODO should we define a prefix like STATUSMSG for this value?)
-
-`Value` is a UTF-8 encoded value.
+*--End non-normative examples]]*
 
 ## METADATA client command
 
@@ -175,224 +262,193 @@ The format of the `METADATA` server message is:
 
 Clients MAY use this command during connection registration if the server advertises the `before-connect` token. Clients that have not completed connection registration MUST use `*` to target themselves, since they have not been assigned a nickname, even if they sent a `NICK` command.
 
+If the server receives a syntactically invalid `METADATA` command, e.g., an unknown subcommand, missing parameters, or excess parameters, the server SHOULD reply with `FAIL METADATA INVALID_PARAMS`. If an existing error numeric such as `461 ERR_NEEDMOREPARAMS` is appropriate, it MAY be used instead.
+
+Servers MAY rate limit any `METADATA` subcommand. If they do so and a client is rate limited, servers SHOULD send `FAIL METADATA RATE_LIMITED` indicating the client SHOULD retry the `METADATA` request at a later time.
+
+*[[Begin non-normative examples--*
+
+    C: METADATA
+    S: FAIL METADATA INVALID_PARAMS * :Not enough parameters
+    C: METADATA #chan GET
+    S: FAIL METADATA INVALID_PARAMS GET :Not enough parameters
+    C: METADATA #chan SNEEZE
+    S: FAIL METADATA INVALID_PARAMS SNEEZE :Unknown subcommand "SNEEZE"
+    C: METADATA #chan :: hi!
+    S: FAIL METADATA INVALID_PARAMS * :Unknown subcommand ": hi!"
+
+*--End non-normative examples]]*
+
 ### METADATA GET
 
-    METADATA <Target> GET key1 key2 ...
+    METADATA <Target> GET <Key 1> [<Key 2> ... [<Key n>]]
 
-This subcommand lets clients lookup keys on the given target.
+This subcommand lets clients look up the specified keys on the given target. If the target is valid, the response will be a `metadata` batch containing one of the following responses for each key specified by the client:
 
-Multiple keys may be given.
+* `761 RPL_KEYVALUE` with the key's value
+* `766 RPL_KEYNOTSET` indicating the key is not set or the key is not visible to the requesting client
+* `WARN METADATA INVALID_KEY` indicating the key contains invalid characters or is otherwise considered invalid by the server
+* `WARN METADATA KEY_NO_PERMISSION` indicating the key is not visible to the requesting client
 
-The response will be a `metadata` batch containing:
+The ordering of responses within the batch MUST match the order keys were specified by the client. In the event that a key is not visible to the requesting client, the server MAY choose to send either `766 RPL_KEYNOTSET` or `WARN METADATA KEY_NO_PERMISSION`, but MUST NOT send both.
 
-* `RPL_KEYVALUE`
-* `RPL_KEYNOTSET`
-* `FAIL METADATA KEY_INVALID`
-
-for every key in order.
-
-Servers MAY replace metadata which is considered not visible for the requesting user, with `RPL_KEYNOTSET` or with `FAIL METADATA KEY_NO_PERMISSION`.
-
-*Failures*: `KEY_INVALID`, `KEY_NO_PERMISSION`
+If the target is not valid, the server MUST reply with `FAIL METADATA INVALID_TARGET` instead of a batch.
 
 ### METADATA LIST
 
     METADATA <Target> LIST
 
-This subcommand lists all of the target's currently-set metadata keys along with their values.
+This subcommand lists all of the target's currently-set metadata keys along with their values. If the target is valid, the response is a `metadata` batch containing `761 RPL_KEYVALUE` for all visible keys. Servers MAY additionally include information about keys that are not visible to the client by sending `WARN METADATA KEY_NO_PERMISSION` for such keys.
 
-If the target is valid, the response is a `metadata` batch containing zero or more `RPL_KEYVALUE` events.
-If the target is not valid, ONLY a `FAIL METADATA INVALID_TARGET` reply is sent.
-
-Servers MAY omit metadata which is considered not visible for the requesting user, or replace it with `FAIL METADATA KEY_NO_PERMISSION` within the batch.
-
-*Failures*: `FAIL METADATA KEY_NO_PERMISSION`.
+If the target is not valid, the server MUST reply with `FAIL METADATA INVALID_TARGET` instead of a batch.
 
 ### METADATA SET
 
-    METADATA <Target> SET <Key> [:Value]
+    METADATA <Target> SET <Key> [:<Value>]
 
-This subcommand sets the key on the target to the given value. If no value is given, the key is removed.
+This subcommand sets the key on the target to the given value. If the Value parameter is omitted or is an empty string, the key is removed. If the request is successful, the server carries out the requested change and responds with one `761 RPL_KEYVALUE` event, representing the new value if any, or `766 RPL_KEYNOTSET` if no value is set. This new value MAY differ from the one sent by the client.
 
-If the key is invalid, the server responsds with `FAIL METADATA KEY_INVALID` and fails the request.
+Otherwise, the server MUST send a `FAIL METADATA` response with an appropriate error message:
 
-If the key is valid, but not set, and the client tries to remove the key, the server responds with `FAIL METADATA KEY_NOT_SET` and fails the request.
+* `FAIL METADATA INVALID_TARGET` if the specified target is not valid
+* `FAIL METADATA INVALID_KEY` if the key contains invalid characters or is otherwise deemed invalid by the server
+* `FAIL METADATA KEY_NO_PERMISSION` if the client does not have permission to set keys on the specified target or is otherwise disallowed from setting or removing this key by the server
 
-If the user cannot set keys on the given target, the server responds with `FAIL METADATA KEY_NO_PERMISSION` and fails the request.
-
-Servers MAY respond to certain keys considered not settable by the requesting user, or otherwise disallowed by the server, with `FAIL METADATA KEY_NO_PERMISSION` and fail the request.
-
-Servers MAY respond with `FAIL METADATA RATE_LIMITED` and fail the request. When a client receives `FAIL METADATA RATE_LIMITED`, it SHOULD retry the `METADATA SET` request at a later time. If the `FAIL METADATA RATE_LIMITED` event contains the `<RetryAfter>` parameter, the parameter value MUST be a positive integer indicating the minimum number of seconds the client should wait before retrying the request.
-
-If the request is successful, the server carries out the requested change and responds with one `RPL_KEYVALUE` event, representing the new value if any, or `RPL_KEYNOTSET` if no value is set.
-This new value MAY differ from the one sent by the client.
-
-*Failures*: `FAIL METADATA LIMIT_REACHED`, `FAIL METADATA KEY_INVALID`, `FAIL METADATA KEY_NO_PERMISSION`, `FAIL METADATA RATE_LIMITED`, `FAIL METADATA KEY_NOT_SET`, `FAIL METADATA VALUE_INVALID`
+It is not an error if a client attempts to set a key to its current value or remove a nonexistent key; such attempts generate successful responses if there are no other issues with the request.
 
 ### METADATA CLEAR
 
     METADATA <Target> CLEAR
 
-This subcommand removes all metadata from the target, equivalently to using `METADATA SET` on all currently-set keys with no value.
+This subcommand removes all metadata from the target, equivalently to using `METADATA SET` on all currently-set keys with no value. If the user cannot clear keys on the given target, the server responds with `FAIL METADATA KEY_NO_PERMISSION` with an asterisk (`*`) in the `<Key>` field and fails the request.
 
-If the user cannot clear keys on the given target, the server responds with `FAIL METADATA KEY_NO_PERMISSION` with an asterisk (`*`) in the `<Key>` field and fails the request.
-
-Servers MAY omit certain keys which are considered not settable by the requesting user, or respond with `FAIL METADATA KEY_NO_PERMISSION` for each of those keys.
-
-If the request is successful, the server responds with a `metadata` batch containing one `RPL_KEYNOTSET` event per cleared key, and failure messages if any.
-
-*Failures*: `FAIL METADATA KEY_NO_PERMISSION`
+If the request is successful, the server responds with a `metadata` batch containing one `766 RPL_KEYNOTSET` message per cleared key. Servers MAY omit certain keys which are considered not settable by the requesting user or respond with `WARN METADATA KEY_NO_PERMISSION` for each of those keys.
 
 ### METADATA SUB
 
-    METADATA * SUB <key1> [<key2> ...]
+    METADATA <Target> SUB <Key 1> [<Key 2> ... [<Key n>]]
 
-This subcommand lets clients subscribe to updates for the given keys.
+This subcommand lets clients subscribe to updates for the given keys. If the `<Target>` parameter is not an asterisk (`*`) or the client's nickname, the server MUST fail the request with `FAIL METADATA INVALID_TARGET`. Otherwise, the server MUST process each key in order and clients SHOULD send keys in order of preference.
 
-The server MUST process each key in order, as the client uses this order to determine which keys they were and were not able to subscribe to. Clients SHOULD send keys in order of preference.
+The server responds with one or more of the following responses:
 
-The server processes each key in order, and:
+* `770 RPL_METADATASUBOK` for successful subscriptions or when the client is already subscribed to that key,
+* `WARN METADATA INVALID_KEY` for keys that contain invalid characters or are otherwise deemed as invalid by the server, or
+* `FAIL METADATA LIMIT_REACHED` if the client has reached the maximum allowable number of subscriptions. If the server sends this, it MUST stop processing any further keys. The `<Item>` parameter of the `FAIL METADATA LIMIT_REACHED` reply MUST be this first key that the client could not subscribe to (so the client knows all keys sent after that one were not processed).
 
-> If the client has subscribed to too many keys, the server does not process any further keys in the subcommand. The `<key>` parameter of the `FAIL METADATA TOO_MANY_SUBS` reply MUST be this first key that the client could not subscribe to (so the client knows all keys sent after that one were not processed).
->
-> If the client successfully subscribes to a key, or is already subscribed to a requested key, that key MUST appear in a `RPL_METADATASUBOK` reply numeric.
->
-> If the key's name is invalid, the server sends a `FAIL METADATA KEY_INVALID` reply to the client and continues processing keys.
->
-> If the client does not have permission to view a given key, the server sends a `FAIL METADATA KEY_NO_PERMISSION` reply to the client and continues processing keys. However, the subscription MUST still be successful, and that key MUST appear in a `RPL_METADATASUBOK` reply numeric. In this case, the `FAIL METADATA KEY_NO_PERMISSION` reply serves as a warning indicating that the client will not receive `METADATA` messages about this key unless it gains the necessary (implementation defined) privileges later.
+If the client does not have permission to view a given key, the server MAY send a `NOTE METADATA KEY_NO_PERMISSION` reply to the client. The subscription MUST still be successful and that key MUST appear in a `770 RPL_METADATASUBOK` reply. In this case, the `NOTE METADATA KEY_NO_PERMISSION` reply serves as a notice indicating that the client will not receive notifications about this key unless it gains the necessary (implementation-defined) privileges later.
 
-Once the server is finished processing keys, it responds with:
-* zero or more of this numeric in any order: `RPL_METADATASUBOK`,
-* zero or more of these standard reply codes: `FAIL METADATA KEY_INVALID`, `FAIL METADATA KEY_NO_PERMISSION`
-* and MAY respond with one `FAIL METADATA TOO_MANY_SUBS` reply.
+After finishing sending responses as described above, if the client has completed connection registration and has added new subscriptions, the server MUST then either send a `metadata` batch with `*ALL` as its parameter containing the current values of all newly-subscribed keys visible to the user for all visible targets or a `774 RPL_METADATASYNCLATER` message with `*ALL` as its `<Target>` to indicate [postponed synchronization](#postponed-synchronization). In the event that the client has also negotiated [`labeled-response`](../extensions/labeled-response.html), the `metadata` batch MUST be nested within the `labeled-response` batch.
+
+*[[Begin non-normative example--*
+
+The client is joined to #chan (sharing the channel with userA, userB, and userC) and additionally has userD on their `MONITOR` list, who is currently online. The server is configured to allow a maximum of 3 subscriptions (advertising `max-subs=3` in the `draft/metadata-2` CAP value).
+
+    C: METADATA * SUB display-name status super-secret-key avatar
+    S: :irc.example.com 770 modernclient display-name status super-secret-key
+    S: :irc.example.com NOTE METADATA KEY_NO_PERMISSION SUB * super-secret-key :You do not have permission to view this key
+    S: :irc.example.com WARN METADATA LIMIT_REACHED SUB avatar 3 :Cannot subscribe to "avatar" as you have reached the subscription limit
+    S: :irc.example.com BATCH +d8amD metadata *
+    S: @batch=d8amD :irc.example.com 761 modernclient #chan display-name :Cool Channel
+    S: @batch=d8amD :irc.example.com 761 modernclient userA display-name :User A
+    S: @batch=d8amD :irc.example.com 761 modernclient userA status :Playing games
+    S: @batch=d8amD :irc.example.com 761 modernclient userD display-name :User D
+    S: :irc.example.com BATCH -d8amD
+
+*--End non-normative example]]*
 
 ### METADATA UNSUB
 
-    METADATA * UNSUB <key1> [<key2> ...]
+    METADATA <Target> UNSUB <Key 1> [<Key 2> ... [<Key n>]]
 
-This subcommand lets clients unsubscribe from updates for the given keys.
+This subcommand lets clients remove their subscriptions of the given keys. If the `<Target>` parameter is not an asterisk (`*`) or the client's nickname, the server MUST fail the request with `FAIL METADATA INVALID_TARGET`. Otherwise, the server MUST process each key in order and clients SHOULD send keys in order of preference.
 
 Servers process the given keys, and:
 
-> If the client successfully unsubscribes from a key, or is not subscribed to a requested key, that key MUST appear in a `RPL_METADATAUNSUBOK` reply numeric.
->
-> If the key's name is invalid, the server sends a `FAIL METADATA KEY_INVALID` reply to the client and continues processing keys.
+The server responds with one of the following responses for each key:
 
-Once the server is finished processing keys, it responds with:
-* zero or more of this numeric in any order: `RPL_METADATAUNSUBOK`
-* zero of more of this standard reply: `FAIL METADATA KEY_INVALID`
+* `771 RPL_METADATAUNSUBOK` for successful removal of subscriptions or when the client is not subscribed to that key, or
+* `WARN METADATA INVALID_KEY` for keys that contain invalid characters or are otherwise deemed as invalid by the server.
 
 ### METADATA SUBS
 
-    METADATA * SUBS
+    METADATA <Target> SUBS
 
-This subcommand returns which keys the client is currently subscribed to.
+This subcommand returns which keys the client is currently subscribed to. If the `<Target>` parameter is not an asterisk (`*`) or the client's nickname, the server MUST fail the request with `FAIL METADATA INVALID_TARGET`.
 
-The server responds with a `metadata-subs` batch containing zero or more `RPL_METADATASUBS` numerics. The server MAY return the keys in any order. The server MUST NOT list the same key multiple times in a response to this subcommand.
+The server responds with a `metadata-subs` batch containing zero or more `772 RPL_METADATASUBS` messages. The server MAY return the keys in any order. The server MUST NOT list the same key multiple times in a response to this subcommand.
+
+If the client does not have permission to view a given subscribed key, the server MAY additionally send a `NOTE METADATA KEY_NO_PERMISSION` reply to the client within the `metadata-subs` batch for that key. This reply serves as a notice indicating that the client will not receive notifications about this key unless it gains the necessary (implementation-defined) privileges later.
 
 ### METADATA SYNC
 
     METADATA <Target> SYNC
 
-Clients use this subcommand to receive all subscribed metadata from the given target. If the target is a channel, it also syncs the metadata for all other users in that channel.
+Clients use this subcommand to receive all subscribed metadata from the given target. If the target is a channel, it also synchronizes the metadata for all other users in that channel. If the target is an asterisk followed by uppercase "ALL" (`*ALL`), it synchronizes metadata for all visible targets.
 
-If the sync cannot be performed at this time (due to load or other implementation-defined details), the server responds with a `RPL_METADATASYNCLATER`. If the sync can be performed, the server responds with a `metadata` batch containing zero or more METADATA events.
+If the sync cannot be performed at this time (due to load or other implementation-defined details), the server responds with a `774 RPL_METADATASYNCLATER` indicating [postponed synchronization](#postponed-synchronization). If the sync can be performed, the server responds with a `metadata` batch containing zero or more of the following messages for each key the client is subscribed to:
 
-For details, please see the [postponed synchronization](#postponed-synchronization) section.
+* `761 RPL_KEYVALUE` with the key's value
+* `766 RPL_KEYNOTSET` indicating the key is not set or the key is not visible to the requesting client
+* `WARN METADATA KEY_NO_PERMISSION` indicating the key is not visible to the requesting client
 
-## Standard Replies
+In the event that a key is not visible to the requesting client, the server MAY choose to send either `766 RPL_KEYNOTSET` or `WARN METADATA KEY_NO_PERMISSION`, or it MAY omit the key entirely from the batch, but it MUST NOT send both.
 
-The following Standard Replies codes are defined with these parameters:
+The batch MAY additionally contain messages for keys that the client is not subscribed to.
 
-| Code                    | Parameters                               |
-| ----------------------- | ---------------------------------------- |
-| `INVALID_TARGET`        | `<Target> :invalid metadata target`      |
-| `KEY_INVALID`           | `<InvalidKey> :invalid key`              |
-| `SUBCOMMAND_INVALID`    | `<SubCommand> :invalid subcommand`       |
-| `KEY_NO_PERMISSION`     | `<Target> <Key> :permission denied`      |
-| `KEY_NOT_SET`           | `<Target> <Key> :key not set`            |
-| `LIMIT_REACHED`         | `<Target> :metadata limit reached`       |
-| `RATE_LIMITED`          | `<Target> <Key> <RetryAfter> :too many changes`  |
-| `TOO_MANY_SUBS`         | `<Key> :too many subscriptions`          |
-| `VALUE_INVALID`         | `:value is too long or not UTF8`         |
+## Client implementation considerations
 
+*This section is non-normative.*
 
-Reference table of Standard Replies codes and the `METADATA` subcommands or any other commands that produce them:
+While this is true of any batch, clients should take particular care not to pause processing of other messages while a `metadata` batch is open. As these batches can be potentially large, servers are likely to produce them asynchronously in order to avoid freezing delivery of more important messages or filling up a client's send queue.
 
-| Code                     | GET | LIST | SET | CLEAR | SUB | UNSUB | SUBS | SYNC | Other   |
-| ---    | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: |
-| `INVALID_TARGET`         | *   | *    | *   | *     | *   | *     | *    | *    |         |
-| `KEY_INVALID`            | *   |      | *   |       | *   | *     |      |      |         |
-| `VALUE_INVALID`          |     |      | *   |       |     |       |      |      |         |
-| `SUBCOMMAND_INVALID`     |     |      |     |       |     |       |      |      | *       |
-| `KEY_NO_PERMISSION`      | *   | *    | *   |       | *   | *     |      |      |         |
-| `KEY_NOT_SET`            |     |      | *   |       |     |       |      |      |         |
-| `LIMIT_REACHED`          |     |      | *   |       |     |       |      |      |         |
-| `RATE_LIMITED`           |     |      | *   |       |     |       |      |      |         |
-| `TOO_MANY_SUBS`          |     |      |     |       | *   |       |      |      |         |
+As servers may rewrite values set by clients with `METADATA SET`, clients should check the response before storing it in any local cache.
 
-Each subcommand section describes the reply and error numerics it expects from the server, but here are brief descriptions of numerics that are used for multiple subcommands:
+Because servers may choose to omit unset keys or keys that are not visible to the client from `metadata` batches, clients should assume that any subscribed keys missing from a `METADATA SYNC` have been unset in the interim and update local caches accordingly.
 
-### Examples
+Avoid sending more than 12 keys with `METADATA GET`, `METADATA SUB`, or `METADATA UNSUB` unless you know the server is capable of handling more parameters. Old RFCs limited the number of parameters in an IRC message to 15, and some server implementations treat the command itself towards that parameter limit.
 
-* `FAIL METADATA TARGET_INVALID ExampleUser!lol :Invalid target.` when a client refers to an invalid target.
-* `FAIL METADATA KEY_INVALID %key% :That is not a valid key.` when a client refers to an invalid key.
-* `FAIL METADATA KEY_NO_PERMISSION %target% %key% :You do not have permission to set %key% on %target%` when a client attempts to access or set a key on a target when they lack sufficient permission.
-* `FAIL METADATA SUBCOMMAND_INVALID destr0y :Invalid subcommand.` when a client calls a `METADATA` subcommand which is not defined.
+## Server implementation considerations
 
-## Numerics
+*This section is non-normative.*
 
-The following numerics 760 through 775 are reserved for metadata, with these labels and parameters:
+Servers with traditional send queue setups should ensure that they do not disconnect clients requesting large `metadata` batches, such as by producing the batch asynchronously. In cases where such a process is not feasible (such as most automatic synchronization batches), they should make use of postponed synchronization when the amount of metadata to send is too large (by whatever server-specific metric is chosen).
 
-| No. | Label                     | Parameters                               |
-| --- | ------------------------- | ---------------------------------------- |
-| 760 | `RPL_WHOISKEYVALUE`       | `<Target> <Key> <Visibility> :<Value>`   |
-| 761 | `RPL_KEYVALUE`            | `<Target> <Key> <Visibility> :<Value>` |
-| 766 | `RPL_KEYNOTSET`           | `<Target> <Key> :key not set`            |
-| 770 | `RPL_METADATASUBOK`       | `<Key1> [<Key2> ...]`                   |
-| 771 | `RPL_METADATAUNSUBOK`     | `<Key1> [<Key2> ...]`                   |
-| 772 | `RPL_METADATASUBS`        | `<Key1> [<Key2> ...]`                   |
-| 774 | `RPL_METADATASYNCLATER`   | `<Target> [<RetryAfter>]`                |
+Servers may wish to provide network administrators the ability to configure an allowlist or denylist of metadata keys. They may also wish to reserve certain keys or patterns of keys as requiring elevated permissions to view or modify, to allow network administrators the ability to use `METADATA` as a secure key:value store for network operations or to ensure certain keys are only writable by services.
+
+When responding with `FAIL METADATA RATE_LIMITED` or `774 RPL_METADATASYNCLATER`, servers should attempt to provide a usable value for the `<RetryAfter>` parameter, to avoid clients flooding the server with retries. A server is not required to accept the command after the provided RetryAfter period and may still rate-limit the client at that time. This provides a middle ground for servers that do not wish to publish precise rate-limit details to clients while ensuring clients do not attempt to retry commands too aggressively.
+
+## Reference tables
 
 Reference table of numerics and the `METADATA` subcommands or any other commands that produce them:
 
-| Label                              | GET | LIST | SET | CLEAR | SUB | UNSUB | SUBS | SYNC | Other   |
-| ---    | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: | :-: |
-| `RPL_WHOISKEYVALUE`                |     |      |     |       |     |       |      |      | `WHOIS` |
-| `RPL_KEYVALUE`                     | *   | *    | *   | *     |     |       |      |      |         |
-| `RPL_KEYNOTSET`                    | *   |      |     |       |     |       |      |      |         |
-| `RPL_METADATASUBOK`                |     |      |     |       | *   |       |      |      |         |
-| `RPL_METADATAUNSUBOK`              |     |      |     |       |     | *     |      |      |         |
-| `RPL_METADATASUBS`                 |     |      |     |       |     |       | *    |      |         |
-| `RPL_METADATASYNCLATER`            |     |      |     |       | *   |       |      | *    | `JOIN`  |
+| Label                              | GET | LIST | SET | CLEAR | SUB | UNSUB | SUBS | SYNC | Other             |
+| ---------------------------------- | :-: | :--: | :-: | :---: | :-: | :---: | :--: | :--: | :---------------: |
+| `RPL_WHOISKEYVALUE`                |     |      |     |       |     |       |      |      | `WHOIS`           |
+| `RPL_KEYVALUE`                     | *   | *    | *   |       | *   |       |      | *    |                   |
+| `RPL_KEYNOTSET`                    | *   |      | *   | *     | *   |       |      | *    |                   |
+| `RPL_METADATASUBOK`                |     |      |     |       | *   |       |      |      |                   |
+| `RPL_METADATAUNSUBOK`              |     |      |     |       |     | *     |      |      |                   |
+| `RPL_METADATASUBS`                 |     |      |     |       |     |       | *    |      |                   |
+| `RPL_METADATASYNCLATER`            |     |      |     |       | *   |       |      | *    | `JOIN`, `MONITOR` |
 
-Replies:
+Reference table of Standard Replies codes and the `METADATA` subcommands or any other commands that produce them:
 
-* `RPL_KEYVALUE` reports the values of metadata keys. The `Visibility` parameter is defined in the [server message](#metadata-server-message) section.
-
-### `RPL_WHOISKEYVALUE` numeric
-
-When a user with the capability enabled runs `WHOIS` on a user with metadata set, a subset of that metadata MAY be sent with `RPL_WHOISKEYVALUE` numerics.
+| Code                    | GET  | LIST | SET       | CLEAR | SUB  | UNSUB | SUBS | SYNC | Other   |
+| ----------------------- | :--: | :--: | :-------: | :---: | :--: | :---: | :--: | :--: | :-----: |
+| `INVALID_KEY`           | WARN |      | FAIL      |       | WARN | WARN  |      |      |         |
+| `INVALID_PARAMS`        | FAIL | FAIL | FAIL      | FAIL  | FAIL | FAIL  | FAIL | FAIL | FAIL    |
+| `INVALID_TARGET`        | FAIL | FAIL | FAIL      | FAIL  | FAIL | FAIL  | FAIL | FAIL |         |
+| `INVALID_VALUE`         |      |      | FAIL      |       |      |       |      |      |         |
+| `KEY_NO_PERMISSION`     | WARN | WARN | FAIL/WARN | WARN  | NOTE |       | NOTE | WARN |         |
+| `LIMIT_REACHED`         |      |      | FAIL      |       | FAIL |       |      |      |         |
+| `RATE_LIMITED`          | FAIL | FAIL | FAIL      | FAIL  | FAIL | FAIL  | FAIL | FAIL | FAIL    |
 
 ## Examples
 
+*This section and all of its sub-sections are non-normative.*
+
 All examples begin with the client not being subscribed to any keys.
-
------
-
-### Capability Examples
-
-#### Capability value in `CAP LS` 1 
-
-    C: CAP LS 302
-    S: CAP * LS :userhost-in-names draft/metadata-2=foo,max-subs=50,bar multi-prefix
-
-#### Capability value in `CAP LS` 2
-
-    C: CAP LS 302
-    S: CAP * LS :draft/metadata-2=max-subs=25 multi-prefix invite-notify
-
------
 
 ### METADATA command examples
 
@@ -404,7 +460,7 @@ All examples begin with the client not being subscribed to any keys.
 #### Setting metadata on self, but the limit has been reached
 
     C: METADATA * SET url :http://www.example.com
-    S: FAIL METADATA LIMIT_REACHED :Metadata limit reached
+    S: FAIL METADATA LIMIT_REACHED 50 :Metadata limit reached
 
 #### Setting metadata on another user, without permission
 
@@ -424,35 +480,26 @@ All examples begin with the client not being subscribed to any keys.
 #### Setting metadata with an invalid key
 
     C: METADATA user1 SET $url$ :http://www.example.com
-    S: FAIL METADATA KEY_INVALID $url$ :Invalid key.
+    S: FAIL METADATA INVALID_KEY $url$ :Invalid key.
 
-#### Server rate-limits setting metadata and provides a RetryAfter value
+#### Server rate-limits setting metadata
 
     C: METADATA * SET url :http://www.example.com
     S: FAIL METADATA RATE_LIMITED * url 5 :Rate-limit reached. You're going too fast! Try again in 5 seconds.
 
-#### Server rate-limits setting metadata with no RetryAfter value
-
-    C: METADATA * SET url :http://www.example.com
-    S: FAIL METADATA RATE_LIMITED * url * :Rate-limit reached. You're going too fast!
-    
-Thought: A non-normative retry value helps against automated spam while still being descriptive for the end-user.
+Servers can pick an arbitrary value here, if a client waits that long there is no guarantee the next attempt will not also be rate-limited.
 
 -----
 
-### METADATA message examples
+### Notification examples
 
-#### External server sets metadata on a user
+#### Metadata was set on a user
 
-    S: :irc.example.com METADATA user1 account * :user1
+    S: :irc.example.com 761 client user1 account * :user1
 
-#### User sets metadata on a channel
+### Metadata was set on a channel
 
-    S: :user1!~user@somewhere.example.com METADATA #example url * :http://www.example.com
-
-### External server updates metadata on a channel
-
-    S: :irc.example.com METADATA #example wiki-url * :http://wiki.example.com
+    S: :irc.example.com 761 client #example wiki-url * :http://wiki.example.com
 
 -----
 
@@ -471,8 +518,8 @@ Thought: A non-normative retry value helps against automated spam while still be
 
     C: METADATA user1 GET blargh splot im.xmpp
     S: :irc.example.com BATCH +gWkCiV metadata
-    S: @batch=gWkCiV 766 client user1 blargh :No matching key
-    S: @batch=gWkCiV 766 client user1 splot :No matching key
+    S: @batch=gWkCiV :irc.example.com 766 client user1 blargh :No matching key
+    S: @batch=gWkCiV :irc.example.com 766 client user1 splot :No matching key
     S: @batch=gWkCiV :irc.example.com 761 client user1 im.xmpp * :user1@xmpp.example.com
     S: :irc.example.com BATCH -gWkCiV
 
@@ -486,16 +533,14 @@ Thought: A non-normative retry value helps against automated spam while still be
     S: :irc.example.com 353 modernclient @ #smallchan :user151 user152 user153 user154 ...
     S: :irc.example.com 366 modernclient #smallchan :End of /NAMES list.
     S: :irc.example.com BATCH +UwZ67M metadata
-    S: @batch=UwZ67M :irc.example.com METADATA user2 bar * :second example value 
-    S: @batch=UwZ67M :irc.example.com METADATA user1 foo * :third example value
-    S: @batch=UwZ67M :irc.example.com METADATA user1 bar * :this is another example value
-    S: @batch=UwZ67M :irc.example.com METADATA user3 website * :www.example.com
+    S: @batch=UwZ67M :irc.example.com 761 modernclient user2 bar * :second example value 
+    S: @batch=UwZ67M :irc.example.com 761 modernclient user1 foo * :third example value
+    S: @batch=UwZ67M :irc.example.com 761 modernclient user1 bar * :this is another example value
+    S: @batch=UwZ67M :irc.example.com 761 modernclient user3 website * :www.example.com
     ...and some more metadata messages
     S: :irc.example.com BATCH -UwZ67M
 
 #### Client joins a channel and but needs to sync metadata later
-
-To-do: Think of a better sync-later flow
 
 Client joins channel:
 
@@ -506,24 +551,24 @@ Client joins channel:
     S: :irc.example.com 353 modernclient @ #bigchan :user101 user102 user103 user104 ...
     S: :irc.example.com 353 modernclient @ #bigchan :user151 user152 user153 user154 ...
     S: :irc.example.com 366 modernclient #bigchan :End of /NAMES list.
-    S: :irc.example.com 774 modernclient #bigchan 4
+    S: :irc.example.com 774 modernclient #bigchan 4 :Please try SYNC again in 4 seconds.
 
 Client waits 4 seconds:
 
     C: METADATA #bigchan SYNC
-    S: :irc.example.com 774 modernclient #bigchan 6
+    S: :irc.example.com 774 modernclient #bigchan 6 :Please try SYNC again in 6 seconds.
 
 Client waits 6 more seconds:
 
     C: METADATA #bigchan SYNC
     S: :irc.example.com BATCH +O5J6rk metadata
-    S: @batch=O5J6rk :irc.example.com METADATA user52 foo * :example value 1
-    S: @batch=O5J6rk :irc.example.com METADATA user2 bar * :second example value 
-    S: @batch=O5J6rk :irc.example.com METADATA user1 foo * :third example value
-    S: @batch=O5J6rk :irc.example.com METADATA user1 bar * :this is another example value
-    S: @batch=O5J6rk :irc.example.com METADATA user152 baz * :Lorem ipsum
-    S: @batch=O5J6rk :irc.example.com METADATA user3 website * :www.example.com
-    S: @batch=O5J6rk :irc.example.com METADATA user152 bar * :dolor sit amet
+    S: @batch=O5J6rk :irc.example.com 761 modernclient user52 foo * :example value 1
+    S: @batch=O5J6rk :irc.example.com 761 modernclient user2 bar * :second example value 
+    S: @batch=O5J6rk :irc.example.com 761 modernclient user1 foo * :third example value
+    S: @batch=O5J6rk :irc.example.com 761 modernclient user1 bar * :this is another example value
+    S: @batch=O5J6rk :irc.example.com 761 modernclient user152 baz * :Lorem ipsum
+    S: @batch=O5J6rk :irc.example.com 761 modernclient user3 website * :www.example.com
+    S: @batch=O5J6rk :irc.example.com 761 modernclient user152 bar * :dolor sit amet
     ...and many more metadata messages
     S: :irc.example.com BATCH -O5J6rk
 
@@ -531,10 +576,15 @@ Client waits 6 more seconds:
 
 ### Subscription Examples
 
+Most replies to `METADATA SUB` in these examples send `774 RPL_METADATASYNCLATER` for brevity. A real implementation may wish to more eagerly send `metadata` batches in response to `METADATA SUB`.
+
 #### Basic subscriping and unsubscribing
 
     C: METADATA * SUB avatar website foo bar
     S: :irc.example.com 770 modernclient avatar website foo bar
+    S: :irc.example.com BATCH +vla9D metadata *ALL
+    ...metadata messages for avatar/website/foo/bar for all visible targets
+    S: :irc.exmaple.com BATCH -vla9D
     C: METADATA * UNSUB foo bar
     S: :irc.example.com 771 modernclient bar foo
 
@@ -544,12 +594,14 @@ Client waits 6 more seconds:
     S: :irc.example.com 770 modernclient avatar website
     S: :irc.example.com 770 modernclient foo
     S: :irc.example.com 770 modernclient bar baz
+    S: :irc.example.com 774 modernclient *ALL 5 :Please run SYNC later
 
 #### Invalid key name in reply to subscription
 
     C: METADATA * SUB foo $url bar
     S: :irc.example.com 770 modernclient foo bar
-    S: FAIL METADATA KEY_INVALID $url :Invalid key
+    S: WARN METADATA INVALID_KEY $url :Invalid key
+    S: :irc.example.com 774 modernclient *ALL 5 :Please run SYNC later
 
 #### "Subscribed to too many keys" error in reply to subscription 1
 
@@ -557,10 +609,14 @@ The client first successfully subscribes to some keys and later it tries to subs
 
     C: METADATA * SUB website avatar foo bar baz
     S: :irc.example.com 770 modernclient website avatar foo bar baz
+    S: :irc.example.com 774 modernclient *ALL 5 :Please run SYNC later
     C: METADATA * SUB email city
-    S: FAIL METADATA TOO_MANY_SUBS email :Too many subscriptions!
+    S: FAIL METADATA LIMIT_REACHED email 5 :Too many subscriptions!
+    S: :irc.example.com 774 modernclient *ALL 5 :Please run SYNC later
     C: METADATA * SUBS
-    S: :irc.example.com 770 modernclient website avatar foo bar baz
+    S: :irc.example.com BATCH +c2LO6 metadata-subs
+    S: @batch=c2LO6 :irc.example.com 772 modernclient website avatar foo bar baz
+    S: :irc.example.com BATCH -c2LO6
 
 #### "Subscribed to too many keys" error in reply to subscription 2
 
@@ -569,10 +625,13 @@ This is like the previous case, except when the second METADATA SUB happens the 
     C: METADATA * SUB website avatar foo
     S: :irc.example.com 770 modernclient website avatar foo
     C: METADATA * SUB email city country bar baz
-    S: FAIL METADATA TOO_MANY_SUBS country :Too many subscriptions!
+    S: FAIL METADATA LIMIT_REACHED country 5 :Too many subscriptions!
     S: :irc.example.com 770 modernclient email city
+    S: :irc.example.com 774 modernclient *ALL 5 :Please run SYNC later
     C: METADATA * SUBS
-    S: :irc.example.com 770 modernclient website avatar city foo email
+    S: :irc.example.com BATCH +mda82 metadata-subs
+    S: @batch=mda82 :irc.example.com 772 modernclient website avatar city foo email
+    S: :irc.example.com BATCH -mda82
 
 #### "Subscribed to too many keys" error in reply to subscription 3
 
@@ -581,65 +640,90 @@ The client, however, successfully subscribes to the `foo` key which was also in 
 
     C: METADATA * SUB avatar website
     S: :irc.example.com 770 modernclient avatar website
+    S: :irc.example.com 774 modernclient *ALL 5 :Please run SYNC later
     C: METADATA * SUB foo website avatar
-    S: FAIL METADATA TOO_MANY_SUBS website :Too many subscriptions!
+    S: FAIL METADATA LIMIT_REACHED website 3 :Too many subscriptions!
     S: :irc.example.com 770 modernclient :foo
+    S: :irc.example.com 774 modernclient *ALL 5 :Please run SYNC later
     C: METADATA * SUBS
-    S: :irc.example.com 772 modernclient avatar foo website
+    S: :irc.example.com BATCH +DMa04 metadata-subs
+    S: @batch=DMa04 :irc.example.com 772 modernclient avatar foo website
+    S: :irc.example.com BATCH -DMa04
 
 #### Querying the list of subscribed keys 1
 
-The server replies with a single `RPL_METADATASUBS` (`772`) numeric.
+The server replies with a single `772 RPL_METADATASUBS` numeric.
 
     C: METADATA * SUB website avatar foo bar baz
     S: :irc.example.com 770 modernclient website avatar foo bar baz
+    S: :irc.example.com 774 modernclient *ALL 5 :Please run SYNC later
     C: METADATA * SUBS
-    S: :irc.example.com 772 modernclient avatar bar baz foo website
+    S: :irc.example.com BATCH +TACM1 metadata-subs
+    S: @batch=TACM1 :irc.example.com 772 modernclient avatar bar baz foo website
+    S: :irc.example.com BATCH -TACM1
 
 #### Querying the list of subscribed keys 2
 
-The server replies with multiple `RPL_METADATASUBS` (`772`) numerics.
+The server replies with multiple `772 RPL_METADATASUBS` numerics.
 
     C: METADATA * SUB website avatar foo bar baz
     S: :irc.example.com 770 modernclient website avatar foo bar baz
+    S: :irc.example.com 774 modernclient *ALL 5 :Please run SYNC later
     C: METADATA * SUBS
-    S: :irc.example.com 772 modernclient avatar
-    S: :irc.example.com 772 modernclient bar baz
-    S: :irc.example.com 772 modernclient foo website
+    S: :irc.example.com BATCH +B089a metadata-subs
+    S: @batch=B089a :irc.example.com 772 modernclient avatar
+    S: @batch=B089a :irc.example.com 772 modernclient bar baz
+    S: @batch=B089a :irc.example.com 772 modernclient foo website
+    S: :irc.example.com BATCH -B089a
 
 #### Empty list of subscribed keys
 
-In this case, there are no `RPL_METADATASUB` numerics sent.
+In this case, there are no `772 RPL_METADATASUBS` numerics sent.
 
     C: METADATA * SUBS
-    S: *no replies*
+    S: :irc.example.com BATCH +fad02 metadata-subs
+    S: :irc.example.com BATCH -fad02
 
 #### Unsubscribing
 
     C: METADATA * SUB website avatar foo bar baz
     S: :irc.example.com 770 modernclient website avatar foo bar baz
+    S: :irc.example.com 774 modernclient *ALL 5 :Please run SYNC later
     C: METADATA * SUBS
-    S: :irc.example.com 772 modernclient avatar bar baz foo website
+    S: :irc.example.com BATCH +5r8af metadata-subs
+    S: @batch=5r8af :irc.example.com 772 modernclient avatar bar baz foo website
+    S: :irc.example.com BATCH -5r8af
     C: METADATA * UNSUB bar foo baz
     S: :irc.example.com 771 modernclient baz foo bar
     C: METADATA * SUBS
-    S: :irc.example.com 772 modernclient avatar website
+    S: :irc.example.com BATCH +b05mn metadata-subs
+    S: @batch=b05mn :irc.example.com 772 modernclient avatar website
+    S: :irc.example.com BATCH -b05mn
 
 #### Subscribing to the same key multiple times 1
 
+No `metadata` batch or `774 RPL_METADATASYNCLATER` response is given to the second `METADATA SUB` because no new keys were subscribed to.
+
     C: METADATA * SUB website avatar foo bar baz
     S: :irc.example.com 779 modernclient website avatar foo bar baz
+    S: :irc.example.com BATCH +bv48i metadata *ALL
+    S: ...metadata messages for website/avatar/foo/bar/baz for all visible targets
+    S: :irc.example.com BATCH -bv48i
     C: METADATA * SUBS
-    S: :irc.example.com 772 modernclient avatar bar baz foo website
+    S: :irc.example.com BATCH +mz7qq metadata-subs
+    S: @batch=mz7qq :irc.example.com 772 modernclient avatar bar baz foo website
+    S: :irc.example.com BATCH -mz7qq
     C: METADATA * SUB avatar website
     S: :irc.example.com 770 modernclient avatar website
     C: METADATA * SUBS
-    S: :irc.example.com 772 modernclient avatar bar baz foo website
+    S: :irc.example.com BATCH +1mM45 metadata-subs
+    S: @batch=1mM45 :irc.example.com 772 modernclient avatar bar baz foo website
+    S: :irc.example.com BATCH -1mM45
 
 #### Subscribing to the same key multiple times 2
 
 The client (erroneously) subscribes to the same key twice in the same command.
-The server is free to include the key being subscribed to in the `RPL_METADATASUBOK` (`770`) numeric once or twice.
+The server is free to include the key being subscribed to in the `770 RPL_METADATASUBOK` numeric once or twice.
 
 In both cases, the key will only appear once in the reply to a following `METADATA SUBS` command.
 
@@ -647,68 +731,96 @@ Once:
 
     C: METADATA * SUB avatar avatar
     S: :irc.example.com 770 modernclient avatar
+    S: :irc.example.com 774 modernclient *ALL 5 :Please run SYNC later
     C: METADATA * SUBS
-    S: :irc.example.com 772 modernclient avatar
+    S: :irc.example.com BATCH +MC02d metadata-subs
+    S: @batch=MC02d :irc.example.com 772 modernclient avatar
+    S: :irc.example.com BATCH -MC02d
 
 Twice:
 
     C: METADATA * SUB avatar avatar
     S: :irc.example.com 770 modernclient avatar avatar
+    S: :irc.example.com 774 modernclient *ALL 5 :Please run SYNC later
     C: METADATA * SUBS
-    S: :irc.example.com 772 modernclient avatar
+    S: :irc.example.com BATCH +MC02d metadata-subs
+    S: @batch=MC02d :irc.example.com 772 modernclient avatar
+    S: :irc.example.com BATCH -MC02d
 
 #### Unsubscribing from a non-subscribed key 1
 
     C: METADATA * SUBS
+    S: :irc.example.com BATCH +mjay4 metadata-subs
+    S: :irc.example.com BATCH -mjay4
     C: METADATA * UNSUB website
     S: :irc.example.com 771 modernclient website
     C: METADATA * SUBS
+    S: :irc.example.com BATCH +a2OWA metadata-subs
+    S: :irc.example.com BATCH -a2OWA
     C: METADATA * SUB website
     S: :irc.example.com 771 modernclient website
+    S: :irc.example.com 774 modernclient *ALL 5 :Please run SYNC later
     C: METADATA * SUBS
-    S: :irc.example.com 772 modernclient website
+    S: :irc.example.com BATCH +rbqDZ metadata-subs
+    S: @batch=rbqDZ :irc.example.com 772 modernclient website
+    S: :irc.example.com BATCH -rbqDZ
 
 #### Unsubscribing from a non-subscribed key 2
 
 The client (erroneously) unsubscribes from the same key twice in the same command.
-The server is free to include the key being unsubscribed from in the `RPL_METADATAUNSUBOK` numeric once or twice.
+The server is free to include the key being unsubscribed from in the `771 RPL_METADATAUNSUBOK` numeric once or twice.
 
 Once:
 
     C: METADATA * SUBS
-    S: :irc.example.com 772 modernclient website
+    S: :irc.example.com BATCH +byuvs metadata-subs
+    S: @batch=byuvs :irc.example.com 772 modernclient website
+    S: :irc.example.com BATCH -byuvs
     C: METADATA * UNSUB website website
     S: :irc.example.com 772 modernclient website
 
 Twice:
 
     C: METADATA * SUBS
-    S: :irc.example.com 772 modernclient website
+    S: :irc.example.com BATCH +byuvs metadata-subs
+    S: @batch=byuvs :irc.example.com 772 modernclient website
+    S: :irc.example.com BATCH -byuvs
     C: METADATA * UNSUB website website
     S: :irc.example.com 771 modernclient website website
 
 #### Subscribing to a key which requires privileges but without privileges
 
     C: METADATA * SUB avatar secretkey website
-    S: FAIL METADATA KEY_NO_PERMISSION modernclient secretkey :You do not have permission to do that.
+    S: NOTE METADATA KEY_NO_PERMISSION modernclient secretkey :You do not have permission to do that.
     S: :irc.example.com 770 modernclient avatar website
+    S: :irc.example.com 774 modernclient *ALL 5 :Please run SYNC later
     C: METADATA * SUBS
-    S: :irc.example.com 772 modernclient avatar website
+    S: :irc.example.com BATCH +ra20D metadata-subs
+    S: @batch=ra20D :irc.example.com 772 modernclient avatar website
+    S: :irc.example.com BATCH -ra20D
 
-#### Subscribing to invalid keys and a key which requires privileges but without privileges
+#### Subscribing to invalid keys and keys which requires privileges but without privileges
 
-    C: METADATA * SUB $invalid1 secretkey1 $invalid2 secretkey2 website
-    S: FAIL METADATA KEY_NO_PERMISSION modernclient secretkey1 :You do not have permission to do that.
-    S: FAIL METADATA KEY_INVALID $invalid1 :Invalid key
-    S: FAIL METADATA KEY_NO_PERMISSION modernclient secretkey2 :You do not have permission to do that.
-    S: FAIL METADATA KEY_INVALID $invalid2 :Invalid key
-    S: :irc.example.com 770 modernclient website
+Because the client does not have permission to view any of the newly-added keys, the resultant `metadata` batch is empty.
+
+    C: METADATA * SUB $invalid1 secretkey1 $invalid2 secretkey2
+    S: NOTE METADATA KEY_NO_PERMISSION modernclient secretkey1 :You do not have permission to do that.
+    S: WARN METADATA INVALID_KEY $invalid1 :Invalid key
+    S: NOTE METADATA KEY_NO_PERMISSION modernclient secretkey2 :You do not have permission to do that.
+    S: WARN METADATA INVALID_KEY $invalid2 :Invalid key
+    S: :irc.example.com 770 modernclient secretkey1 secretkey2
+    S: :irc.example.com BATCH +nEOfT metadata *ALL
+    S: :irc.example.com BATCH -nEOfT
     C: METADATA * SUBS
-    S: :irc.example.com 772 modernclient website
+    S: :irc.example.com BATCH +RInLU metadata-subs
+    S: @batch=RInLU :irc.example.com 772 modernclient secretkey1 secretkey2
+    S: :irc.example.com BATCH -RInLU
 
 -----
 
 ### Setting keys and subscribing with `before-connect`
+
+`METADATA SUB` does not generate any `metadata` batches or `774 RPL_METADATASYNCLATER` when used before connection registration has completed.
 
     C: CAP LS 302
     S: :metadata.test CAP * LS :batch message-tags draft/metadata-2=before-connect,max-subs=100,max-keys=100
@@ -723,13 +835,13 @@ Twice:
     C: CAP END
     S: :metadata.test 001 abc :Welcome to the MetadataTesting IRC Network abc
     S: [redacted registration burst messages]
-    S: :metadata.test BATCH +1 metadata
-    S: @batch=1 :metadata.test METADATA abc display-name * :a b c
+    S: :metadata.test BATCH +1 metadata abc
+    S: @batch=1 :metadata.test 761 abc abc display-name * :a b c
     S: :metadata.test BATCH -1
     S: [redacted registration burst messages]
     S: :metadata.test 376 abc :End of MOTD command
     C: METADATA * LIST
-    S: :metadata.test BATCH +2 metadata
+    S: :metadata.test BATCH +2 metadata abc
     S: @batch=2 :metadata.test 761 abc abc display-name * :a b c
     S: :metadata.test BATCH -2
     C: METADATA * SUBS
@@ -737,41 +849,37 @@ Twice:
     S: @batch=3 :metadata.test 772 abc display-name
     S: :metadata.test BATCH -3
 
------
-
-### Non-normative examples
-
-The following examples describe how an implementation might use certain features.
-Unlike previous examples, they are in no way intended to guide implementations' behaviour.
-
-#### Notification for a user becoming an operator:
-
-    :OperServ!OperServ@services.int METADATA user1 services.operclass oper:auspex :services-root
-
-### Client implementation considerations
-
-*This section is not normative*
-
-While this is true of any batch, clients should take particular care not to pause processing of other messages while a `metadata` batch is open.
-As these batches can be potentially large, servers are likely to produce them asynchronously in order to avoid freezing delivery of more important messages.
-
-As servers may rewrite values set by clients with `METADATA SET`, clients should check the response before storing it in any local cache.
-
 ### Differences between this specification and `metadata-notify`
 
-*This section is not normative*
+*This section is non-normative.*
 
 This specification replaces an earlier deprecated `metadata-notify` specification, by adding the following incompatible changes:
 
 * The `metadata-notify` cap subscribed you to all keys. With the addition of explicit [`SUB`](#metadata-sub) and [`UNSUB`](#metadata-unsub) subcommands, this is no longer the case.
 * Rate limiting protocol mechanics.
 * Support for delayed synchronization and `METADATA SYNC`.
-* Moved `ERR_*` replies to Standard Replies format
-* The `RPL_KEYNOTSET(766)` numeric replaces the `ERR_NOMATCHINGKEY` numeric in previous versions. It is no longer an error response and has a different meaning. For the error response see the `KEY_NOT_SET` standard reply.
-* The numerics `RPL_METADATASUBOK(770)`, `RPL_METADATAUNSUBOK(771)`, `RPL_METADATASUBS(772)` changed from using a space separated final parameter `:<Key1> [<Key2> ...]` to a list of individual parameters `<Key1> [<Key2> ...]`.
-* Use of batch instead of `RPL_METADATAEND` in situations where more than one `RPL_KEYVALUE` is sent.
-* Non-standard keys should now use a vendor prefix
+* Moved `ERR_*` replies to Standard Replies format.
+* The `766 RPL_KEYNOTSET` numeric replaces the `766 ERR_NOMATCHINGKEY` numeric in previous versions. It is no longer an error response and has a different meaning.
+* The numerics `770 RPL_METADATASUBOK`, `771 RPL_METADATAUNSUBOK`, and `772 RPL_METADATASUBS` changed from using a space separated final parameter `:<Key 1> [<Key 2> ... [<Key n>]]` to a list of individual parameters `<Key1> [<Key2> ... [<Key n>]]`.
+* Use of batch instead of `762 RPL_METADATAEND` in situations where more than one `761 RPL_KEYVALUE` is sent.
+* Non-standard keys should now use a vendor prefix.
 
 ## Errata
 
-* A previous version of this specification sent `RPL_KEYVALUE` as the response to `METADATA CLEAR`. This was changed to `RPL_KEYNOTSET` to simplify client processsing.
+* A previous version of this specification sent `761 RPL_KEYVALUE` as the response to `METADATA CLEAR`. This was changed to `766 RPL_KEYNOTSET` to simplify client processsing.
+* The `METADATA` server message was removed; `761 RPL_KEYVALUE` and `766 RPL_KEYNOTSET` are used in all cases to advertise key values or the lack thereof.
+* The `SUBCOMMAND_INVALID` standard reply code has been removed. The more generic `INVALID_PARAMS` code should be used in its place.
+* The `KEY_NOT_SET` standard reply code has been removed. With its removal, `METADATA SET` is fully idempotent with regards to its replies.
+* The `TOO_MANY_SUBS` standard reply code has been removed. The `LIMIT_REACHED` standard reply code should be used in its place.
+* The `VALUE_INVALID` standard reply code has been renamed to `INVALID_VALUE` for better consistency between this specification and other specifications. It additionally now takes a `<Key>` parameter.
+* The `KEY_INVALID` standard reply code has been renamed to `INVALID_KEY` for better consistency between this specification and other specifications.
+* The `RATE_LIMITED` standard reply code is now specified for every subcommand.
+* The `INVALID_PARAMS` standard reply code has been added for all other errors with `METADATA` command parameters.
+* Standard reply codes have been adjusted to use `WARN` and `NOTE` when and where appropriate. `FAIL` is reserved for when the entire command cannot proceed due to an error. `WARN` is used when a portion of a command cannot proceed but other parts may still proceed. `NOTE` is used for ancillary data when the command is fully successful.
+* The `*ALL` target has been specified for `METADATA SYNC` to synchronize all visible targets.
+* Servers sending either a `metadata` batch or `774 RPL_METADATASYNCLATER` upon `JOIN`, `730 RPL_MONONLINE`, or when a client subscribes to a new key post-registration is no longer optional.
+* Clients removing the metadata CAP from themselves are now automatically unsubscribed from all keys.
+* The `<RetryAfter>` parameter of `774 RPL_METADATASYNCLATER` and `RATE_LIMITED` is no longer optional and must be a non-negative integer.
+* A `max-key-bytes` token was added to the CAP value to limit the maximum number of bytes a metadata key may consume.
+* The `before-connect` token in the CAP value list was clarified to not have its own value and that clients must ignore any value it carries.
+* Missing CAP value tokens which specify maximum lengths or numbers of entries are clarified to be unlimited.

--- a/extensions/metadata.md
+++ b/extensions/metadata.md
@@ -140,21 +140,24 @@ The `metadata-subs` batch type takes no parameters and clients MUST ignore any p
 
 The following numerics are reserved for metadata, with these labels and parameters:
 
-| No. | Label                     | Parameters                               |
-| --- | ------------------------- | ---------------------------------------- |
-| 760 | `RPL_WHOISKEYVALUE`       | `<Target> <Key> <Visibility> :<Value>`   |
-| 761 | `RPL_KEYVALUE`            | `<Target> <Key> <Visibility> :<Value>`   |
-| 766 | `RPL_KEYNOTSET`           | `<Target> <Key> :Key not set`            |
-| 770 | `RPL_METADATASUBOK`       | `<Key1> [<Key2> ...]`                    |
-| 771 | `RPL_METADATAUNSUBOK`     | `<Key1> [<Key2> ...]`                    |
-| 772 | `RPL_METADATASUBS`        | `<Key1> [<Key2> ...]`                    |
-| 774 | `RPL_METADATASYNCLATER`   | `<Target> <RetryAfter> :Try again later` |
+| No. | Label                     | Parameters                                       |
+| --- | ------------------------- | ------------------------------------------------ |
+| 760 | `RPL_WHOISKEYVALUE`       | `<Target> <Key> <Visibility> :<Value>`           |
+| 761 | `RPL_KEYVALUE`            | `<Target> <Key> <Visibility> :<Value>`           |
+| 766 | `RPL_KEYNOTSET`           | `<Target> <Key> :Key not set`                    |
+| 770 | `RPL_METADATASUBOK`       | `<Key1> [<Key2> ...]`                            |
+| 771 | `RPL_METADATAUNSUBOK`     | `<Key1> [<Key2> ...]`                            |
+| 772 | `RPL_METADATASUBS`        | `<Key1> [<Key2> ...]`                            |
+| 774 | `ERR_METADATASYNCLATER`   | `<Target> <RetryAfter> :Try again later`         |
+| 775 | `ERR_METADATARATELIMIT`   | `<RetryAfter> <Target> <Command> [<Params> ...]` |
 
-The trailing parameter of `766 RPL_KEYNOTSET` and `774 RPL_METADATASYNCLATER` MAY vary wildly between implementations.
+The trailing parameter of `766 RPL_KEYNOTSET` and `774 ERR_METADATASYNCLATER` MAY vary wildly between implementations.
 
-The `<RetryAfter>` parameter of `774 RPL_METADATASYNCLATER` MUST be a non-negative integer. This parameter indicates the number of seconds clients SHOULD wait before re-trying the command.
+The `<RetryAfter>` parameter of `774 ERR_METADATASYNCLATER` and `775 ERR_METADATARATELIMIT` MUST be a non-negative integer. This parameter indicates the number of seconds clients SHOULD wait before re-trying the command.
 
 The `<Visibility>` parameter of `760 RPL_WHOISKEYVALUE` and `761 RPL_KEYVALUE` is an asterisk (`*`) for keys visible to everyone, or an implementation-defined value which describes the key’s visibility status; for instance, it MAY be a permission level or flag.
+
+The `<Target>`, `<Command>`, and `<Params>` parameters of `775 ERR_METADATARATELIMIT` reflect the target, subcommand, and any additional parameters that were passed into the rate-limited command, so that clients can re-send the command without needing stateful tracking of what was originally sent.
 
 The following [standard reply](../extensions/standard-replies.html) codes are used in this specification, with these labels and parameters:
 
@@ -165,16 +168,13 @@ The following [standard reply](../extensions/standard-replies.html) codes are us
 | `INVALID_TARGET`        | `<Target> :Invalid metadata target`            |
 | `INVALID_VALUE`         | `<Key> :Invalid value`                         |
 | `KEY_NO_PERMISSION`     | `<Target> <Key> :Permission denied`            |
-| `LIMIT_REACHED`         | `<Item> <Limit> :Limit reached`                |
-| `RATE_LIMITED`          | `<Target> <Key> <RetryAfter> :Try again later` |
+| `LIMIT_REACHED`         | `<Command> <Item> <Limit> :Limit reached`      |
 
 The trailing parameter containing the descriptive message MAY vary wildly between implementations and SHOULD contain a relevant description for the specific error encountered.
 
-The `<Command>` parameter of `INVALID_PARAMS` is the subcommand specified by the client, or an asterisk (`*`) if no subcommand was provided or the subcommand is not valid as a middle parameter.
+The `<Command>` parameter of `INVALID_PARAMS` and `LIMIT_REACHED` is the subcommand specified by the client, or an asterisk (`*`) if no subcommand was provided or the subcommand is not valid as a middle parameter.
 
 The `<Item>` parameter of `LIMIT_REACHED` will be the target if the metadata limit for a particular target was reached while performing [`METADATA SET`](#metadata-set) or the key name unable to be subscribed to if the subscription limit was reached while performing [`METADATA SUB`](#metadata-sub).
-
-The `<RetryAfter>` parameter of `RATE_LIMITED` MUST be a non-negative integer. This parameter indicates the number of seconds clients SHOULD wait before re-trying the command.
 
 ## Notifications
 
@@ -195,23 +195,23 @@ The notification framework provides clients updates on metadata keys for visible
 
 If the `draft/metadata-3` capability was negotiated during connection registration, servers MUST send clients a list of their current metadata (any metadata stored by the server or by services, plus any metadata set by the client during connection registration via `before-connect`) in a `metadata` batch with their own nick as target as part of the registration burst, i.e. before `RPL_ENDOFMOTD` or `ERR_NOMOTD`. This batch MUST include all visible keys set on the client, irrespective of whether the client has subscribed to that key.
 
-When server sends `730 RPL_MONONLINE` to a metadata-aware client (see [`MONITOR`](../extensions/monitor.html#monitor-command)), the server MUST additionally send either a `metadata` batch containing the monitored user's metadata to the client or a `774 RPL_METADATASYNCLATER` message to indicate postponed synchronization. If the server sends a batch, the batch MUST be identical to what would be returned if [`METADATA SYNC`](#metadata-sync) was issued against that target.
+When server sends `730 RPL_MONONLINE` to a metadata-aware client (see [`MONITOR`](../extensions/monitor.html#monitor-command)), the server MUST additionally send either a `metadata` batch containing the monitored user's metadata to the client or a `774 ERR_METADATASYNCLATER` message to indicate postponed synchronization. If the server sends a batch, the batch MUST be identical to what would be returned if [`METADATA SYNC`](#metadata-sync) was issued against that target.
 
-When a metadata-aware client joins a channel, the server MUST send either a `metadata` batch containing the channel's metadata as well as the metadata for all users on the channel or a `774 RPL_METADATASYNCLATER` message to indicate postponed synchronization. If the server sends a batch, the batch MUST be identical to what would be returned if [`METADATA SYNC`](#metadata-sync) was issued against that channel.
+When a metadata-aware client joins a channel, the server MUST send either a `metadata` batch containing the channel's metadata as well as the metadata for all users on the channel or a `774 ERR_METADATASYNCLATER` message to indicate postponed synchronization. If the server sends a batch, the batch MUST be identical to what would be returned if [`METADATA SYNC`](#metadata-sync) was issued against that channel.
 
 ## Postponed synchronization
 
-Servers MAY respond with `774 RPL_METADATASYNCLATER` to certain types of automatic synchronization as well as to the [`METADATA SYNC`](#metadata-sync) command for implementation-defined reasons, such as joining a channel with too many users or internal rate-limiting. This numeric indicates that the client SHOULD request synchronization of that target's metadata at a later time.
+Servers MAY respond with `774 ERR_METADATASYNCLATER` to certain types of automatic synchronization as well as to the [`METADATA SYNC`](#metadata-sync) command for implementation-defined reasons, such as joining a channel with too many users or internal rate-limiting. This numeric indicates that the client SHOULD request synchronization of that target's metadata at a later time.
 
 The client can use the `METADATA SYNC` command to request the synchronization of metadata for the given target. If the `<RetryAfter>` parameter of the numeric is nonzero, the client SHOULD wait at least that many seconds before sending the synchronization request.
 
-Clients SHOULD deduplicate `774 RPL_METADATASYNCLATER` numerics that they receive based on the numeric's target and only send one `METADATA SYNC` command for that target to the server after the `<RetryAfter>` waiting period.
+Clients SHOULD deduplicate `774 ERR_METADATASYNCLATER` numerics that they receive based on the numeric's target and only send one `METADATA SYNC` command for that target to the server after the `<RetryAfter>` waiting period.
 
 *[[Begin non-normative examples--*
 
 These examples assume the client has previously enabled the [no-implicit-names](../extensions/no-implicit-names.html) capability and has subscribed to the `display-name` metadata key for brevity.
 
-A metadata-aware client joins multiple channels and the server responds with `774 RPL_METADATASYNCLATER` to each of those joins with a target of `*ALL`. The client deduplicates these and sends only one `METADATA *ALL SYNC` after all channel joins are complete. This server implementation additionally responds with `766 RPL_KEYNOTSET` for subscribed keys that are not set on the target or are not visible to the user.
+A metadata-aware client joins multiple channels and the server responds with `774 ERR_METADATASYNCLATER` to each of those joins with a target of `*ALL`. The client deduplicates these and sends only one `METADATA *ALL SYNC` after all channel joins are complete. This server implementation additionally responds with `766 RPL_KEYNOTSET` for subscribed keys that are not set on the target or are not visible to the user.
 
     C: JOIN #chan1,#chan2,#chan3,#chan4
     S: :modernclient!modernclient@example.com JOIN #chan1
@@ -234,7 +234,7 @@ A metadata-aware client joins multiple channels and the server responds with `77
     ... and many more messages
     S: BATCH -r2Nla
 
-A metdata-aware client joins a large channel and the server responds with `774 RPL_METADATASYNCLATER` with a defined delay. After the initial delay, the server is still not ready to process the command. This server implementation additionally omits subscribed keys that are not set on the target or are not visible to the user.
+A metdata-aware client joins a large channel and the server responds with `774 ERR_METADATASYNCLATER` with a defined delay. After the initial delay, the server is still not ready to process the command. This server implementation additionally omits subscribed keys that are not set on the target or are not visible to the user.
 
     C: JOIN #bigchannel
     S: :modernclient!modernclient@example.com JOIN #bigchannel
@@ -264,7 +264,7 @@ Clients MAY use this command during connection registration if the server advert
 
 If the server receives a syntactically invalid `METADATA` command, e.g., an unknown subcommand, missing parameters, or excess parameters, the server SHOULD reply with `FAIL METADATA INVALID_PARAMS`. If an existing error numeric such as `461 ERR_NEEDMOREPARAMS` is appropriate, it MAY be used instead.
 
-Servers MAY rate limit any `METADATA` subcommand. If they do so and a client is rate limited, servers SHOULD send `FAIL METADATA RATE_LIMITED` indicating the client SHOULD retry the `METADATA` request at a later time.
+Servers MAY rate limit any `METADATA` subcommand. If they do so and a client is rate limited, servers SHOULD send `775 ERR_METADATARATELIMIT` indicating the client SHOULD retry the `METADATA` request at a later time.
 
 *[[Begin non-normative examples--*
 
@@ -338,7 +338,7 @@ The server responds with one or more of the following responses:
 
 If the client does not have permission to view a given key, the server MAY send a `NOTE METADATA KEY_NO_PERMISSION` reply to the client. The subscription MUST still be successful and that key MUST appear in a `770 RPL_METADATASUBOK` reply. In this case, the `NOTE METADATA KEY_NO_PERMISSION` reply serves as a notice indicating that the client will not receive notifications about this key unless it gains the necessary (implementation-defined) privileges later.
 
-After finishing sending responses as described above, if the client has completed connection registration and has added new subscriptions, the server MUST then either send a `metadata` batch with `*ALL` as its parameter containing the current values of all newly-subscribed keys visible to the user for all visible targets or a `774 RPL_METADATASYNCLATER` message with `*ALL` as its `<Target>` to indicate [postponed synchronization](#postponed-synchronization). In the event that the client has also negotiated [`labeled-response`](../extensions/labeled-response.html), the `metadata` batch MUST be nested within the `labeled-response` batch.
+After finishing sending responses as described above, if the client has completed connection registration and has added new subscriptions, the server MUST then either send a `metadata` batch with `*ALL` as its parameter containing the current values of all newly-subscribed keys visible to the user for all visible targets or a `774 ERR_METADATASYNCLATER` message with `*ALL` as its `<Target>` to indicate [postponed synchronization](#postponed-synchronization). In the event that the client has also negotiated [`labeled-response`](../extensions/labeled-response.html), the `metadata` batch MUST be nested within the `labeled-response` batch.
 
 *[[Begin non-normative example--*
 
@@ -347,7 +347,7 @@ The client is joined to #chan (sharing the channel with userA, userB, and userC)
     C: METADATA * SUB display-name status super-secret-key avatar
     S: :irc.example.com 770 modernclient display-name status super-secret-key
     S: :irc.example.com NOTE METADATA KEY_NO_PERMISSION SUB * super-secret-key :You do not have permission to view this key
-    S: :irc.example.com WARN METADATA LIMIT_REACHED SUB avatar 3 :Cannot subscribe to "avatar" as you have reached the subscription limit
+    S: :irc.example.com FAIL METADATA LIMIT_REACHED SUB avatar 3 :Cannot subscribe to "avatar" as you have reached the subscription limit
     S: :irc.example.com BATCH +d8amD metadata *
     S: @batch=d8amD :irc.example.com 761 modernclient #chan display-name :Cool Channel
     S: @batch=d8amD :irc.example.com 761 modernclient userA display-name :User A
@@ -386,7 +386,7 @@ If the client does not have permission to view a given subscribed key, the serve
 
 Clients use this subcommand to receive all subscribed metadata from the given target. If the target is a channel, it also synchronizes the metadata for all other users in that channel. If the target is an asterisk followed by uppercase "ALL" (`*ALL`), it synchronizes metadata for all visible targets.
 
-If the sync cannot be performed at this time (due to load or other implementation-defined details), the server responds with a `774 RPL_METADATASYNCLATER` indicating [postponed synchronization](#postponed-synchronization). If the sync can be performed, the server responds with a `metadata` batch containing zero or more of the following messages for each key the client is subscribed to:
+If the sync cannot be performed at this time (due to load or other implementation-defined details), the server responds with a `774 ERR_METADATASYNCLATER` indicating [postponed synchronization](#postponed-synchronization). If the sync can be performed, the server responds with a `metadata` batch containing zero or more of the following messages for each key the client is subscribed to:
 
 * `761 RPL_KEYVALUE` with the key's value
 * `766 RPL_KEYNOTSET` indicating the key is not set or the key is not visible to the requesting client
@@ -416,7 +416,7 @@ Servers with traditional send queue setups should ensure that they do not discon
 
 Servers may wish to provide network administrators the ability to configure an allowlist or denylist of metadata keys. They may also wish to reserve certain keys or patterns of keys as requiring elevated permissions to view or modify, to allow network administrators the ability to use `METADATA` as a secure key:value store for network operations or to ensure certain keys are only writable by services.
 
-When responding with `FAIL METADATA RATE_LIMITED` or `774 RPL_METADATASYNCLATER`, servers should attempt to provide a usable value for the `<RetryAfter>` parameter, to avoid clients flooding the server with retries. A server is not required to accept the command after the provided RetryAfter period and may still rate-limit the client at that time. This provides a middle ground for servers that do not wish to publish precise rate-limit details to clients while ensuring clients do not attempt to retry commands too aggressively.
+When responding with `774 ERR_METADATASYNCLATER` or `775 ERR_METADATARATELIMIT`, servers should attempt to provide a usable value for the `<RetryAfter>` parameter, to avoid clients flooding the server with retries. A server is not required to accept the command after the provided RetryAfter period and may still rate-limit the client at that time. This provides a middle ground for servers that do not wish to publish precise rate-limit details to clients while ensuring clients do not attempt to retry commands too aggressively.
 
 ## Reference tables
 
@@ -430,7 +430,8 @@ Reference table of numerics and the `METADATA` subcommands or any other commands
 | `RPL_METADATASUBOK`                |     |      |     |       | *   |       |      |      |                   |
 | `RPL_METADATAUNSUBOK`              |     |      |     |       |     | *     |      |      |                   |
 | `RPL_METADATASUBS`                 |     |      |     |       |     |       | *    |      |                   |
-| `RPL_METADATASYNCLATER`            |     |      |     |       | *   |       |      | *    | `JOIN`, `MONITOR` |
+| `ERR_METADATASYNCLATER`            |     |      |     |       | *   |       |      | *    | `JOIN`, `MONITOR` |
+| `ERR_METADATARATELIMIT`            | *   | *    | *   | *     | *   | *     | *    | *    |                   |
 
 Reference table of Standard Replies codes and the `METADATA` subcommands or any other commands that produce them:
 
@@ -442,7 +443,6 @@ Reference table of Standard Replies codes and the `METADATA` subcommands or any 
 | `INVALID_VALUE`         |      |      | FAIL      |       |      |       |      |      |         |
 | `KEY_NO_PERMISSION`     | WARN | WARN | FAIL/WARN | WARN  | NOTE |       | NOTE | WARN |         |
 | `LIMIT_REACHED`         |      |      | FAIL      |       | FAIL |       |      |      |         |
-| `RATE_LIMITED`          | FAIL | FAIL | FAIL      | FAIL  | FAIL | FAIL  | FAIL | FAIL | FAIL    |
 
 ## Examples
 
@@ -460,7 +460,7 @@ All examples begin with the client not being subscribed to any keys.
 #### Setting metadata on self, but the limit has been reached
 
     C: METADATA * SET url :http://www.example.com
-    S: FAIL METADATA LIMIT_REACHED 50 :Metadata limit reached
+    S: FAIL METADATA LIMIT_REACHED SET * 50 :Metadata limit reached
 
 #### Setting metadata on another user, without permission
 
@@ -485,7 +485,7 @@ All examples begin with the client not being subscribed to any keys.
 #### Server rate-limits setting metadata
 
     C: METADATA * SET url :http://www.example.com
-    S: FAIL METADATA RATE_LIMITED * url 5 :Rate-limit reached. You're going too fast! Try again in 5 seconds.
+    S: :irc.example.com 775 client 5 * SET url :http://www.example.com
 
 Servers can pick an arbitrary value here, if a client waits that long there is no guarantee the next attempt will not also be rate-limited.
 
@@ -576,7 +576,7 @@ Client waits 6 more seconds:
 
 ### Subscription Examples
 
-Most replies to `METADATA SUB` in these examples send `774 RPL_METADATASYNCLATER` for brevity. A real implementation may wish to more eagerly send `metadata` batches in response to `METADATA SUB`.
+Most replies to `METADATA SUB` in these examples send `774 ERR_METADATASYNCLATER` for brevity. A real implementation may wish to more eagerly send `metadata` batches in response to `METADATA SUB`.
 
 #### Basic subscriping and unsubscribing
 
@@ -611,7 +611,7 @@ The client first successfully subscribes to some keys and later it tries to subs
     S: :irc.example.com 770 modernclient website avatar foo bar baz
     S: :irc.example.com 774 modernclient *ALL 5 :Please run SYNC later
     C: METADATA * SUB email city
-    S: FAIL METADATA LIMIT_REACHED email 5 :Too many subscriptions!
+    S: FAIL METADATA LIMIT_REACHED SUB email 5 :Too many subscriptions!
     S: :irc.example.com 774 modernclient *ALL 5 :Please run SYNC later
     C: METADATA * SUBS
     S: :irc.example.com BATCH +c2LO6 metadata-subs
@@ -625,7 +625,7 @@ This is like the previous case, except when the second METADATA SUB happens the 
     C: METADATA * SUB website avatar foo
     S: :irc.example.com 770 modernclient website avatar foo
     C: METADATA * SUB email city country bar baz
-    S: FAIL METADATA LIMIT_REACHED country 5 :Too many subscriptions!
+    S: FAIL METADATA LIMIT_REACHED SUB country 5 :Too many subscriptions!
     S: :irc.example.com 770 modernclient email city
     S: :irc.example.com 774 modernclient *ALL 5 :Please run SYNC later
     C: METADATA * SUBS
@@ -642,7 +642,7 @@ The client, however, successfully subscribes to the `foo` key which was also in 
     S: :irc.example.com 770 modernclient avatar website
     S: :irc.example.com 774 modernclient *ALL 5 :Please run SYNC later
     C: METADATA * SUB foo website avatar
-    S: FAIL METADATA LIMIT_REACHED website 3 :Too many subscriptions!
+    S: FAIL METADATA LIMIT_REACHED SUB website 3 :Too many subscriptions!
     S: :irc.example.com 770 modernclient :foo
     S: :irc.example.com 774 modernclient *ALL 5 :Please run SYNC later
     C: METADATA * SUBS
@@ -702,7 +702,7 @@ In this case, there are no `772 RPL_METADATASUBS` numerics sent.
 
 #### Subscribing to the same key multiple times 1
 
-No `metadata` batch or `774 RPL_METADATASYNCLATER` response is given to the second `METADATA SUB` because no new keys were subscribed to.
+No `metadata` batch or `774 ERR_METADATASYNCLATER` response is given to the second `METADATA SUB` because no new keys were subscribed to.
 
     C: METADATA * SUB website avatar foo bar baz
     S: :irc.example.com 779 modernclient website avatar foo bar baz
@@ -820,7 +820,7 @@ Because the client does not have permission to view any of the newly-added keys,
 
 ### Setting keys and subscribing with `before-connect`
 
-`METADATA SUB` does not generate any `metadata` batches or `774 RPL_METADATASYNCLATER` when used before connection registration has completed.
+`METADATA SUB` does not generate any `metadata` batches or `774 ERR_METADATASYNCLATER` when used before connection registration has completed.
 
     C: CAP LS 302
     S: :metadata.test CAP * LS :batch message-tags draft/metadata-3=before-connect,max-subs=100,max-keys=100
@@ -871,15 +871,16 @@ This specification replaces an earlier deprecated `metadata-notify` specificatio
 * The `SUBCOMMAND_INVALID` standard reply code has been removed. The more generic `INVALID_PARAMS` code should be used in its place.
 * The `KEY_NOT_SET` standard reply code has been removed. With its removal, `METADATA SET` is fully idempotent with regards to its replies.
 * The `TOO_MANY_SUBS` standard reply code has been removed. The `LIMIT_REACHED` standard reply code should be used in its place.
+* The `LIMIT_REACHED` standard reply code gained a `<Command>` parameter to indicate which subcommand the limit is associated with.
 * The `VALUE_INVALID` standard reply code has been renamed to `INVALID_VALUE` for better consistency between this specification and other specifications. It additionally now takes a `<Key>` parameter.
 * The `KEY_INVALID` standard reply code has been renamed to `INVALID_KEY` for better consistency between this specification and other specifications.
-* The `RATE_LIMITED` standard reply code is now specified for every subcommand.
+* The `RATE_LIMITED` standard reply code was replaced with the `775 ERR_METADATARATELIMIT` numeric and is now specified for every subcommand.
 * The `INVALID_PARAMS` standard reply code has been added for all other errors with `METADATA` command parameters.
 * Standard reply codes have been adjusted to use `WARN` and `NOTE` when and where appropriate. `FAIL` is reserved for when the entire command cannot proceed due to an error. `WARN` is used when a portion of a command cannot proceed but other parts may still proceed. `NOTE` is used when a portion of a command is fully successful but needs ancillary data.
 * The `*ALL` target has been specified for `METADATA SYNC` to synchronize all visible targets.
-* Servers sending either a `metadata` batch or `774 RPL_METADATASYNCLATER` upon `JOIN`, `730 RPL_MONONLINE`, or when a client subscribes to a new key post-registration is no longer optional.
+* Servers sending either a `metadata` batch or `774 ERR_METADATASYNCLATER` upon `JOIN`, `730 RPL_MONONLINE`, or when a client subscribes to a new key post-registration is no longer optional.
 * Clients removing either the metadata or batch CAPs from themselves are now automatically unsubscribed from all keys.
-* The `<RetryAfter>` parameter of `774 RPL_METADATASYNCLATER` and `RATE_LIMITED` is no longer optional and must be a non-negative integer.
+* The `<RetryAfter>` parameter of `774 ERR_METADATASYNCLATER` and `775 ERR_METADATARATELIMIT` is no longer optional and must be a non-negative integer.
 * A `max-key-bytes` token was added to the CAP value to limit the maximum number of bytes a metadata key may consume.
 * The `before-connect` token in the CAP value list was clarified to not have its own value and that clients must ignore any value it carries.
 * CAP value tokens which specify maximum lengths or numbers of entries (i.e. `max-key-bytes`, `max-value-bytes`, `max-keys`, and `max-subs`) are clarified to be unlimited if those tokens are missing from the `CAP LS 302` response.

--- a/extensions/metadata.md
+++ b/extensions/metadata.md
@@ -39,7 +39,7 @@ copyrights:
 
 This is a work-in-progress specification.
 
-Software implementing this work-in-progress specification MUST NOT use the unprefixed `metadata` capability name. Instead, implementations SHOULD use the `draft/metadata-2` capability name to be interoperable with other software implementing a compatible work-in-progress version.
+Software implementing this work-in-progress specification MUST NOT use the unprefixed `metadata` capability name. Instead, implementations SHOULD use the `draft/metadata-3` capability name to be interoperable with other software implementing a compatible work-in-progress version.
 
 The final version of the specification will use an unprefixed capability name.
 
@@ -64,23 +64,23 @@ On joining a server, clients have to configure their 'metadata key subscriptions
 
 Servers may additionally restrict the visibility of metadata keys to certain subsets of users (e.g. based on operator status). A *visible key* is a metadata key that the user has permissions to view, according to the server's implementation-defined means.
 
-A *metadata-aware client* is a client who has negotiated both the `draft/metadata-2` capability and the `batch` capability.
+A *metadata-aware client* is a client who has negotiated both the `draft/metadata-3` capability and the `batch` capability.
 
 ## Relation with other specifications
 
-This specification depends on the [`batch`](../extensions/batch.html) capability which MUST be negotiated to use `draft/metadata-2`. The order of capability negotiation is not significant and MUST NOT be enforced.
+This specification depends on the [`batch`](../extensions/batch.html) capability which MUST be negotiated to use `draft/metadata-3`. The order of capability negotiation is not significant and MUST NOT be enforced.
 
 This specification also uses the [standard replies](../extensions/standard-replies.html) framework.
 
-Clients MUST NOT request both `metadata-notify` and `draft/metadata-2`. Servers MUST NOT accept these requests either.
+Clients MUST NOT request more than one of `metadata-notify`, `draft/metadata-2`, and `draft/metadata-3`. Servers MUST NOT accept these requests either.
 
-## `draft/metadata-2` Capability
+## `draft/metadata-3` Capability
 
-The `draft/metadata-2` capability indicates that a server supports metadata, and provides any limits and information about the system that clients must be aware of. Clients MUST request this capability in order to receive [`METADATA` notifications](#notifications).
+The `draft/metadata-3` capability indicates that a server supports metadata, and provides any limits and information about the system that clients must be aware of. Clients MUST request this capability in order to receive [`METADATA` notifications](#notifications).
 
-The ABNF format of the `draft/metadata-2` capability is:
+The ABNF format of the `draft/metadata-3` capability is:
 
-    capability ::= 'draft/metadata-2' ['=' tokens]
+    capability ::= 'draft/metadata-3' ['=' tokens]
     tokens     ::= token [',' token]*
     token      ::= key ['=' value]
     key        ::= <sequence of one or more a-z0-9_./->
@@ -94,18 +94,18 @@ These are the defined tokens:
 * `max-key-bytes`: The maximum size of keys a client is allowed to set. Servers MAY send longer keys.
 * `max-value-bytes`: The maximum size of values a client is allowed to set. Servers MAY send longer values.
 
-Clients MUST silently ignore any unknown tokens. If the server does not provide a token indicating one of the above limits, clients SHOULD assume that particular item has no limit.
+Clients MUST silently ignore any unknown tokens. If the server does not provide a token indicating one of the above maximum limits, clients SHOULD assume that particular item has no limit.
 
-If a client removes this capability from themselves, servers MUST clear that client's subscription list.
+If a client removes this capability or the batch capability from themselves, servers MUST clear that client's subscription list.
 
 *[[Begin non-normative examples--*
 
 In both of these examples, max-subs is specified but other tokens are not. Clients should assume that max-keys, max-key-bytes, and max-value-bytes have no limit. In practice, the key and value must still fit on a single IRC protocol line despite not having any server-specified limit.
 
     C: CAP LS 302
-    S: CAP * LS :userhost-in-names draft/metadata-2=foo,max-subs=50,bar multi-prefix
+    S: CAP * LS :userhost-in-names draft/metadata-3=foo,max-subs=50,bar multi-prefix
     C: CAP LS 302
-    S: CAP * LS :draft/metadata-2=max-subs=25 multi-prefix invite-notify
+    S: CAP * LS :draft/metadata-3=max-subs=25 multi-prefix invite-notify
 
 *--End non-normative examples]]*
 
@@ -193,7 +193,7 @@ Servers MUST send notifications to subscribers the key is visible to for changes
 
 The notification framework provides clients updates on metadata keys for visible targets, but does not share any information about keys already set before the target became visible to the client. This section describes events outside of the `METADATA` command that trigger automatic synchronization of metadata so that the client has a usable baseline to work from.
 
-If the `draft/metadata-2` capability was negotiated during connection registration, servers MUST send clients a list of their current metadata (any metadata stored by the server or by services, plus any metadata set by the client during connection registration via `before-connect`) in a `metadata` batch with their own nick as target as part of the registration burst, i.e. before `RPL_ENDOFMOTD` or `ERR_NOMOTD`. This batch MUST include all visible keys set on the client, irrespective of whether the client has subscribed to that key.
+If the `draft/metadata-3` capability was negotiated during connection registration, servers MUST send clients a list of their current metadata (any metadata stored by the server or by services, plus any metadata set by the client during connection registration via `before-connect`) in a `metadata` batch with their own nick as target as part of the registration burst, i.e. before `RPL_ENDOFMOTD` or `ERR_NOMOTD`. This batch MUST include all visible keys set on the client, irrespective of whether the client has subscribed to that key.
 
 When server sends `730 RPL_MONONLINE` to a metadata-aware client (see [`MONITOR`](../extensions/monitor.html#monitor-command)), the server MUST additionally send either a `metadata` batch containing the monitored user's metadata to the client or a `774 RPL_METADATASYNCLATER` message to indicate postponed synchronization. If the server sends a batch, the batch MUST be identical to what would be returned if [`METADATA SYNC`](#metadata-sync) was issued against that target.
 
@@ -211,7 +211,7 @@ Clients SHOULD deduplicate `774 RPL_METADATASYNCLATER` numerics that they receiv
 
 These examples assume the client has previously enabled the [no-implicit-names](../extensions/no-implicit-names.html) capability and has subscribed to the `display-name` metadata key for brevity.
 
-A metadata-aware client joins multiple channels and the server responds with `774 RPL_METADATASYNCLATER` to each of those joins with a target of `*`. The client deduplicates these and sends only one `METADATA * SYNC` after all channel joins are complete. This server implementation additionally responds with `766 RPL_KEYNOTSET` for subscribed keys that are not set on the target or are not visible to the user.
+A metadata-aware client joins multiple channels and the server responds with `774 RPL_METADATASYNCLATER` to each of those joins with a target of `*ALL`. The client deduplicates these and sends only one `METADATA *ALL SYNC` after all channel joins are complete. This server implementation additionally responds with `766 RPL_KEYNOTSET` for subscribed keys that are not set on the target or are not visible to the user.
 
     C: JOIN #chan1,#chan2,#chan3,#chan4
     S: :modernclient!modernclient@example.com JOIN #chan1
@@ -222,8 +222,8 @@ A metadata-aware client joins multiple channels and the server responds with `77
     S: :irc.example.com 774 modernclient * 0 :Please synchronize metadata later
     S: :modernclient!modernclient@example.com JOIN #chan4
     S: :irc.example.com 774 modernclient * 0 :Please synchronize metadata later
-    C: METADATA * SYNC
-    S: BATCH +r2Nla metadata *
+    C: METADATA *ALL SYNC
+    S: BATCH +r2Nla metadata *ALL
     S: @batch=r2Nla :irc.example.com 761 modernclient #chan1 display-name * :channel 1️⃣
     S: @batch=r2Nla :irc.example.com 761 modernclient #chan2 display-name * :channel 2️⃣
     S: @batch=r2Nla :irc.example.com 766 modernclient #chan3 display-name :Key not set
@@ -342,7 +342,7 @@ After finishing sending responses as described above, if the client has complete
 
 *[[Begin non-normative example--*
 
-The client is joined to #chan (sharing the channel with userA, userB, and userC) and additionally has userD on their `MONITOR` list, who is currently online. The server is configured to allow a maximum of 3 subscriptions (advertising `max-subs=3` in the `draft/metadata-2` CAP value).
+The client is joined to #chan (sharing the channel with userA, userB, and userC) and additionally has userD on their `MONITOR` list, who is currently online. The server is configured to allow a maximum of 3 subscriptions (advertising `max-subs=3` in the `draft/metadata-3` CAP value).
 
     C: METADATA * SUB display-name status super-secret-key avatar
     S: :irc.example.com 770 modernclient display-name status super-secret-key
@@ -823,9 +823,9 @@ Because the client does not have permission to view any of the newly-added keys,
 `METADATA SUB` does not generate any `metadata` batches or `774 RPL_METADATASYNCLATER` when used before connection registration has completed.
 
     C: CAP LS 302
-    S: :metadata.test CAP * LS :batch message-tags draft/metadata-2=before-connect,max-subs=100,max-keys=100
-    C: CAP REQ :batch message-tags draft/metadata-2
-    S: :metadata.test CAP * ACK :batch message-tags draft/metadata-2
+    S: :metadata.test CAP * LS :batch message-tags draft/metadata-3=before-connect,max-subs=100,max-keys=100
+    C: CAP REQ :batch message-tags draft/metadata-3
+    S: :metadata.test CAP * ACK :batch message-tags draft/metadata-3
     C: METADATA * SUB display-name
     S: :metadata.test 770 * display-name
     C: METADATA * SET display-name :a b c
@@ -875,11 +875,12 @@ This specification replaces an earlier deprecated `metadata-notify` specificatio
 * The `KEY_INVALID` standard reply code has been renamed to `INVALID_KEY` for better consistency between this specification and other specifications.
 * The `RATE_LIMITED` standard reply code is now specified for every subcommand.
 * The `INVALID_PARAMS` standard reply code has been added for all other errors with `METADATA` command parameters.
-* Standard reply codes have been adjusted to use `WARN` and `NOTE` when and where appropriate. `FAIL` is reserved for when the entire command cannot proceed due to an error. `WARN` is used when a portion of a command cannot proceed but other parts may still proceed. `NOTE` is used for ancillary data when the command is fully successful.
+* Standard reply codes have been adjusted to use `WARN` and `NOTE` when and where appropriate. `FAIL` is reserved for when the entire command cannot proceed due to an error. `WARN` is used when a portion of a command cannot proceed but other parts may still proceed. `NOTE` is used when a portion of a command is fully successful but needs ancillary data.
 * The `*ALL` target has been specified for `METADATA SYNC` to synchronize all visible targets.
 * Servers sending either a `metadata` batch or `774 RPL_METADATASYNCLATER` upon `JOIN`, `730 RPL_MONONLINE`, or when a client subscribes to a new key post-registration is no longer optional.
-* Clients removing the metadata CAP from themselves are now automatically unsubscribed from all keys.
+* Clients removing either the metadata or batch CAPs from themselves are now automatically unsubscribed from all keys.
 * The `<RetryAfter>` parameter of `774 RPL_METADATASYNCLATER` and `RATE_LIMITED` is no longer optional and must be a non-negative integer.
 * A `max-key-bytes` token was added to the CAP value to limit the maximum number of bytes a metadata key may consume.
 * The `before-connect` token in the CAP value list was clarified to not have its own value and that clients must ignore any value it carries.
-* Missing CAP value tokens which specify maximum lengths or numbers of entries are clarified to be unlimited.
+* CAP value tokens which specify maximum lengths or numbers of entries (i.e. `max-key-bytes`, `max-value-bytes`, `max-keys`, and `max-subs`) are clarified to be unlimited if those tokens are missing from the `CAP LS 302` response.
+* Empty strings are no longer valid metadata values; setting a metadata key to an empty string will now remove it (in addition to removal by omitting the value parameter entirely).

--- a/extensions/metadata.md
+++ b/extensions/metadata.md
@@ -98,7 +98,9 @@ Clients MUST silently ignore any unknown tokens. If the server does not provide 
 
 If a client removes this capability or the batch capability from themselves, servers MUST clear that client's subscription list.
 
-*[[Begin non-normative examples--*
+### Examples
+
+*This section is non-normative.*
 
 In both of these examples, max-subs is specified but other tokens are not. Clients should assume that max-keys, max-key-bytes, and max-value-bytes have no limit. In practice, the key and value must still fit on a single IRC protocol line despite not having any server-specified limit.
 
@@ -106,8 +108,6 @@ In both of these examples, max-subs is specified but other tokens are not. Clien
     S: CAP * LS :userhost-in-names draft/metadata-3=foo,max-subs=50,bar multi-prefix
     C: CAP LS 302
     S: CAP * LS :draft/metadata-3=max-subs=25 multi-prefix invite-notify
-
-*--End non-normative examples]]*
 
 ## Keys and Values
 
@@ -205,9 +205,9 @@ Servers MAY respond with `774 ERR_METADATASYNCLATER` to certain types of automat
 
 The client can use the `METADATA SYNC` command to request the synchronization of metadata for the given target. If the `<RetryAfter>` parameter of the numeric is nonzero, the client SHOULD wait at least that many seconds before sending the synchronization request.
 
-Clients SHOULD deduplicate `774 ERR_METADATASYNCLATER` numerics that they receive based on the numeric's target and only send one `METADATA SYNC` command for that target to the server after the `<RetryAfter>` waiting period.
+### Examples
 
-*[[Begin non-normative examples--*
+*This section is non-normative.*
 
 These examples assume the client has previously enabled the [no-implicit-names](../extensions/no-implicit-names.html) capability and has subscribed to the `display-name` metadata key for brevity.
 
@@ -250,8 +250,6 @@ A metdata-aware client joins a large channel and the server responds with `774 E
     ... and many more messages
     S: BATCH -M40ad
 
-*--End non-normative examples]]*
-
 ## METADATA client command
 
     METADATA <Target> <Subcommand> [<Param 1> ... [<Param n>]]
@@ -266,7 +264,9 @@ If the server receives a syntactically invalid `METADATA` command, e.g., an unkn
 
 Servers MAY rate limit any `METADATA` subcommand. If they do so and a client is rate limited, servers SHOULD send `775 ERR_METADATARATELIMIT` indicating the client SHOULD retry the `METADATA` request at a later time.
 
-*[[Begin non-normative examples--*
+### Examples
+
+*This section is non-normative.*
 
     C: METADATA
     S: FAIL METADATA INVALID_PARAMS * :Not enough parameters
@@ -276,8 +276,6 @@ Servers MAY rate limit any `METADATA` subcommand. If they do so and a client is 
     S: FAIL METADATA INVALID_PARAMS SNEEZE :Unknown subcommand "SNEEZE"
     C: METADATA #chan :: hi!
     S: FAIL METADATA INVALID_PARAMS * :Unknown subcommand ": hi!"
-
-*--End non-normative examples]]*
 
 ### METADATA GET
 
@@ -313,6 +311,7 @@ Otherwise, the server MUST send a `FAIL METADATA` response with an appropriate e
 * `FAIL METADATA INVALID_TARGET` if the specified target is not valid
 * `FAIL METADATA INVALID_KEY` if the key contains invalid characters or is otherwise deemed invalid by the server
 * `FAIL METADATA KEY_NO_PERMISSION` if the client does not have permission to set keys on the specified target or is otherwise disallowed from setting or removing this key by the server
+* `FAIL METADATA LIMIT_REACHED` if trying to add a new key when the maximum number of keys has already been set on the target
 
 It is not an error if a client attempts to set a key to its current value or remove a nonexistent key; such attempts generate successful responses if there are no other issues with the request.
 
@@ -340,7 +339,9 @@ If the client does not have permission to view a given key, the server MAY send 
 
 After finishing sending responses as described above, if the client has completed connection registration and has added new subscriptions, the server MUST then either send a `metadata` batch with `*ALL` as its parameter containing the current values of all newly-subscribed keys visible to the user for all visible targets or a `774 ERR_METADATASYNCLATER` message with `*ALL` as its `<Target>` to indicate [postponed synchronization](#postponed-synchronization). In the event that the client has also negotiated [`labeled-response`](../extensions/labeled-response.html), the `metadata` batch MUST be nested within the `labeled-response` batch.
 
-*[[Begin non-normative example--*
+### Examples
+
+*This section is non-normative.*
 
 The client is joined to #chan (sharing the channel with userA, userB, and userC) and additionally has userD on their `MONITOR` list, who is currently online. The server is configured to allow a maximum of 3 subscriptions (advertising `max-subs=3` in the `draft/metadata-3` CAP value).
 
@@ -354,8 +355,6 @@ The client is joined to #chan (sharing the channel with userA, userB, and userC)
     S: @batch=d8amD :irc.example.com 761 modernclient userA status :Playing games
     S: @batch=d8amD :irc.example.com 761 modernclient userD display-name :User D
     S: :irc.example.com BATCH -d8amD
-
-*--End non-normative example]]*
 
 ### METADATA UNSUB
 
@@ -407,6 +406,8 @@ As servers may rewrite values set by clients with `METADATA SET`, clients should
 Because servers may choose to omit unset keys or keys that are not visible to the client from `metadata` batches, clients should assume that any subscribed keys missing from a `METADATA SYNC` have been unset in the interim and update local caches accordingly.
 
 Avoid sending more than 12 keys with `METADATA GET`, `METADATA SUB`, or `METADATA UNSUB` unless you know the server is capable of handling more parameters. Old RFCs limited the number of parameters in an IRC message to 15, and some server implementations treat the command itself towards that parameter limit.
+
+Many clients can be configured to automatically join channels upon connect. If a client receives `774 ERR_METADATASYNCLATER` while performing such automatic joins, it should consider ignoring such numerics and instead send a single `METADATA *ALL SYNC` after all automatic joins have been completed. Doing this allows for server-side deduplication of user metadata for users that are present in more than one of the automatically-joined channels and may yield faster results depending on server rate-limiting implementations.
 
 ## Server implementation considerations
 


### PR DESCRIPTION
The errata section at the bottom lists all normative changes. Additionally, the specification was rearranged and copyedited to flow more nicely when read from top-to-bottom. It should (hopefully) be possible to now follow the specification without needing to jump around, and all concepts are (hopefully) introduced before being used in the specification. Some examples were moved inline to help illustrate, although the rather large examples section at the end was maintained in case it was helpful.

Addresses issues and discussion from #588 

## Summary of changes between earlier versions of this PR and the current version

* The `LIMIT_REACHED` FAIL code has gained a new parameter to indicate the subcommand for which the limit was reached, allowing clients to statelessly track whether the limit was reached for SUB vs SET
* The `RATE_LIMITED` FAIL code was removed and the `ERR_METADATARATELIMIT` error numeric (775) was reintroduced to indicate commands are rate-limited; this allows clients to retry the command without needing stateful tracking as the numeric can pass a useful trailing parameter while standard reply trailing parameters must be for human consumption
* `RPL_METADATASYNCLATER` was renamed to `ERR_METADATASYNCLATER`; unlike the changes above this is not a breaking change but rather reflects that the command was not successfully executed

## Summary of changes between `draft/metadata-2` and this PR

### Standard Replies

* Standard reply codes have been adjusted to use `WARN` and `NOTE` when and where appropriate. `FAIL` is reserved for when the entire command cannot proceed due to an error. `WARN` is used when a portion of a command cannot proceed but other parts may still proceed. `NOTE` is used when a portion of a command is fully successful but needs ancillary data.
* The `SUBCOMMAND_INVALID` standard reply code has been removed. The more generic `INVALID_PARAMS` code should be used in its place.
* The `KEY_NOT_SET` standard reply code has been removed. With its removal, `METADATA SET` is fully idempotent with regards to its replies.
* The `TOO_MANY_SUBS` standard reply code has been removed. The `LIMIT_REACHED` standard reply code should be used in its place.
* The `VALUE_INVALID` standard reply code has been renamed to `INVALID_VALUE` for better consistency between this specification and other specifications. It additionally now takes a `<Key>` parameter.
* The `KEY_INVALID` standard reply code has been renamed to `INVALID_KEY` for better consistency between this specification and other specifications.
* ~~The `RATE_LIMITED` standard reply code is now specified for every subcommand.~~ (now removed)
* The `INVALID_PARAMS` standard reply code has been added for all other errors with `METADATA` command parameters.

### Server Messages / Numerics

* The `METADATA` server message was removed; `761 RPL_KEYVALUE` and `766 RPL_KEYNOTSET` are used in all cases to advertise key values or the lack thereof.
* Servers sending either a `metadata` batch or `774 RPL_METADATASYNCLATER` upon `JOIN`, `730 RPL_MONONLINE`, or when a client subscribes to a new key post-registration is no longer optional.
* The `<RetryAfter>` parameter of `774 RPL_METADATASYNCLATER` and `RATE_LIMITED` is no longer optional and must be a non-negative integer.

### CAP changes

* The CAP token is now `draft/metadata-3`.
* Clients removing either the metadata or batch CAPs from themselves are now automatically unsubscribed from all keys.
* A `max-key-bytes` token was added to the CAP value to limit the maximum number of bytes a metadata key may consume.
* The `before-connect` token in the CAP value list was clarified to not have its own value and that clients must ignore any value it carries.
* CAP value tokens which specify maximum lengths or numbers of entries (i.e. `max-key-bytes`, `max-value-bytes`, `max-keys`, and `max-subs`) are clarified to be unlimited if those tokens are missing from the `CAP LS 302` response.

### Other

* The `*ALL` target has been specified for `METADATA SYNC` to synchronize all visible targets.
* Empty strings are no longer valid metadata values; setting a metadata key to an empty string will now remove it (in addition to removal by omitting the value parameter entirely).